### PR TITLE
Espace usager : historique des consommations intégré dans la page (#23, #24)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -52,6 +52,14 @@ par cadran facturé. Sélectionnée par les dates d'une *Période*, ce qui perme
 *régularisation* aux prix historiques.
 _Éviter_ : tarif (collision avec la FTA / tarif d'acheminement réseau), barème.
 
+**Facture** :
+Le document comptable légal (`account.move`, *facture d'énergie*) émis à partir d'une *Période*
+qu'il référence (`periode_id`). Une *Période* est dite **facturée** dès qu'une *Facture* la
+référence ; elle est **émise** (finalisée, opposable) à un état ultérieur. Seules les *Périodes*
+dont la *Facture* est **émise** sont visibles du·de la *souscripteur·rice* au *Portail* — un
+brouillon de facture ne fuite jamais côté usager.
+_Éviter_ : confondre « facturée » (une facture existe) et « émise » (facture finalisée).
+
 **Configuration Enedis** :
 La configuration *réseau* d'un PDL — FTA, calendrier distributeur, puissance réseau, cadrans
 réseau — propriété d'electricore (source : C15). Détermine le coût d'acheminement (TURPE).
@@ -76,5 +84,7 @@ Rôle métier qui conduit la facturation mensuelle depuis Odoo et **vérifie les
 
 **Portail** :
 Espace en ligne en lecture du·de la *souscripteur·rice* (contrats, factures, infos utiles),
-pensé dans une logique de commun (évolutif).
+pensé dans une logique de commun (évolutif). L'historique des consommations (les *Périodes*
+dont la *Facture* est **émise**) est présenté **directement** dans la page de détail d'une
+*Souscription*, sans page dédiée.
 _Éviter_ : espace client.

--- a/PORTAL_USAGER.md
+++ b/PORTAL_USAGER.md
@@ -25,8 +25,11 @@ Le portal usager·ère utilise le framework Portal standard d'Odoo pour permettr
 ### Détail d'une souscription (`/my/souscription/<id>`)
 - Informations complètes du contrat
 - État de facturation
-- Historique des 10 dernières factures
-- Liens vers les PDF de factures
+- Historique des consommations **intégré à la page** (plus de page séparée) :
+  périodes dont la facture est **émise (postée)**, énergie par cadran, TURPE,
+  montant TTC, état de paiement et lien vers le PDF de la facture
+- 12 périodes affichées (plus récente en haut), bouton « Voir plus » pour le reste
+- Totaux (conso, TURPE, total facturé, nombre de périodes) + glossaire
 - Informations de dépannage
 
 ## Architecture technique

--- a/__manifest__.py
+++ b/__manifest__.py
@@ -1,6 +1,6 @@
 {
     "name": "Souscriptions Électricité",
-    "version": "19.0.1.0.0",
+    "version": "19.0.1.1.0",
     "depends": ["base", "mail", "contacts", "account", "portal"],
     "author": "Virgile Daugé",
     "category": "Energy",

--- a/controllers/portal.py
+++ b/controllers/portal.py
@@ -46,34 +46,22 @@ class SouscriptionPortal(CustomerPortal):
     def portal_my_souscription(self, souscription_id=None, **kw):
         partner = request.env.user.partner_id
         souscription = request.env['souscription.souscription'].browse(souscription_id)
-        
-        # Vérifier que la souscription appartient bien au partenaire
-        if not souscription.exists() or souscription.partner_id != partner:
-            return request.redirect('/my')
-            
-        values = {
-            'souscription': souscription,
-            'page_name': 'souscription',
-        }
-        
-        return request.render("souscriptions_odoo.portal_souscription_page", values)
 
-    @http.route(['/my/souscription/<int:souscription_id>/periodes'], type='http', auth="user", website=True)
-    def portal_souscription_periodes(self, souscription_id=None, **kw):
-        partner = request.env.user.partner_id
-        souscription = request.env['souscription.souscription'].browse(souscription_id)
-        
         # Vérifier que la souscription appartient bien au partenaire
         if not souscription.exists() or souscription.partner_id != partner:
             return request.redirect('/my')
-            
-        # Récupérer les périodes triées par date
-        periodes = souscription.periode_ids.sorted('date_debut', reverse=True)
-        
+
+        # Historique des consommations intégré à la page : uniquement les périodes
+        # dont la facture est émise (postée) — un brouillon ne fuite pas côté usager
+        # (ADR 0004). Plus récente en premier.
+        periodes = souscription.periode_ids.filtered(
+            lambda p: p.facture_id and p.facture_id.state == 'posted'
+        ).sorted('date_debut', reverse=True)
+
         values = {
             'souscription': souscription,
             'periodes': periodes,
-            'page_name': 'souscription_periodes',
+            'page_name': 'souscription',
         }
-        
-        return request.render("souscriptions_odoo.portal_souscription_periodes", values)
+
+        return request.render("souscriptions_odoo.portal_souscription_page", values)

--- a/demo/souscriptions_demo.xml
+++ b/demo/souscriptions_demo.xml
@@ -399,6 +399,11 @@
             <field name="quantity">1</field>
             <field name="price_unit">12.60</field>
         </record>
-        
+
+        <!-- Comptabilisation des factures admin : côté portail, seules les
+             factures postées sont visibles de l'usager·ère (ADR 0004, issue #23). -->
+        <function model="account.move" name="action_post"
+                  eval="[[ref('demo_facture_janvier_admin'), ref('demo_facture_fevrier_admin'), ref('demo_facture_mars_admin')]]"/>
+
     </data>
 </odoo>

--- a/docs/adr/0004-lien-periode-facture-source-unique.md
+++ b/docs/adr/0004-lien-periode-facture-source-unique.md
@@ -1,0 +1,49 @@
+# Lien Période ↔ Facture : une seule source, côté facture
+
+Une *Période* et sa *Facture* étaient reliées par **deux champs parallèles indépendants** :
+`account.move.periode_id` (la facture pointe sa période) et `souscription.periode.facture_id`
+(M2o distinct, écrit à la main par le workflow de facturation). Rien ne garantissait leur
+cohérence, et en pratique les données démo ne peuplaient que `periode_id` — laissant
+`facture_id` (donc `souscription.facture_ids`, donc le bloc « Factures récentes » du portail)
+**vide pour tous les contrats démo**.
+
+**Décision** : `account.move.periode_id` est la **seule source de vérité** du lien. Le champ
+`souscription.periode.facture_id` devient **calculé/stocké, inverse** de `periode_id` ; on
+**supprime** son écriture manuelle dans le workflow (`_creer_facture_periode` crée déjà le
+`account.move` avec `periode_id`). Le garde-anti-doublon (`periode_ids.filtered(lambda p: not
+p.facture_id)`) et `souscription.facture_ids` (mapping de `facture_id`) continuent de fonctionner
+sans changement d'appelant.
+
+## « Facturée » vs « émise »
+
+`facture_id` est posé **dès qu'une facture existe** (brouillon inclus) — c'est ce qui préserve
+l'anti-doublon : on ne re-facture pas une période qui a déjà un `account.move`. Mais le *Portail*
+ne montre une *Période* que si sa *Facture* est **émise** (`state == 'posted'`). Les deux notions
+sont distinctes et toutes deux nécessaires : l'une protège la facturation, l'autre protège
+l'usager d'un brouillon non finalisé. Voir le terme **Facture** dans `CONTEXT.md`.
+
+## Conséquences
+
+- Migration : recalcul de `facture_id` sur l'existant (dérivé de `periode_id`).
+- Le workflow ne doit plus écrire `periode.facture_id` (champ calculé).
+- Les factures démo doivent porter `periode_id` **et** être **postées** pour s'afficher au portail
+  (notamment celles ajoutées pour le contrat vitrine S0005).
+
+## Raison
+
+KISS : un seul lien à maintenir, dans le sens naturel (« une facture facture une période »), au
+lieu de deux champs à synchroniser. C'est aussi le seul sens déjà peuplé partout (création réelle
++ démo), donc le moins coûteux à fiabiliser.
+
+## Options écartées
+
+- **Garder `facture_id` stocké éditable et le peupler partout** : maintient deux liens
+  désynchronisables ; charge de cohérence permanente.
+- **Tout relier via la Période** (avoirs, réguls compris) : détourne le concept *Période*
+  (brouillon mensuel amorcé par electricore) et ne règle pas les documents sans période.
+
+## Hors périmètre (follow-up)
+
+L'affichage des **avoirs** (via `reversed_entry_id`), des **périodes de régularisation** couvrant
+d'autres périodes, et le **visuel croisé** « telle régul régularise telles périodes/factures »
+sont une évolution distincte, à concevoir avec son propre ADR.

--- a/migrations/19.0.1.1.0/post-migrate.py
+++ b/migrations/19.0.1.1.0/post-migrate.py
@@ -1,0 +1,19 @@
+"""Recalcule `souscription.periode.facture_id` (issue #23 / ADR 0004).
+
+`facture_id` devient un champ calculé/stocké dérivé de `account.move.periode_id`.
+Sur une base existante, les lignes ont l'ancienne valeur écrite à la main (ou
+vide pour les périodes facturées uniquement via le lien côté facture) : on force
+le recalcul à partir de la source de vérité unique.
+"""
+
+from odoo import api, SUPERUSER_ID
+
+
+def migrate(cr, version):
+    env = api.Environment(cr, SUPERUSER_ID, {})
+    periodes = env['souscription.periode'].search([])
+    if not periodes:
+        return
+    periodes.invalidate_recordset(['facture_id'])
+    periodes._compute_facture_id()
+    periodes.flush_recordset(['facture_id'])

--- a/models/core/souscription.py
+++ b/models/core/souscription.py
@@ -136,7 +136,8 @@ class Souscription(models.Model):
             for periode in souscription.periode_ids.filtered(lambda p: not p.facture_id):
                 try:
                     facture = souscription._creer_facture_periode(periode)  # Utiliser la souscription spécifique
-                    periode.facture_id = facture
+                    # facture_id est calculé depuis account.move.periode_id (ADR 0004) :
+                    # _creer_facture_periode a déjà posé periode_id sur la facture.
                     _logger.info(f"Facture {facture.name} créée pour période {periode.mois_annee}")
                 except Exception as e:
                     _logger.error(f"Erreur création facture pour période {periode.mois_annee}: {e}")

--- a/models/core/souscription_periode.py
+++ b/models/core/souscription_periode.py
@@ -85,8 +85,23 @@ class SouscriptionPeriode(models.Model):
     provision_kwh = fields.Float(string='Énergie provisionnée (kWh)', compute='_compute_provision_kwh_compat', store=False)
     _fix_provision = fields.Boolean(default=False, readonly=True)
 
-    facture_id = fields.Many2one('account.move', string='Facture associée')
-    
+    # Lien Période ↔ Facture : `account.move.periode_id` est l'unique source de
+    # vérité (ADR 0004). `facture_id` en est dérivé — calculé/stocké, non écrit.
+    move_ids = fields.One2many(
+        'account.move', 'periode_id', string='Documents liés', readonly=True)
+    facture_id = fields.Many2one(
+        'account.move', string='Facture associée',
+        compute='_compute_facture_id', store=True,
+        help="Facture (out_invoice) rattachée à cette période, dérivée du lien "
+             "account.move.periode_id.")
+
+    @api.depends('move_ids.move_type')
+    def _compute_facture_id(self):
+        for periode in self:
+            factures = periode.move_ids.filtered(
+                lambda m: m.move_type == 'out_invoice')
+            periode.facture_id = factures[:1]
+
     _unique_periode_souscription = models.Constraint(
         'UNIQUE(souscription_id, date_debut, date_fin)',
         'Une seule période par souscription et par dates début/fin.',

--- a/scripts/run-app.sh
+++ b/scripts/run-app.sh
@@ -23,6 +23,11 @@ NETWORK="souscriptions-app-net"
 PG="souscriptions-app-pg"
 APP="souscriptions-app"
 PGVOL="souscriptions-app-pgdata"
+# Le filestore (pièces jointes : bundles d'assets, avatars, images) doit être
+# persisté AU MÊME TITRE que la base : sinon la base (volume PG) référence des
+# fichiers absents du conteneur applicatif éphémère (--rm) → FileNotFoundError
+# sur tous les assets/avatars, 500 sur le websocket bundle.
+DATAVOL="souscriptions-app-data"
 DB="${DB:-souscriptions_demo}"
 PORT="${PORT:-8069}"
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
@@ -32,7 +37,7 @@ MOUNT="$REPO_ROOT:/mnt/extra-addons/souscriptions_odoo:ro"
 if [ "${1:-}" = "--reset" ]; then
     echo "Réinitialisation : suppression des conteneurs et du volume de données..."
     docker rm -f "$APP" "$PG" >/dev/null 2>&1 || true
-    docker volume rm "$PGVOL" >/dev/null 2>&1 || true
+    docker volume rm "$PGVOL" "$DATAVOL" >/dev/null 2>&1 || true
     docker network rm "$NETWORK" >/dev/null 2>&1 || true
 fi
 
@@ -59,7 +64,7 @@ if ! docker exec "$PG" psql -U odoo -lqt | cut -d'|' -f1 | grep -qw "$DB"; then
     echo "Première installation de souscriptions_odoo (avec données de démo)..."
     # --with-demo : Odoo 19 ne charge plus les données de démo par défaut.
     docker run --rm --network "$NETWORK" -e HOST="$PG" -e USER=odoo -e PASSWORD=odoo \
-        -v "$MOUNT" odoo:19 odoo $ADDONS \
+        -v "$MOUNT" -v "$DATAVOL:/var/lib/odoo" odoo:19 odoo $ADDONS \
         -d "$DB" -i souscriptions_odoo --with-demo --load-language=fr_FR --stop-after-init \
         2>&1 | grep -vE '^<string>:[0-9]+: \((ERROR|WARNING|INFO)' || true
 fi
@@ -71,5 +76,5 @@ echo ""
 docker rm -f "$APP" >/dev/null 2>&1 || true
 exec docker run --rm --name "$APP" --network "$NETWORK" -p "${PORT}:8069" \
     -e HOST="$PG" -e USER=odoo -e PASSWORD=odoo \
-    -v "$MOUNT" odoo:19 odoo $ADDONS \
+    -v "$MOUNT" -v "$DATAVOL:/var/lib/odoo" odoo:19 odoo $ADDONS \
     -d "$DB" --db-filter="^${DB}\$"

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -3,6 +3,7 @@ from . import test_souscription
 from . import test_facturation
 from . import test_grille_prix
 from . import test_integration
+from . import test_periode_facture
 from . import test_portal
 from . import test_raccordement
 from . import test_security

--- a/tests/test_facturation.py
+++ b/tests/test_facturation.py
@@ -229,11 +229,9 @@ class TestFacturation(TransactionCase):
         turpe_notes = [n for n in note_names if 'turpe' in n.lower()]
         self.assertTrue(len(turpe_notes) >= 2)
         
-        # Assigner manuellement la facture à la période (l'assignation automatique n'est pas implémentée)
-        periode.facture_id = facture
-        
-        # Vérifier que la période est marquée comme facturée
-        self.assertTrue(periode.facture_id.id == facture.id)
+        # facture_id est dérivé de account.move.periode_id (ADR 0004) : la facture
+        # porte déjà periode_id, le lien vers la période est donc automatique.
+        self.assertEqual(periode.facture_id, facture)
     
     def test_generation_facture_hp_hc(self):
         """Test génération facture pour souscription HP/HC"""

--- a/tests/test_periode_facture.py
+++ b/tests/test_periode_facture.py
@@ -1,0 +1,48 @@
+"""
+Tests du lien Période ↔ Facture (issue #23 / ADR 0004).
+
+`account.move.periode_id` est l'unique source de vérité du lien : la période
+expose sa facture via `facture_id`, champ calculé/stocké dérivé de ce lien.
+"""
+
+from odoo.tests.common import tagged
+from datetime import date
+
+from .common import SouscriptionsTestCase
+
+
+@tagged('souscriptions', 'souscriptions_periode_facture', 'post_install', '-at_install')
+class TestPeriodeFactureLien(SouscriptionsTestCase):
+
+    def test_facture_id_derive_du_periode_id(self):
+        """facture_id reflète le account.move qui pointe la période via periode_id."""
+        periode = self.create_test_periode(self.souscription_base)
+        self.assertFalse(periode.facture_id, "Aucune facture liée au départ")
+
+        facture = self.env['account.move'].create({
+            'move_type': 'out_invoice',
+            'partner_id': self.partner_test.id,
+            'invoice_date': date(2024, 2, 5),
+            'periode_id': periode.id,
+        })
+
+        self.assertEqual(periode.facture_id, facture)
+
+    def test_facture_ids_souscription_agrege_les_periodes(self):
+        """souscription.facture_ids agrège automatiquement les factures des périodes."""
+        periode = self.create_test_periode(self.souscription_base)
+        facture = self.souscription_base._creer_facture_periode(periode)
+        self.assertIn(facture, self.souscription_base.facture_ids)
+
+    def test_creer_factures_ne_double_pas(self):
+        """creer_factures est idempotent : une seule facture par période (anti-doublon)."""
+        self.create_test_periode(
+            self.souscription_base,
+            date_debut=date(2024, 1, 1), date_fin=date(2024, 1, 31))
+
+        self.souscription_base.creer_factures()
+        self.assertEqual(len(self.souscription_base.facture_ids), 1)
+
+        # Second appel : aucune facture supplémentaire ne doit être créée.
+        self.souscription_base.creer_factures()
+        self.assertEqual(len(self.souscription_base.facture_ids), 1)

--- a/tests/test_portal.py
+++ b/tests/test_portal.py
@@ -1,9 +1,9 @@
 """
-Tests unitaires pour le portal usager·ère du module souscriptions.
+Tests du portail usager·ère (#24) : l'historique des consommations est intégré
+directement dans la page de détail d'une souscription. Seules les périodes dont
+la facture est émise (postée) sont visibles ; il n'y a plus de page /periodes.
 """
 
-import json
-from unittest.mock import patch
 from odoo.tests.common import HttpCase, tagged
 from odoo.addons.souscriptions_odoo.tests.common import SouscriptionsTestMixin
 from datetime import date
@@ -11,316 +11,215 @@ from datetime import date
 
 @tagged('post_install', '-at_install', 'portal')
 class PortalTestCase(SouscriptionsTestMixin, HttpCase):
-    """Tests du portal usager·ère pour les souscriptions."""
+    """Tests du portail usager·ère pour les souscriptions."""
 
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
         cls.setUpSouscriptionsData()
-        
-        # Créer un utilisateur portal pour les tests
+
         cls.portal_user = cls.env['res.users'].create({
             'name': 'Portal Test User',
             'login': 'portal_test',
             'email': 'portal@test.com',
             'group_ids': [(6, 0, [cls.env.ref('base.group_portal').id])],
         })
-        
-        # Associer le partner de test à l'utilisateur portal
         cls.partner_test.user_ids = [(6, 0, [cls.portal_user.id])]
-        
-        # Créer des périodes et factures de test pour la souscription
-        cls._create_test_periods_and_invoices()
+
+        cls._create_periods_and_posted_invoices()
 
     @classmethod
-    def _create_test_periods_and_invoices(cls):
-        """Créer des données de test complètes pour le portal."""
-        # Période janvier 2024
+    def _create_periods_and_posted_invoices(cls):
+        """Deux périodes facturées et POSTÉES (donc visibles côté portail)."""
         cls.periode_jan = cls.env['souscription.periode'].create({
             'souscription_id': cls.souscription_base.id,
-            'date_debut': date(2024, 1, 1),
-            'date_fin': date(2024, 1, 31),
+            'date_debut': date(2024, 1, 1), 'date_fin': date(2024, 1, 31),
             'type_periode': 'mensuelle',
-            'energie_base_kwh': 280.0,
-            'provision_base_kwh': 300.0,
-            'turpe_fixe': 8.50,
-            'turpe_variable': 12.30,
+            'energie_base_kwh': 280.0, 'provision_base_kwh': 300.0,
+            'turpe_fixe': 8.50, 'turpe_variable': 12.30,
         })
-        
-        # Période février 2024
         cls.periode_feb = cls.env['souscription.periode'].create({
             'souscription_id': cls.souscription_base.id,
-            'date_debut': date(2024, 2, 1),
-            'date_fin': date(2024, 2, 29),
+            'date_debut': date(2024, 2, 1), 'date_fin': date(2024, 2, 29),
             'type_periode': 'mensuelle',
-            'energie_base_kwh': 320.0,
-            'provision_base_kwh': 300.0,
-            'turpe_fixe': 8.50,
-            'turpe_variable': 14.20,
+            'energie_base_kwh': 320.0, 'provision_base_kwh': 300.0,
+            'turpe_fixe': 8.50, 'turpe_variable': 14.20,
         })
-        
-        # Créer des factures associées via le système de souscription.
-        # facture_id se déduit de account.move.periode_id (ADR 0004) : pas
-        # d'assignation manuelle, les factures portent periode_id.
-        try:
-            cls.facture_jan = cls.souscription_base._creer_facture_periode(cls.periode_jan)
-        except:
-            # Fallback - créer une facture simple avec un nom
-            cls.facture_jan = cls.env['account.move'].create({
-                'move_type': 'out_invoice',
-                'partner_id': cls.partner_test.id,
-                'invoice_date': date(2024, 2, 5),
-                'periode_id': cls.periode_jan.id,
-                'name': 'FACT/2024/0001',
-            })
+        cls.facture_jan = cls.souscription_base._creer_facture_periode(cls.periode_jan)
+        cls.facture_feb = cls.souscription_base._creer_facture_periode(cls.periode_feb)
+        (cls.facture_jan | cls.facture_feb).action_post()
 
-        try:
-            cls.facture_feb = cls.souscription_base._creer_facture_periode(cls.periode_feb)
-        except:
-            # Fallback - créer une facture simple avec un nom
-            cls.facture_feb = cls.env['account.move'].create({
-                'move_type': 'out_invoice',
-                'partner_id': cls.partner_test.id,
-                'invoice_date': date(2024, 3, 5),
-                'periode_id': cls.periode_feb.id,
-                'name': 'FACT/2024/0002',
-            })
+    @classmethod
+    def _facture_postee_simple(cls, souscription, periode, invoice_date):
+        """Facture postée minimale (sans dépendre d'une grille de prix)."""
+        produit = cls.env.ref('souscriptions_odoo.souscriptions_product_energie_base')
+        move = cls.env['account.move'].create({
+            'move_type': 'out_invoice',
+            'partner_id': souscription.partner_id.id,
+            'invoice_date': invoice_date,
+            'periode_id': periode.id,
+            'invoice_line_ids': [(0, 0, {
+                'product_id': produit.id, 'quantity': 1, 'price_unit': 10.0,
+            })],
+        })
+        move.action_post()
+        return move
 
-    def test_portal_access_redirect_unauthenticated(self):
-        """Test que l'accès non authentifié redirige vers login."""
-        # Test liste des souscriptions
+    def _detail_url(self, souscription=None):
+        souscription = souscription or self.souscription_base
+        return f'/my/souscription/{souscription.id}'
+
+    # --- Accès ---
+
+    def test_acces_non_authentifie_redirige_login(self):
+        """Accès non authentifié à la liste et au détail : redirection login."""
+        for url in ('/my/souscriptions', self._detail_url()):
+            response = self.url_open(url)
+            self.assertEqual(response.status_code, 200)
+            self.assertIn('login', response.url)
+
+    def test_liste_souscriptions_authentifie(self):
+        """La liste des souscriptions montre la souscription de l'usager."""
+        self.authenticate(self.portal_user.login, self.portal_user.login)
         response = self.url_open('/my/souscriptions')
         self.assertEqual(response.status_code, 200)
-        # Vérifier qu'on est sur la page de login
-        self.assertIn('login', response.url)
-        
-        # Test détail souscription
-        response = self.url_open(f'/my/souscription/{self.souscription_base.id}')
-        self.assertEqual(response.status_code, 200)
-        self.assertIn('login', response.url)
-        
-        # Test vue périodes
-        response = self.url_open(f'/my/souscription/{self.souscription_base.id}/periodes')
-        self.assertEqual(response.status_code, 200)
-        self.assertIn('login', response.url)
-
-    def test_portal_souscriptions_list_authenticated(self):
-        """Test de la liste des souscriptions avec utilisateur authentifié."""
-        # Se connecter comme utilisateur portal
-        self.authenticate(self.portal_user.login, self.portal_user.login)
-        
-        # Accéder à la liste des souscriptions
-        response = self.url_open('/my/souscriptions')
-        self.assertEqual(response.status_code, 200)
-        
-        # Vérifier que la souscription apparaît
         self.assertIn(self.souscription_base.name, response.text)
         self.assertIn(self.souscription_base.pdl, response.text)
-        
-        # Vérifier les éléments de l'interface
-        self.assertIn('Base', response.text)  # Type de tarif
-        self.assertIn('Active', response.text)  # État
-        # Le titre peut être dans la searchbar, l'important est que les souscriptions soient listées
-        self.assertTrue('souscription' in response.text.lower() or 'S0001' in response.text)
 
-    def test_portal_souscription_detail_authenticated(self):
-        """Test de la vue détail d'une souscription."""
+    # --- Historique intégré ---
+
+    def test_detail_affiche_historique_inline_sans_bouton(self):
+        """L'historique est dans la page ; l'ancien bouton de navigation a disparu."""
         self.authenticate(self.portal_user.login, self.portal_user.login)
-        
-        response = self.url_open(f'/my/souscription/{self.souscription_base.id}')
+        response = self.url_open(self._detail_url())
         self.assertEqual(response.status_code, 200)
-        
-        # Vérifier les informations de la souscription
-        self.assertIn(self.souscription_base.name, response.text)
+
         self.assertIn(self.souscription_base.pdl, response.text)
-        self.assertIn(str(self.souscription_base.puissance_souscrite), response.text)
-        
-        # Vérifier les liens vers les fonctionnalités
-        self.assertIn('Voir l\'historique des consommations', response.text)
-        self.assertIn('Factures récentes', response.text)
-
-    def test_portal_periods_view_authenticated(self):
-        """Test de la vue des périodes de facturation."""
-        self.authenticate(self.portal_user.login, self.portal_user.login)
-        
-        # Vérifier d'abord que la souscription a des périodes
-        self.assertTrue(len(self.periode_jan) > 0, "Période janvier doit exister")
-        self.assertTrue(len(self.periode_feb) > 0, "Période février doit exister")
-        
-        response = self.url_open(f'/my/souscription/{self.souscription_base.id}/periodes')
-        self.assertEqual(response.status_code, 200)
-        
-        # La page se charge : on s'appuie sur le code HTTP (200) ci-dessus, qui
-        # est le contrôle fiable « ce n'est pas une page d'erreur ». On ne fait
-        # PAS de recherche de sous-chaîne '404'/'500' dans le HTML : ces motifs
-        # apparaissent par hasard dans des valeurs aléatoires (registry_hash,
-        # csrf_token, URLs d'assets), ce qui rendait ce test instable.
         self.assertIn('Historique des consommations', response.text)
+        # le bouton vers l'ancienne page séparée n'existe plus
+        self.assertNotIn("Voir l'historique des consommations", response.text)
+        # les périodes facturées (postées) sont listées, avec leur facture
+        self.assertIn(self.facture_jan.name, response.text)
+        self.assertIn(self.facture_feb.name, response.text)
 
-    def test_portal_security_other_user_data(self):
-        """Test que l'utilisateur ne peut pas voir les données d'autres utilisateurs."""
-        # Créer un autre utilisateur et souscription
-        other_partner = self.env['res.partner'].create({
-            'name': 'Other User',
-            'email': 'other@test.com',
+    def test_seules_periodes_facture_postee_visibles(self):
+        """Une période dont la facture est en brouillon n'apparaît pas."""
+        periode_draft = self.env['souscription.periode'].create({
+            'souscription_id': self.souscription_base.id,
+            'date_debut': date(2024, 3, 1), 'date_fin': date(2024, 3, 31),
+            'type_periode': 'mensuelle',
+            'energie_base_kwh': 999.0, 'turpe_fixe': 1.0, 'turpe_variable': 1.0,
         })
-        
-        other_user = self.env['res.users'].create({
-            'name': 'Other Portal User',
-            'login': 'other_portal',
-            'email': 'other_portal@test.com',
-            'group_ids': [(6, 0, [self.env.ref('base.group_portal').id])],
-        })
-        other_partner.user_ids = [(6, 0, [other_user.id])]
-        
-        other_souscription = self.env['souscription.souscription'].create({
-            'partner_id': other_partner.id,
-            'pdl': 'PDL_OTHER_USER',
-            'puissance_souscrite': '3',
-            'type_tarif': 'base',
-            'etat_facturation_id': self.etat_facturation.id,
-        })
-        
-        # Se connecter comme premier utilisateur
-        self.authenticate(self.portal_user.login, self.portal_user.login)
-        
-        # Tenter d'accéder aux données de l'autre utilisateur
-        response = self.url_open(f'/my/souscription/{other_souscription.id}')
-        # Doit retourner 403 (accès refusé) grâce aux règles de sécurité
-        self.assertEqual(response.status_code, 403)
+        facture_draft = self.souscription_base._creer_facture_periode(periode_draft)
+        self.assertEqual(facture_draft.state, 'draft')
 
-    def test_portal_invoice_links(self):
-        """Test que les liens vers les factures fonctionnent."""
         self.authenticate(self.portal_user.login, self.portal_user.login)
-        
-        # D'abord tester la vue détail de souscription
-        response = self.url_open(f'/my/souscription/{self.souscription_base.id}')
+        response = self.url_open(self._detail_url())
         self.assertEqual(response.status_code, 200)
-        
-        # Vérifier que les factures apparaissent
-        if hasattr(self.facture_jan, 'name') and self.facture_jan.name:
-            self.assertIn(str(self.facture_jan.name), response.text)
-        if hasattr(self.facture_feb, 'name') and self.facture_feb.name:
-            self.assertIn(str(self.facture_feb.name), response.text)
-        
-        # Fallback - au moins vérifier qu'il y a des références de factures
-        self.assertIn('facture', response.text.lower())
+        # l'énergie spécifique de la période en brouillon ne doit pas fuiter
+        self.assertNotIn('999', response.text)
 
-    def test_portal_responsive_display_base_vs_hphc(self):
-        """Test que l'affichage s'adapte selon le type de tarif."""
-        # Test avec souscription Base
+    def test_route_periodes_supprimee(self):
+        """L'ancienne page /periodes n'existe plus (404)."""
         self.authenticate(self.portal_user.login, self.portal_user.login)
-        
-        response = self.url_open(f'/my/souscription/{self.souscription_base.id}/periodes')
-        self.assertEqual(response.status_code, 200)
-        
-        # Doit afficher les colonnes Base
+        response = self.url_open(self._detail_url() + '/periodes')
+        self.assertEqual(response.status_code, 404)
+
+    def test_colonnes_energie_selon_type_tarif(self):
+        """Les colonnes énergie s'adaptent au type de tarif (Base vs HP/HC)."""
+        self.authenticate(self.portal_user.login, self.portal_user.login)
+
+        # Base
+        response = self.url_open(self._detail_url())
         self.assertIn('Énergie Base (kWh)', response.text)
         self.assertNotIn('Énergie HP (kWh)', response.text)
-        
-        # Test avec souscription HP/HC
-        # Créer des périodes pour la souscription HP/HC
+
+        # HP/HC
+        self.souscription_hphc.partner_id = self.partner_test.id
         periode_hphc = self.env['souscription.periode'].create({
             'souscription_id': self.souscription_hphc.id,
-            'date_debut': date(2024, 1, 1),
-            'date_fin': date(2024, 1, 31),
+            'date_debut': date(2024, 1, 1), 'date_fin': date(2024, 1, 31),
             'type_periode': 'mensuelle',
-            'energie_hp_kwh': 200.0,
-            'energie_hc_kwh': 120.0,
-            'provision_hp_kwh': 210.0,
-            'provision_hc_kwh': 130.0,
-            'turpe_fixe': 12.80,
-            'turpe_variable': 18.50,
+            'energie_hph_kwh': 120.0, 'energie_hpb_kwh': 80.0,
+            'energie_hch_kwh': 70.0, 'energie_hcb_kwh': 50.0,
+            'turpe_fixe': 12.80, 'turpe_variable': 18.50,
         })
-        
-        # Associer la souscription HP/HC au même partner pour le test
-        self.souscription_hphc.partner_id = self.partner_test.id
-        
-        response = self.url_open(f'/my/souscription/{self.souscription_hphc.id}/periodes')
+        self.souscription_hphc._creer_facture_periode(periode_hphc).action_post()
+
+        response = self.url_open(self._detail_url(self.souscription_hphc))
         self.assertEqual(response.status_code, 200)
-        
-        # Doit afficher les colonnes HP/HC
         self.assertIn('Énergie HP (kWh)', response.text)
         self.assertIn('Énergie HC (kWh)', response.text)
         self.assertNotIn('Énergie Base (kWh)', response.text)
 
-    def test_portal_data_completeness(self):
-        """Test que toutes les données importantes sont affichées."""
+    def test_totaux_affiches(self):
+        """La carte Totaux est présente et somme les périodes facturées."""
         self.authenticate(self.portal_user.login, self.portal_user.login)
-        
-        # Test page détail souscription
-        response = self.url_open(f'/my/souscription/{self.souscription_base.id}')
+        response = self.url_open(self._detail_url())
         self.assertEqual(response.status_code, 200)
-        
-        # Vérifier les informations techniques
-        self.assertIn(self.souscription_base.pdl, response.text)
-        self.assertIn(str(self.souscription_base.puissance_souscrite), response.text)
-        self.assertIn('Base', response.text)  # Type de tarif
-        
-        # Vérifier les informations de facturation
-        if self.souscription_base.lisse:
-            self.assertIn('Facturation lissée', response.text)
-            self.assertIn(str(self.souscription_base.provision_mensuelle_kwh), response.text)
 
-    def test_portal_breadcrumb_navigation(self):
-        """Test que la navigation breadcrumb fonctionne."""
-        self.authenticate(self.portal_user.login, self.portal_user.login)
-        
-        # Test sur la vue des périodes
-        response = self.url_open(f'/my/souscription/{self.souscription_base.id}/periodes')
-        self.assertEqual(response.status_code, 200)
-        
-        # Vérifier les éléments de navigation
-        self.assertIn('Mes Souscriptions', response.text)
-        self.assertIn(self.souscription_base.name, response.text)
-        self.assertIn('Périodes de facturation', response.text)
-        
-        # Vérifier les liens
-        self.assertIn('/my/souscriptions', response.text)
-        self.assertIn(f'/my/souscription/{self.souscription_base.id}', response.text)
+        self.assertIn('Consommation totale', response.text)
+        self.assertIn('TURPE total', response.text)
+        self.assertIn('Total facturé', response.text)
 
-    def test_portal_calculations_accuracy(self):
-        """Test que les calculs de totaux sont corrects."""
-        self.authenticate(self.portal_user.login, self.portal_user.login)
-        
-        response = self.url_open(f'/my/souscription/{self.souscription_base.id}/periodes')
-        self.assertEqual(response.status_code, 200)
-        
-        # Calculer les totaux attendus
-        expected_total_kwh = self.periode_jan.energie_base_kwh + self.periode_feb.energie_base_kwh
-        expected_total_turpe = (
-            (self.periode_jan.turpe_fixe + self.periode_jan.turpe_variable) +
-            (self.periode_feb.turpe_fixe + self.periode_feb.turpe_variable)
-        )
-        
-        # Vérifier que les totaux calculés apparaissent
-        self.assertIn(f'{expected_total_kwh:.0f}', response.text)
-        self.assertIn(f'{expected_total_turpe:.2f}', response.text)
+        total_kwh = self.periode_jan.energie_base_kwh + self.periode_feb.energie_base_kwh
+        self.assertIn(f'{total_kwh:.0f}', response.text)
 
-    def test_portal_empty_data_handling(self):
-        """Test la gestion des cas où il n'y a pas de données."""
-        # Créer une souscription sans périodes
-        empty_souscription = self.env['souscription.souscription'].create({
+    def test_etat_vide_sans_facture_postee(self):
+        """Une souscription sans période facturée affiche un état vide propre."""
+        empty = self.env['souscription.souscription'].create({
             'partner_id': self.partner_test.id,
-            'pdl': 'PDL_EMPTY_TEST',
-            'puissance_souscrite': '6',
-            'type_tarif': 'base',
+            'pdl': 'PDL_EMPTY_TEST', 'puissance_souscrite': '6',
+            'type_tarif': 'base', 'etat_facturation_id': self.etat_facturation.id,
+        })
+        self.authenticate(self.portal_user.login, self.portal_user.login)
+        response = self.url_open(self._detail_url(empty))
+        self.assertEqual(response.status_code, 200)
+        self.assertIn('Aucune période facturée', response.text)
+
+    def test_voir_plus_au_dela_de_douze(self):
+        """Au-delà de 12 périodes facturées, un bouton « Voir plus » apparaît."""
+        for mois in range(1, 12):  # 11 périodes supplémentaires -> 13 au total
+            periode = self.env['souscription.periode'].create({
+                'souscription_id': self.souscription_base.id,
+                'date_debut': date(2023, mois, 1),
+                'date_fin': date(2023, mois, 28),
+                'type_periode': 'mensuelle',
+                'energie_base_kwh': 100.0 + mois,
+                'turpe_fixe': 5.0, 'turpe_variable': 2.0,
+            })
+            self._facture_postee_simple(
+                self.souscription_base, periode, date(2023, mois, 28))
+
+        self.authenticate(self.portal_user.login, self.portal_user.login)
+        response = self.url_open(self._detail_url())
+        self.assertEqual(response.status_code, 200)
+        self.assertIn('Voir plus', response.text)
+
+    def test_securite_autre_usager(self):
+        """Un usager ne peut pas voir la souscription d'un autre (403)."""
+        other_partner = self.env['res.partner'].create({
+            'name': 'Other User', 'email': 'other@test.com'})
+        other_user = self.env['res.users'].create({
+            'name': 'Other Portal User', 'login': 'other_portal',
+            'email': 'other_portal@test.com',
+            'group_ids': [(6, 0, [self.env.ref('base.group_portal').id])],
+        })
+        other_partner.user_ids = [(6, 0, [other_user.id])]
+        other_souscription = self.env['souscription.souscription'].create({
+            'partner_id': other_partner.id, 'pdl': 'PDL_OTHER_USER',
+            'puissance_souscrite': '3', 'type_tarif': 'base',
             'etat_facturation_id': self.etat_facturation.id,
         })
-        
+
         self.authenticate(self.portal_user.login, self.portal_user.login)
-        
-        # Test vue des périodes sans données
-        response = self.url_open(f'/my/souscription/{empty_souscription.id}/periodes')
-        self.assertEqual(response.status_code, 200)
-        
-        # Vérifier le message d'absence de données
-        self.assertIn('Aucune période de facturation trouvée', response.text)
+        response = self.url_open(self._detail_url(other_souscription))
+        self.assertEqual(response.status_code, 403)
 
 
 @tagged('post_install', '-at_install', 'portal_integration')
 class PortalIntegrationTestCase(SouscriptionsTestMixin, HttpCase):
-    """Tests d'intégration du portal avec le reste du système."""
+    """Tests d'intégration du portail avec le reste du système."""
 
     @classmethod
     def setUpClass(cls):
@@ -328,94 +227,47 @@ class PortalIntegrationTestCase(SouscriptionsTestMixin, HttpCase):
         cls.setUpSouscriptionsData()
 
     def test_portal_menu_integration(self):
-        """Test que le menu portal s'intègre correctement."""
-        # Vérifier que l'entrée portal existe dans les données
-        portal_menu = self.env.ref('souscriptions_odoo.portal_my_home_souscriptions', raise_if_not_found=False)
+        """L'entrée du portail (tuile d'accueil) existe."""
+        portal_menu = self.env.ref(
+            'souscriptions_odoo.portal_my_home_souscriptions', raise_if_not_found=False)
         self.assertTrue(portal_menu, "Le menu portal doit exister")
 
-    def test_portal_with_real_invoice_data(self):
-        """Test avec des factures réelles générées par le système."""
-        # Créer une période et générer une vraie facture
+    def test_facture_postee_apparait_dans_historique(self):
+        """Une facture réelle postée apparaît dans l'historique intégré."""
         periode, facture = self.create_test_invoice(self.souscription_base)
-        
-        # Associer au partner de test
+        facture.action_post()
         self.souscription_base.partner_id = self.partner_test.id
-        
-        # Créer utilisateur portal
+
         portal_user = self.env['res.users'].create({
-            'name': 'Integration Test User',
-            'login': 'integration_test',
+            'name': 'Integration Test User', 'login': 'integration_test',
             'email': 'integration@test.com',
             'group_ids': [(6, 0, [self.env.ref('base.group_portal').id])],
         })
         self.partner_test.user_ids = [(6, 0, [portal_user.id])]
-        
         self.authenticate(portal_user.login, portal_user.login)
-        
-        # Test accès aux factures depuis le portal
+
         response = self.url_open(f'/my/souscription/{self.souscription_base.id}')
         self.assertEqual(response.status_code, 200)
-        
-        # Vérifier que la facture apparaît
-        if hasattr(facture, 'name') and facture.name:
-            self.assertIn(facture.name, response.text)
-        else:
-            # Fallback - just check that there's a facture reference
-            self.assertIn('facture', response.text.lower())
+        self.assertIn(facture.name, response.text)
 
     def test_portal_permissions_consistency(self):
-        """Test que les permissions portal sont cohérentes."""
-        # Vérifier les droits d'accès des modèles
+        """Les droits portail (lecture seule) sont cohérents."""
         portal_group = self.env.ref('base.group_portal')
-        
-        # Souscription
+
         access = self.env['ir.model.access'].search([
             ('model_id.model', '=', 'souscription.souscription'),
-            ('group_id', '=', portal_group.id)
+            ('group_id', '=', portal_group.id),
         ])
         self.assertTrue(access, "Accès portal aux souscriptions requis")
         self.assertTrue(access.perm_read, "Lecture autorisée")
         self.assertFalse(access.perm_write, "Écriture interdite")
         self.assertFalse(access.perm_create, "Création interdite")
         self.assertFalse(access.perm_unlink, "Suppression interdite")
-        
-        # Périodes
+
         access = self.env['ir.model.access'].search([
             ('model_id.model', '=', 'souscription.periode'),
-            ('group_id', '=', portal_group.id)
+            ('group_id', '=', portal_group.id),
         ])
         self.assertTrue(access, "Accès portal aux périodes requis")
         self.assertTrue(access.perm_read, "Lecture autorisée")
         self.assertFalse(access.perm_write, "Écriture interdite")
-
-
-# Compatibilité avec les anciens tests Python standalone
-class PortalCompatibilityTests:
-    """
-    Wrapper pour intégrer les anciens tests Python standalone.
-    Ces méthodes peuvent être appelées depuis les tests unitaires.
-    """
-    
-    @staticmethod
-    def test_portal_accessibility():
-        """Test basique d'accessibilité du portal (équivalent test_portal.py)."""
-        import requests
-        base_url = "http://localhost:8069"  # Port par défaut des tests
-        
-        try:
-            response = requests.get(f"{base_url}/my/souscriptions", allow_redirects=False, timeout=5)
-            return response.status_code in [302, 303, 200]
-        except:
-            return False
-    
-    @staticmethod
-    def test_periods_route_exists():
-        """Test que la route des périodes existe (équivalent test_periods_view.py)."""
-        import requests
-        base_url = "http://localhost:8069"
-        
-        try:
-            response = requests.get(f"{base_url}/my/souscription/1/periodes", allow_redirects=False, timeout=5)
-            return response.status_code in [302, 303, 200, 404]  # 404 = route existe mais pas d'ID 1
-        except:
-            return False

--- a/tests/test_portal.py
+++ b/tests/test_portal.py
@@ -59,10 +59,11 @@ class PortalTestCase(SouscriptionsTestMixin, HttpCase):
             'turpe_variable': 14.20,
         })
         
-        # Créer des factures associées via le système de souscription
+        # Créer des factures associées via le système de souscription.
+        # facture_id se déduit de account.move.periode_id (ADR 0004) : pas
+        # d'assignation manuelle, les factures portent periode_id.
         try:
             cls.facture_jan = cls.souscription_base._creer_facture_periode(cls.periode_jan)
-            cls.periode_jan.facture_id = cls.facture_jan
         except:
             # Fallback - créer une facture simple avec un nom
             cls.facture_jan = cls.env['account.move'].create({
@@ -72,11 +73,9 @@ class PortalTestCase(SouscriptionsTestMixin, HttpCase):
                 'periode_id': cls.periode_jan.id,
                 'name': 'FACT/2024/0001',
             })
-            cls.periode_jan.facture_id = cls.facture_jan
-        
+
         try:
             cls.facture_feb = cls.souscription_base._creer_facture_periode(cls.periode_feb)
-            cls.periode_feb.facture_id = cls.facture_feb
         except:
             # Fallback - créer une facture simple avec un nom
             cls.facture_feb = cls.env['account.move'].create({
@@ -86,7 +85,6 @@ class PortalTestCase(SouscriptionsTestMixin, HttpCase):
                 'periode_id': cls.periode_feb.id,
                 'name': 'FACT/2024/0002',
             })
-            cls.periode_feb.facture_id = cls.facture_feb
 
     def test_portal_access_redirect_unauthenticated(self):
         """Test que l'accès non authentifié redirige vers login."""

--- a/views/portal_templates.xml
+++ b/views/portal_templates.xml
@@ -198,67 +198,90 @@
                                 </div>
                             </div>
 
-                            <!-- Navigation vers les périodes -->
-                            <div class="text-center mb-4">
-                                <a t-attf-href="/my/souscription/#{souscription.id}/periodes" 
-                                   class="btn btn-primary">
-                                    <i class="fa fa-calendar"/> Voir l'historique des consommations
-                                </a>
-                            </div>
-                            
-                            <!-- Factures récentes -->
-                            <h5 class="mt-4">Factures récentes</h5>
-                            <t t-if="souscription.facture_ids">
+                            <!-- Historique des consommations (intégré à la page) -->
+                            <h5 class="mt-4">Historique des consommations</h5>
+                            <t t-if="not periodes">
+                                <p class="text-muted">Aucune période facturée pour cette souscription.</p>
+                            </t>
+                            <t t-else="">
                                 <div class="table-responsive">
-                                    <table class="table table-sm table-striped">
+                                    <table class="table table-sm table-striped align-middle">
                                         <thead>
                                             <tr>
-                                                <th>Numéro</th>
-                                                <th>Date</th>
                                                 <th>Période</th>
-                                                <th>Montant TTC</th>
-                                                <th>État</th>
-                                                <th class="text-end">Actions</th>
+                                                <th>Type</th>
+                                                <t t-if="souscription.type_tarif == 'base'">
+                                                    <th class="text-end">Énergie Base (kWh)</th>
+                                                </t>
+                                                <t t-else="">
+                                                    <th class="text-end">Énergie HP (kWh)</th>
+                                                    <th class="text-end">Énergie HC (kWh)</th>
+                                                </t>
+                                                <th class="text-end">TURPE Fixe (€)</th>
+                                                <th class="text-end">TURPE Variable (€)</th>
+                                                <th class="text-end">Montant TTC</th>
+                                                <th class="text-center">Paiement</th>
+                                                <th class="text-center">Facture</th>
                                             </tr>
                                         </thead>
                                         <tbody>
-                                            <t t-foreach="souscription.facture_ids[:10]" t-as="facture">
-                                                <tr>
+                                            <t t-foreach="periodes" t-as="periode">
+                                                <tr t-attf-class="#{'collapse periode-extra' if periode_index &gt;= 12 else ''}">
                                                     <td>
-                                                        <a t-attf-href="/my/invoices/#{facture.id}">
-                                                            <t t-esc="facture.name"/>
-                                                        </a>
+                                                        <strong t-esc="periode.date_debut.strftime('%m/%Y') if periode.date_debut else '-'"/>
+                                                        <br/>
+                                                        <small class="text-muted">
+                                                            <t t-esc="periode.date_debut.strftime('%d/%m/%Y') if periode.date_debut else ''"/> -
+                                                            <t t-esc="periode.date_fin.strftime('%d/%m/%Y') if periode.date_fin else ''"/>
+                                                        </small>
                                                     </td>
                                                     <td>
-                                                        <t t-esc="facture.invoice_date.strftime('%d/%m/%Y') if facture.invoice_date else '-'"/>
+                                                        <span class="badge rounded-pill text-bg-secondary">
+                                                            <t t-esc="dict(periode._fields['type_periode'].selection).get(periode.type_periode, periode.type_periode)"/>
+                                                        </span>
                                                     </td>
-                                                    <td>
-                                                        <t t-if="facture.periode_id">
-                                                            <t t-esc="facture.periode_id.mois_annee"/>
+                                                    <t t-if="souscription.type_tarif == 'base'">
+                                                        <td class="text-end">
+                                                            <strong><t t-esc="periode.energie_base_kwh or 0"/></strong>
+                                                            <t t-if="periode.provision_base_kwh">
+                                                                <br/><small class="text-muted">Prov: <t t-esc="periode.provision_base_kwh"/></small>
+                                                            </t>
+                                                        </td>
+                                                    </t>
+                                                    <t t-else="">
+                                                        <td class="text-end">
+                                                            <strong><t t-esc="periode.energie_hp_kwh or 0"/></strong>
+                                                            <t t-if="periode.provision_hp_kwh">
+                                                                <br/><small class="text-muted">Prov: <t t-esc="periode.provision_hp_kwh"/></small>
+                                                            </t>
+                                                        </td>
+                                                        <td class="text-end">
+                                                            <strong><t t-esc="periode.energie_hc_kwh or 0"/></strong>
+                                                            <t t-if="periode.provision_hc_kwh">
+                                                                <br/><small class="text-muted">Prov: <t t-esc="periode.provision_hc_kwh"/></small>
+                                                            </t>
+                                                        </td>
+                                                    </t>
+                                                    <td class="text-end"><t t-esc="'%.2f' % (periode.turpe_fixe or 0)"/></td>
+                                                    <td class="text-end"><t t-esc="'%.2f' % (periode.turpe_variable or 0)"/></td>
+                                                    <td class="text-end">
+                                                        <strong><t t-esc="'%.2f' % (periode.facture_id.amount_total or 0)"/> €</strong>
+                                                    </td>
+                                                    <td class="text-center">
+                                                        <t t-if="periode.facture_id.payment_state == 'paid'">
+                                                            <span class="badge rounded-pill text-bg-success"><i class="fa fa-check"/> Payée</span>
                                                         </t>
-                                                        <t t-else="">-</t>
-                                                    </td>
-                                                    <td>
-                                                        <strong><t t-esc="'%.2f' % facture.amount_total"/> €</strong>
-                                                    </td>
-                                                    <td>
-                                                        <t t-if="facture.payment_state == 'paid'">
-                                                            <span class="badge rounded-pill text-bg-success">
-                                                                <i class="fa fa-check"/> Payée
-                                                            </span>
-                                                        </t>
-                                                        <t t-elif="facture.payment_state == 'partial'">
+                                                        <t t-elif="periode.facture_id.payment_state == 'partial'">
                                                             <span class="badge rounded-pill text-bg-warning">Partielle</span>
                                                         </t>
                                                         <t t-else="">
                                                             <span class="badge rounded-pill text-bg-danger">Impayée</span>
                                                         </t>
                                                     </td>
-                                                    <td class="text-end">
-                                                        <a t-attf-href="/my/invoices/#{facture.id}" 
-                                                           class="btn btn-sm btn-secondary"
-                                                           title="Télécharger PDF">
-                                                            <i class="fa fa-download"/>
+                                                    <td class="text-center">
+                                                        <a t-attf-href="/my/invoices/#{periode.facture_id.id}"
+                                                           class="btn btn-sm btn-outline-primary" title="Voir la facture">
+                                                            <i class="fa fa-file-text-o"/> <t t-esc="periode.facture_id.name"/>
                                                         </a>
                                                     </td>
                                                 </tr>
@@ -266,9 +289,56 @@
                                         </tbody>
                                     </table>
                                 </div>
-                            </t>
-                            <t t-else="">
-                                <p class="text-muted">Aucune facture émise pour cette souscription.</p>
+
+                                <t t-if="len(periodes) &gt; 12">
+                                    <div class="text-center mb-3">
+                                        <button class="btn btn-sm btn-outline-secondary" type="button"
+                                                data-bs-toggle="collapse" data-bs-target=".periode-extra"
+                                                aria-expanded="false">
+                                            <i class="fa fa-chevron-down"/> Voir plus
+                                        </button>
+                                    </div>
+                                </t>
+
+                                <!-- Totaux (sur toutes les périodes facturées) + glossaire -->
+                                <t t-set="total_kwh" t-value="0"/>
+                                <t t-set="total_turpe" t-value="0"/>
+                                <t t-set="total_facture" t-value="0"/>
+                                <t t-foreach="periodes" t-as="p">
+                                    <t t-if="souscription.type_tarif == 'base'">
+                                        <t t-set="total_kwh" t-value="total_kwh + (p.energie_base_kwh or 0)"/>
+                                    </t>
+                                    <t t-else="">
+                                        <t t-set="total_kwh" t-value="total_kwh + (p.energie_hp_kwh or 0) + (p.energie_hc_kwh or 0)"/>
+                                    </t>
+                                    <t t-set="total_turpe" t-value="total_turpe + (p.turpe_fixe or 0) + (p.turpe_variable or 0)"/>
+                                    <t t-set="total_facture" t-value="total_facture + (p.facture_id.amount_total or 0)"/>
+                                </t>
+                                <div class="row mt-3">
+                                    <div class="col-md-6 mb-3">
+                                        <div class="card h-100">
+                                            <div class="card-header py-2"><h6 class="mb-0"><i class="fa fa-info-circle"/> Informations</h6></div>
+                                            <div class="card-body py-2">
+                                                <p class="mb-1"><strong>TURPE</strong> : Tarif d'Utilisation des Réseaux Publics d'Électricité</p>
+                                                <p class="mb-1"><strong>HP/HC</strong> : Heures Pleines / Heures Creuses</p>
+                                                <t t-if="souscription.lisse">
+                                                    <p class="mb-0"><strong>Facturation lissée</strong> : les écarts entre provision et consommation réelle sont régularisés périodiquement.</p>
+                                                </t>
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <div class="col-md-6 mb-3">
+                                        <div class="card h-100">
+                                            <div class="card-header py-2"><h6 class="mb-0"><i class="fa fa-calculator"/> Totaux</h6></div>
+                                            <div class="card-body py-2">
+                                                <p class="mb-1"><strong>Consommation totale :</strong> <t t-esc="'%.0f' % total_kwh"/> kWh</p>
+                                                <p class="mb-1"><strong>TURPE total :</strong> <t t-esc="'%.2f' % total_turpe"/> €</p>
+                                                <p class="mb-1"><strong>Total facturé :</strong> <t t-esc="'%.2f' % total_facture"/> €</p>
+                                                <p class="mb-0"><strong>Nombre de périodes :</strong> <t t-esc="len(periodes)"/></p>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
                             </t>
 
                             <!-- Informations de contact -->
@@ -291,217 +361,4 @@
         </t>
     </template>
 
-    <!-- Vue des périodes d'une souscription -->
-    <template id="portal_souscription_periodes" name="Périodes de facturation">
-        <t t-call="portal.portal_layout">
-            <t t-set="breadcrumbs_searchbar" t-value="True"/>
-            
-            <nav aria-label="breadcrumb" class="mb-4">
-                <ol class="breadcrumb">
-                    <li class="breadcrumb-item">
-                        <a href="/my/souscriptions">Mes Souscriptions</a>
-                    </li>
-                    <li class="breadcrumb-item">
-                        <a t-attf-href="/my/souscription/#{souscription.id}">
-                            <t t-esc="souscription.name"/>
-                        </a>
-                    </li>
-                    <li class="breadcrumb-item active" aria-current="page">
-                        Périodes de facturation
-                    </li>
-                </ol>
-            </nav>
-            
-            <div class="row">
-                <div class="col-12">
-                    <div class="d-flex justify-content-between align-items-center mb-4">
-                        <h1>Historique des consommations</h1>
-                        <div class="text-muted">
-                            <small>Souscription : <strong><t t-esc="souscription.name"/></strong></small>
-                        </div>
-                    </div>
-                    
-                    <!-- Informations du contrat en résumé -->
-                    <div class="card mb-4">
-                        <div class="card-body">
-                            <div class="row">
-                                <div class="col-md-3">
-                                    <small class="text-muted">PDL</small><br/>
-                                    <strong><t t-esc="souscription.pdl"/></strong>
-                                </div>
-                                <div class="col-md-3">
-                                    <small class="text-muted">Puissance</small><br/>
-                                    <strong><t t-esc="souscription.puissance_souscrite"/> kVA</strong>
-                                </div>
-                                <div class="col-md-3">
-                                    <small class="text-muted">Type de tarif</small><br/>
-                                    <strong>
-                                        <t t-if="souscription.type_tarif == 'base'">Base</t>
-                                        <t t-else="">HP/HC</t>
-                                    </strong>
-                                </div>
-                                <div class="col-md-3">
-                                    <small class="text-muted">Facturation</small><br/>
-                                    <strong>
-                                        <t t-if="souscription.lisse">Lissée</t>
-                                        <t t-else="">Au réel</t>
-                                    </strong>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                    
-                    <!-- Liste des périodes -->
-                    <t t-if="not periodes">
-                        <div class="alert alert-info" role="alert">
-                            <p class="mb-0">Aucune période de facturation trouvée pour cette souscription.</p>
-                        </div>
-                    </t>
-                    
-                    <t t-else="">
-                        <div class="table-responsive">
-                            <table class="table table-striped">
-                                <thead>
-                                    <tr>
-                                        <th>Période</th>
-                                        <th>Type</th>
-                                        <t t-if="souscription.type_tarif == 'base'">
-                                            <th class="text-end">Énergie Base (kWh)</th>
-                                        </t>
-                                        <t t-else="">
-                                            <th class="text-end">Énergie HP (kWh)</th>
-                                            <th class="text-end">Énergie HC (kWh)</th>
-                                        </t>
-                                        <th class="text-end">TURPE Fixe (€)</th>
-                                        <th class="text-end">TURPE Variable (€)</th>
-                                        <th class="text-center">Actions</th>
-                                    </tr>
-                                </thead>
-                                <tbody>
-                                    <t t-foreach="periodes" t-as="periode">
-                                        <tr>
-                                            <td>
-                                                <strong>
-                                                    <t t-esc="periode.date_debut.strftime('%m/%Y') if periode.date_debut else '-'"/>
-                                                </strong>
-                                                <br/>
-                                                <small class="text-muted">
-                                                    <t t-esc="periode.date_debut.strftime('%d/%m/%Y') if periode.date_debut else ''"/> - 
-                                                    <t t-esc="periode.date_fin.strftime('%d/%m/%Y') if periode.date_fin else ''"/>
-                                                </small>
-                                            </td>
-                                            <td>
-                                                <span class="badge rounded-pill text-bg-secondary">
-                                                    <t t-esc="dict(periode._fields['type_periode'].selection).get(periode.type_periode, periode.type_periode)"/>
-                                                </span>
-                                            </td>
-                                            <t t-if="souscription.type_tarif == 'base'">
-                                                <td class="text-end">
-                                                    <strong><t t-esc="periode.energie_base_kwh or 0"/></strong>
-                                                    <t t-if="periode.provision_base_kwh">
-                                                        <br/><small class="text-muted">Prov: <t t-esc="periode.provision_base_kwh"/></small>
-                                                    </t>
-                                                </td>
-                                            </t>
-                                            <t t-else="">
-                                                <td class="text-end">
-                                                    <strong><t t-esc="periode.energie_hp_kwh or 0"/></strong>
-                                                    <t t-if="periode.provision_hp_kwh">
-                                                        <br/><small class="text-muted">Prov: <t t-esc="periode.provision_hp_kwh"/></small>
-                                                    </t>
-                                                </td>
-                                                <td class="text-end">
-                                                    <strong><t t-esc="periode.energie_hc_kwh or 0"/></strong>
-                                                    <t t-if="periode.provision_hc_kwh">
-                                                        <br/><small class="text-muted">Prov: <t t-esc="periode.provision_hc_kwh"/></small>
-                                                    </t>
-                                                </td>
-                                            </t>
-                                            <td class="text-end">
-                                                <t t-esc="'%.2f' % (periode.turpe_fixe or 0)"/>
-                                            </td>
-                                            <td class="text-end">
-                                                <t t-esc="'%.2f' % (periode.turpe_variable or 0)"/>
-                                            </td>
-                                            <td class="text-center">
-                                                <t t-if="periode.facture_id">
-                                                    <a t-attf-href="/my/invoices/#{periode.facture_id.id}" 
-                                                       class="btn btn-sm btn-outline-primary"
-                                                       title="Voir la facture" target="_blank">
-                                                        <i class="fa fa-file-text"/> Facture
-                                                    </a>
-                                                </t>
-                                                <t t-else="">
-                                                    <span class="text-muted">-</span>
-                                                </t>
-                                            </td>
-                                        </tr>
-                                    </t>
-                                </tbody>
-                            </table>
-                        </div>
-                        
-                        <!-- Informations complémentaires -->
-                        <div class="row mt-4">
-                            <div class="col-md-6">
-                                <div class="card">
-                                    <div class="card-header">
-                                        <h6 class="mb-0">
-                                            <i class="fa fa-info-circle"/> Informations
-                                        </h6>
-                                    </div>
-                                    <div class="card-body">
-                                        <p class="mb-2">
-                                            <strong>TURPE</strong> : Tarif d'Utilisation des Réseaux Publics d'Électricité
-                                        </p>
-                                        <p class="mb-2">
-                                            <strong>HP/HC</strong> : Heures Pleines / Heures Creuses
-                                        </p>
-                                        <t t-if="souscription.lisse">
-                                            <p class="mb-0">
-                                                <strong>Facturation lissée</strong> : Les écarts entre provision et consommation réelle sont régularisés périodiquement.
-                                            </p>
-                                        </t>
-                                    </div>
-                                </div>
-                            </div>
-                            
-                            <div class="col-md-6">
-                                <div class="card">
-                                    <div class="card-header">
-                                        <h6 class="mb-0">
-                                            <i class="fa fa-chart-line"/> Totaux
-                                        </h6>
-                                    </div>
-                                    <div class="card-body">
-                                        <t t-set="total_kwh" t-value="0"/>
-                                        <t t-set="total_turpe" t-value="0"/>
-                                        <t t-foreach="periodes" t-as="p">
-                                            <t t-if="souscription.type_tarif == 'base'">
-                                                <t t-set="total_kwh" t-value="total_kwh + (p.energie_base_kwh or 0)"/>
-                                            </t>
-                                            <t t-else="">
-                                                <t t-set="total_kwh" t-value="total_kwh + (p.energie_hp_kwh or 0) + (p.energie_hc_kwh or 0)"/>
-                                            </t>
-                                            <t t-set="total_turpe" t-value="total_turpe + (p.turpe_fixe or 0) + (p.turpe_variable or 0)"/>
-                                        </t>
-                                        
-                                        <p class="mb-2">
-                                            <strong>Consommation totale :</strong> <t t-esc="'%.0f' % total_kwh"/> kWh
-                                        </p>
-                                        <p class="mb-2">
-                                            <strong>TURPE total :</strong> <t t-esc="'%.2f' % total_turpe"/> €
-                                        </p>
-                                        <p class="mb-0">
-                                            <strong>Nombre de périodes :</strong> <t t-esc="len(periodes)"/>
-                                        </p>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                    </t>
-                </div>
-            </div>
-        </t>
-    </template>
 </odoo>


### PR DESCRIPTION
Intègre l'historique des consommations **directement** dans la page de détail d'une souscription au portail, en remplacement du bouton + page séparée `/periodes`. Deux slices verticales (ADR 0004).

## Slice 1 — Lien Période↔Facture, source unique (#23)
- `account.move.periode_id` devient l'unique source ; `souscription.periode.facture_id` passe en **calculé/stocké** (via un O2m `move_ids`), plus d'écriture manuelle dans le workflow.
- Relance `souscription.facture_ids` (et donc l'affichage des factures côté portail).
- Démo : les 3 factures admin (S0005) sont **postées** (`<function action_post>`).
- Migration `19.0.1.1.0` : recalcul de `facture_id` sur les bases existantes.

## Slice 2 — Historique intégré dans la page (#24)
- Tableau unique : `Période | Type | Énergie (Base/HP-HC) | TURPE fixe | TURPE variable | Montant TTC | Paiement | Facture (PDF)`.
- **Visibilité** : seules les périodes dont la facture est **postée** (un brouillon ne fuit pas côté usager).
- 12 lignes par défaut (récent en haut) + « Voir plus » ; carte **Totaux** (conso, TURPE, total facturé, nb) sur toutes les périodes facturées + glossaire compact.
- Suppression : bouton, section « Factures récentes », template/route/page `/periodes`.

## Tooling
- `fix: persist the filestore in run-app.sh` — la base était persistée mais pas le filestore, d'où des 404 d'assets/avatars et un 500 sur le websocket bundle. Volume `souscriptions-app-data` monté sur `/var/lib/odoo`. **Bases existantes : `./scripts/run-app.sh --reset` une fois.**

## Validation
- Suite complète **verte (93 tests)** — rendu QWeb réel via HttpCase.
- Démo : S0005 expose 3 factures postées ; chemin d'upgrade : post-migrate recalcule 3/8 périodes.

## Hors périmètre (suivi : #20)
Relation régul-couvre-périodes, avoirs, visuel croisé.

Closes #23
Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)