### PR TITLE
refactor: deepen the Facture composition seam onto the Période (ADR 0006)

### DIFF
--- a/docs/adr/0006-snapshot-periode-fait-autorite-facturation.md
+++ b/docs/adr/0006-snapshot-periode-fait-autorite-facturation.md
@@ -1,0 +1,55 @@
+# Le snapshot figé de la Période fait autorité à la facturation ; pas de repli sur la Souscription live
+
+La composition de la facture d'énergie (quelles lignes, quelles quantités, quelles
+notes TURPE) vit désormais sur la *Période* — `souscription.periode._composer_lignes(grille)`
+renvoie les lignes, `_creer_facture()` les emballe dans l'`account.move`, et
+`souscription.creer_factures()` ne reste qu'orchestrateur (boucle + garde anti-doublon).
+Ce déplacement colle le code à `CONTEXT.md` (« la *Période* porte ce qui est **facturé** »)
+et à [ADR-0004](0004-lien-periode-facture-source-unique.md) (« une facture facture une
+période »).
+
+**Décision.** À la facturation, **toutes** les valeurs contractuelles (type de tarif,
+puissance, coeff PRO, tarif solidaire, provisions) proviennent **exclusivement du snapshot
+figé** sur la Période à sa création. La composition **ne lit jamais** l'état *live* de la
+*Souscription*. On **supprime** les trois replis qui existaient
+(`periode.puissance_souscrite_periode or self.puissance_souscrite`,
+`periode.type_tarif_periode or <live>`, `coeff_pro_periode` derrière un `hasattr` toujours
+vrai) : le snapshot est l'unique source.
+
+Les prix restent l'affaire de la *Grille de prix* passée en paramètre — la Période compose
+les quantités et la structure, la Grille fournit les prix
+([ADR-0002](0002-deux-sources-de-verite-marge-en-analytique.md), « référencer, pas recopier »).
+
+## Conséquences
+
+- **Comportement constant pour les données réelles.** Le snapshot est peuplé
+  inconditionnellement dans `souscription.periode.create()` (et `puissance`/`type_tarif`
+  sont requis sur la Souscription) : pour toute Période créée normalement, lire le snapshot
+  donne le même résultat que l'ancien `snapshot or live`. La suppression du repli retire du
+  **code mort**, pas un cas d'usage.
+- **Reproductibilité.** Modifier la Souscription après création d'une Période (changement de
+  puissance, de tarif…) ne change plus la facture de cette Période — ce qui est précisément
+  l'intention de l'historisation ([ADR-0002](0002-deux-sources-de-verite-marge-en-analytique.md)).
+- **Surface de test déplacée à l'interface.** `_composer_lignes(grille)` se teste sur la liste
+  de lignes renvoyée — sans créer ni comptabiliser de move. Les ~24 sites de test passent de
+  `souscription._creer_facture_periode(periode)` à `periode._creer_facture()`, sans coquille
+  de compatibilité.
+- **N'efface pas les bricoles de typage.** Le snapshot reste partiellement stringly-typed
+  (`"6 kVA"`, libellé `"Base"`), donc `_composer_lignes` hérite encore du parsing
+  (`float("6 kVA"…)`, `'Base' in str(...)`). Leur nettoyage est le **snapshot typé** de
+  [ADR-0005](0005-granularite-energie-calendrier-comptage.md) / issue #14, hors de ce périmètre.
+
+## Options écartées
+
+- **Garder le repli sur l'état live** (robustesse si un champ historisé manque) : rend la
+  facture dépendante de modifications postérieures de la Souscription, ce qui casse la
+  reproductibilité ; et le repli était de toute façon inatteignable en pratique.
+- **Coquille de compatibilité `souscription._creer_facture_periode`** : maintient une
+  interface superficielle (pass-through) — exactement ce que ce refactor supprime.
+
+## Raison
+
+Une facture émise doit être **rejouable à l'identique** depuis ce que la Période a gelé, pas
+depuis un état contractuel qui a pu dériver. Faire de la Période l'unique source à la
+facturation concentre la logique (locality) et ramène la surface de test à une seule
+interface (`_composer_lignes`), au lieu d'un graphe de records + un move comptabilisé.

--- a/models/core/souscription.py
+++ b/models/core/souscription.py
@@ -137,9 +137,12 @@ class Souscription(models.Model):
             sous.facture_ids = sous.periode_ids.mapped('facture_id')
 
     def creer_factures(self):
-        """
-        Crée les factures à partir des périodes de facturation.
-        Utilise les données historisées de chaque période pour générer les bonnes lignes.
+        """Émet les factures des périodes non encore facturées.
+
+        Orchestrateur : pour chaque souscription, boucle sur ses périodes sans
+        facture (garde anti-doublon) et délègue l'émission à la période
+        (``periode._creer_facture``). La composition des lignes et la création du
+        ``account.move`` vivent désormais sur la Période (ADR 0006).
         """
         _logger.info(f'Créer factures appelé pour {len(self)} souscriptions')
 
@@ -148,224 +151,13 @@ class Souscription(models.Model):
                 _logger.warning(f'Souscription {souscription.name} sans partenaire, ignorée')
                 continue
 
-            # Pour chaque période sans facture
             for periode in souscription.periode_ids.filtered(lambda p: not p.facture_id):
                 try:
-                    facture = souscription._creer_facture_periode(periode)  # Utiliser la souscription spécifique
-                    # facture_id est calculé depuis account.move.periode_id (ADR 0004) :
-                    # _creer_facture_periode a déjà posé periode_id sur la facture.
+                    facture = periode._creer_facture()
                     _logger.info(f'Facture {facture.name} créée pour période {periode.mois_annee}')
                 except Exception as e:
                     _logger.error(f'Erreur création facture pour période {periode.mois_annee}: {e}')
                     raise UserError(f'Erreur création facture pour {periode.mois_annee}: {e}')
-
-    def _get_produit_abonnement(self, tarif_solidaire):
-        """Trouve le produit d'abonnement selon le type"""
-        product_ref = (
-            'souscriptions_product_abonnement_solidaire'
-            if tarif_solidaire
-            else 'souscriptions_product_abonnement_standard'
-        )
-
-        try:
-            return self.env.ref(f'souscriptions_odoo.{product_ref}')
-        except Exception:
-            type_abo = 'solidaire' if tarif_solidaire else 'standard'
-            raise UserError(f"Produit d'abonnement {type_abo} non trouvé")
-
-    def _get_produit_energie(self, type_energie):
-        """Trouve le produit d'énergie correspondant au type (base, hp, hc)"""
-        xmlid_map = {
-            'base': 'souscriptions_odoo.souscriptions_product_energie_base',
-            'hp': 'souscriptions_odoo.souscriptions_product_energie_hp',
-            'hc': 'souscriptions_odoo.souscriptions_product_energie_hc',
-        }
-
-        xmlid = xmlid_map.get(type_energie.lower())
-        if not xmlid:
-            raise UserError(f"Type d'énergie non reconnu : {type_energie}")
-
-        produit = self.env.ref(xmlid, raise_if_not_found=False)
-        if not produit:
-            raise UserError(f"Produit d'énergie {type_energie} non trouvé")
-
-        return produit
-
-    def _creer_facture_periode(self, periode):
-        """
-        Crée une facture pour une période donnée en utilisant les données historisées
-        et la grille de prix active avec calcul dynamique.
-        """
-        # 1. Récupération de la grille active
-        grille_active = self.env['grille.prix'].get_grille_active(periode.date_fin)
-        prix_dict = grille_active.get_prix_dict()  # {product_id: prix_interne} pour les énergies
-
-        # 2. Utilisation des données historisées de la période
-        puissance_str = periode.puissance_souscrite_periode or self.puissance_souscrite
-        tarif_solidaire = periode.tarif_solidaire_periode
-        type_tarif = periode.type_tarif_periode or dict(self._fields['type_tarif'].selection).get(
-            self.type_tarif, self.type_tarif
-        )
-
-        if not puissance_str:
-            raise UserError(f'Aucune puissance définie pour la période {periode.mois_annee}')
-
-        # Extraction de la puissance numérique (ex: "6 kVA" -> 6.0)
-        try:
-            puissance_kva = float(puissance_str.replace(' kVA', '').replace(',', '.'))
-        except Exception:
-            raise UserError(f'Format de puissance invalide : {puissance_str}')
-
-        # 3. Création des lignes de facture
-        lines_vals = []
-
-        # Section Abonnement
-        lines_vals.append(
-            (
-                0,
-                0,
-                {
-                    'display_type': 'line_section',
-                    'name': 'Abonnement',
-                },
-            )
-        )
-
-        # Ligne abonnement avec calcul dynamique (utilise le coefficient historisé)
-        coeff_pro_historise = periode.coeff_pro_periode if hasattr(periode, 'coeff_pro_periode') else self.coeff_pro
-        produit_abo = self._get_produit_abonnement(tarif_solidaire)
-        prix_abo_journalier = grille_active.get_prix_abonnement(
-            puissance_kva, coeff_pro=coeff_pro_historise, is_solidaire=tarif_solidaire
-        )
-
-        # Nom descriptif de la ligne
-        type_client = 'PRO' if coeff_pro_historise > 0 else 'PART'
-        puissance_desc = f'{puissance_kva:g} kVA'  # :g supprime les .0 inutiles
-
-        lines_vals.append(
-            (
-                0,
-                0,
-                {
-                    'product_id': produit_abo.id,
-                    'name': f'{produit_abo.name} {puissance_desc} {type_client}',
-                    'quantity': periode.jours,
-                    'price_unit': prix_abo_journalier,
-                },
-            )
-        )
-
-        # Note TURPE fixe sous l'abonnement
-        if periode.turpe_fixe > 0:
-            lines_vals.append(
-                (
-                    0,
-                    0,
-                    {
-                        'display_type': 'line_note',
-                        'name': f'Dont turpe fixe: {periode.turpe_fixe:.2f}€',
-                    },
-                )
-            )
-
-        # Section Énergie
-        lines_vals.append(
-            (
-                0,
-                0,
-                {
-                    'display_type': 'line_section',
-                    'name': 'Énergie',
-                },
-            )
-        )
-
-        # Lignes énergie selon type de tarif historisé
-        # Le type_tarif peut être la clé ('base', 'hphc') ou le libellé complet
-        is_base_tarif = type_tarif == 'base' or type_tarif == 'Base' or 'Base' in str(type_tarif)
-
-        if is_base_tarif:
-            # Tarif BASE : toujours afficher la ligne énergie base (même si 0)
-            produit_base = self._get_produit_energie('base')
-            prix_base = prix_dict.get(produit_base.id)
-            if prix_base is None:
-                raise UserError(f'Prix non trouvé dans la grille pour le produit : {produit_base.name}')
-
-            lines_vals.append(
-                (
-                    0,
-                    0,
-                    {
-                        'product_id': produit_base.id,
-                        'name': produit_base.name,
-                        'quantity': periode.provision_base_kwh,
-                        'price_unit': prix_base,
-                    },
-                )
-            )
-        else:  # HP/HC
-            # Tarif HP/HC : toujours afficher les deux lignes HP et HC (même si 0)
-            # Ligne HP
-            produit_hp = self._get_produit_energie('hp')
-            prix_hp = prix_dict.get(produit_hp.id)
-            if prix_hp is None:
-                raise UserError(f'Prix non trouvé dans la grille pour le produit : {produit_hp.name}')
-
-            lines_vals.append(
-                (
-                    0,
-                    0,
-                    {
-                        'product_id': produit_hp.id,
-                        'name': produit_hp.name,
-                        'quantity': periode.provision_hp_kwh,
-                        'price_unit': prix_hp,
-                    },
-                )
-            )
-
-            # Ligne HC
-            produit_hc = self._get_produit_energie('hc')
-            prix_hc = prix_dict.get(produit_hc.id)
-            if prix_hc is None:
-                raise UserError(f'Prix non trouvé dans la grille pour le produit : {produit_hc.name}')
-
-            lines_vals.append(
-                (
-                    0,
-                    0,
-                    {
-                        'product_id': produit_hc.id,
-                        'name': produit_hc.name,
-                        'quantity': periode.provision_hc_kwh,
-                        'price_unit': prix_hc,
-                    },
-                )
-            )
-
-        # Note TURPE variable sous l'énergie
-        if periode.turpe_variable > 0:
-            lines_vals.append(
-                (
-                    0,
-                    0,
-                    {
-                        'display_type': 'line_note',
-                        'name': f'Dont turpe variable: {periode.turpe_variable:.2f}€',
-                    },
-                )
-            )
-
-        # 4. Création de la facture
-        facture_vals = {
-            'move_type': 'out_invoice',
-            'partner_id': self.partner_id.id,
-            'invoice_date': periode.date_fin,
-            'periode_id': periode.id,
-            'invoice_line_ids': lines_vals,
-        }
-
-        return self.env['account.move'].create(facture_vals)
 
     @api.model
     def ajouter_periodes_mensuelles(self):

--- a/models/core/souscription_periode.py
+++ b/models/core/souscription_periode.py
@@ -1,5 +1,6 @@
 from babel.dates import format_date
 from odoo import api, fields, models
+from odoo.exceptions import UserError
 
 
 class SouscriptionPeriode(models.Model):
@@ -254,3 +255,179 @@ class SouscriptionPeriode(models.Model):
                 rec.mois_annee = format_date(rec.date_debut, format='MMMM yyyy', locale='fr_FR').capitalize()
             else:
                 rec.mois_annee = ''
+
+    # === Composition de la facture (candidate A / ADR 0006) ===
+    # La Période compose ses lignes de facture à partir de son snapshot figé
+    # (puissance, tarif, coeff PRO, solidaire, quantités) et de la grille passée
+    # en paramètre. Aucun repli sur l'état live de la souscription : le snapshot
+    # fait autorité (ADR 0006). Les prix restent l'affaire de la grille (ADR 0002,
+    # « référencer, pas recopier »).
+
+    def _get_produit_abonnement(self, tarif_solidaire):
+        """Produit d'abonnement (standard ou solidaire)."""
+        product_ref = (
+            'souscriptions_product_abonnement_solidaire'
+            if tarif_solidaire
+            else 'souscriptions_product_abonnement_standard'
+        )
+        try:
+            return self.env.ref(f'souscriptions_odoo.{product_ref}')
+        except Exception:
+            type_abo = 'solidaire' if tarif_solidaire else 'standard'
+            raise UserError(f"Produit d'abonnement {type_abo} non trouvé")
+
+    def _get_produit_energie(self, type_energie):
+        """Produit d'énergie correspondant au cadran facturé (base, hp, hc)."""
+        xmlid_map = {
+            'base': 'souscriptions_odoo.souscriptions_product_energie_base',
+            'hp': 'souscriptions_odoo.souscriptions_product_energie_hp',
+            'hc': 'souscriptions_odoo.souscriptions_product_energie_hc',
+        }
+        xmlid = xmlid_map.get(type_energie.lower())
+        if not xmlid:
+            raise UserError(f"Type d'énergie non reconnu : {type_energie}")
+        produit = self.env.ref(xmlid, raise_if_not_found=False)
+        if not produit:
+            raise UserError(f"Produit d'énergie {type_energie} non trouvé")
+        return produit
+
+    def _composer_lignes(self, grille):
+        """Compose les lignes de facture (``[(0, 0, vals)]``) de cette période.
+
+        Lit le snapshot figé de la période et la ``grille`` passée pour les prix.
+        Ne crée aucun ``account.move`` : la liste renvoyée est la surface de test
+        des règles de facturation.
+        """
+        self.ensure_one()
+        prix_dict = grille.get_prix_dict()
+
+        # Snapshot figé — ADR 0006 (pas de repli sur la souscription live)
+        puissance_str = self.puissance_souscrite_periode
+        tarif_solidaire = self.tarif_solidaire_periode
+        type_tarif = self.type_tarif_periode
+
+        if not puissance_str:
+            raise UserError(f'Aucune puissance définie pour la période {self.mois_annee}')
+
+        # Extraction de la puissance numérique (ex: "6 kVA" -> 6.0)
+        try:
+            puissance_kva = float(puissance_str.replace(' kVA', '').replace(',', '.'))
+        except Exception:
+            raise UserError(f'Format de puissance invalide : {puissance_str}')
+
+        lines_vals = []
+
+        # Section Abonnement
+        lines_vals.append((0, 0, {'display_type': 'line_section', 'name': 'Abonnement'}))
+
+        coeff_pro_historise = self.coeff_pro_periode
+        produit_abo = self._get_produit_abonnement(tarif_solidaire)
+        prix_abo_journalier = grille.get_prix_abonnement(
+            puissance_kva, coeff_pro=coeff_pro_historise, is_solidaire=tarif_solidaire
+        )
+
+        type_client = 'PRO' if coeff_pro_historise > 0 else 'PART'
+        puissance_desc = f'{puissance_kva:g} kVA'  # :g supprime les .0 inutiles
+
+        lines_vals.append(
+            (
+                0,
+                0,
+                {
+                    'product_id': produit_abo.id,
+                    'name': f'{produit_abo.name} {puissance_desc} {type_client}',
+                    'quantity': self.jours,
+                    'price_unit': prix_abo_journalier,
+                },
+            )
+        )
+
+        # Note TURPE fixe sous l'abonnement
+        if self.turpe_fixe > 0:
+            lines_vals.append((0, 0, {'display_type': 'line_note', 'name': f'Dont turpe fixe: {self.turpe_fixe:.2f}€'}))
+
+        # Section Énergie
+        lines_vals.append((0, 0, {'display_type': 'line_section', 'name': 'Énergie'}))
+
+        # Le type_tarif historisé peut être la clé ('base') ou le libellé ('Base').
+        # Sniffing conservé tel quel ; son nettoyage relève du snapshot typé (#14).
+        is_base_tarif = type_tarif == 'base' or type_tarif == 'Base' or 'Base' in str(type_tarif)
+
+        if is_base_tarif:
+            produit_base = self._get_produit_energie('base')
+            prix_base = prix_dict.get(produit_base.id)
+            if prix_base is None:
+                raise UserError(f'Prix non trouvé dans la grille pour le produit : {produit_base.name}')
+            lines_vals.append(
+                (
+                    0,
+                    0,
+                    {
+                        'product_id': produit_base.id,
+                        'name': produit_base.name,
+                        'quantity': self.provision_base_kwh,
+                        'price_unit': prix_base,
+                    },
+                )
+            )
+        else:  # HP/HC : toujours les deux lignes (même à 0)
+            produit_hp = self._get_produit_energie('hp')
+            prix_hp = prix_dict.get(produit_hp.id)
+            if prix_hp is None:
+                raise UserError(f'Prix non trouvé dans la grille pour le produit : {produit_hp.name}')
+            lines_vals.append(
+                (
+                    0,
+                    0,
+                    {
+                        'product_id': produit_hp.id,
+                        'name': produit_hp.name,
+                        'quantity': self.provision_hp_kwh,
+                        'price_unit': prix_hp,
+                    },
+                )
+            )
+
+            produit_hc = self._get_produit_energie('hc')
+            prix_hc = prix_dict.get(produit_hc.id)
+            if prix_hc is None:
+                raise UserError(f'Prix non trouvé dans la grille pour le produit : {produit_hc.name}')
+            lines_vals.append(
+                (
+                    0,
+                    0,
+                    {
+                        'product_id': produit_hc.id,
+                        'name': produit_hc.name,
+                        'quantity': self.provision_hc_kwh,
+                        'price_unit': prix_hc,
+                    },
+                )
+            )
+
+        # Note TURPE variable sous l'énergie
+        if self.turpe_variable > 0:
+            lines_vals.append(
+                (0, 0, {'display_type': 'line_note', 'name': f'Dont turpe variable: {self.turpe_variable:.2f}€'})
+            )
+
+        return lines_vals
+
+    def _creer_facture(self):
+        """Émet la facture (``account.move``) de cette période.
+
+        Coquille fine : sélectionne la grille active à la date de fin, compose les
+        lignes (``_composer_lignes``) et crée le move en posant ``periode_id``
+        (source unique du lien Période ↔ Facture, ADR 0004).
+        """
+        self.ensure_one()
+        grille = self.env['grille.prix'].get_grille_active(self.date_fin)
+        return self.env['account.move'].create(
+            {
+                'move_type': 'out_invoice',
+                'partner_id': self.souscription_id.partner_id.id,
+                'invoice_date': self.date_fin,
+                'periode_id': self.id,
+                'invoice_line_ids': self._composer_lignes(grille),
+            }
+        )

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -3,6 +3,7 @@ from . import (
     test_facturation,
     test_grille_prix,
     test_integration,
+    test_periode_composition,
     test_periode_energie,
     test_periode_facture,
     test_periode_form,

--- a/tests/common.py
+++ b/tests/common.py
@@ -240,7 +240,7 @@ class SouscriptionsTestMixin:
         if periode is None:
             periode = self.create_test_periode(souscription, **periode_kwargs)
 
-        facture = souscription._creer_facture_periode(periode)
+        facture = periode._creer_facture()
         return periode, facture
 
     def assert_invoice_structure(self, facture, expected_sections=None, expected_notes=None):

--- a/tests/test_facturation.py
+++ b/tests/test_facturation.py
@@ -86,8 +86,8 @@ class TestFacturation(TransactionCase):
         self.assertEqual(periode_31.jours, 31)
         self.assertEqual(periode_28.jours, 28)
 
-        facture_31 = self.souscription._creer_facture_periode(periode_31)
-        facture_28 = self.souscription._creer_facture_periode(periode_28)
+        facture_31 = periode_31._creer_facture()
+        facture_28 = periode_28._creer_facture()
 
         abo_31 = facture_31.invoice_line_ids.filtered(lambda l: l.product_id and 'Abonnement' in l.product_id.name)
         abo_28 = facture_28.invoice_line_ids.filtered(lambda l: l.product_id and 'Abonnement' in l.product_id.name)
@@ -143,25 +143,25 @@ class TestFacturation(TransactionCase):
 
     def test_get_produit_abonnement(self):
         """Test récupération produits abonnement"""
-        produit_standard = self.souscription._get_produit_abonnement(False)
+        produit_standard = self.env['souscription.periode']._get_produit_abonnement(False)
         self.assertEqual(produit_standard.name, 'Abonnement')
 
-        produit_solidaire = self.souscription._get_produit_abonnement(True)
+        produit_solidaire = self.env['souscription.periode']._get_produit_abonnement(True)
         self.assertEqual(produit_solidaire.name, 'Abonnement solidaire')
 
     def test_get_produit_energie(self):
         """Test récupération produits énergie"""
-        produit_base = self.souscription._get_produit_energie('base')
+        produit_base = self.env['souscription.periode']._get_produit_energie('base')
         self.assertEqual(produit_base.name, 'Énergie Base')
 
-        produit_hp = self.souscription._get_produit_energie('hp')
+        produit_hp = self.env['souscription.periode']._get_produit_energie('hp')
         self.assertEqual(produit_hp.name, 'Énergie HP')
 
-        produit_hc = self.souscription._get_produit_energie('hc')
+        produit_hc = self.env['souscription.periode']._get_produit_energie('hc')
         self.assertEqual(produit_hc.name, 'Énergie HC')
 
         with self.assertRaises(UserError):
-            self.souscription._get_produit_energie('inexistant')
+            self.env['souscription.periode']._get_produit_energie('inexistant')
 
     def test_ajouter_periodes_mensuelles(self):
         """Test création automatique des périodes mensuelles"""
@@ -223,7 +223,7 @@ class TestFacturation(TransactionCase):
         )
 
         # Générer la facture
-        facture = self.souscription._creer_facture_periode(periode)
+        facture = periode._creer_facture()
 
         # Vérifications
         self.assertTrue(facture.is_facture_energie)
@@ -284,7 +284,7 @@ class TestFacturation(TransactionCase):
 
         # Générer facture
         try:
-            facture_hphc = souscription_hphc._creer_facture_periode(periode_hphc)
+            facture_hphc = periode_hphc._creer_facture()
         except Exception as e:
             print(f'DEBUG: Exception during HP/HC invoicing: {e}')
             raise
@@ -324,7 +324,7 @@ class TestFacturation(TransactionCase):
             }
         )
 
-        facture = self.souscription._creer_facture_periode(periode)
+        facture = periode._creer_facture()
 
         # Vérifier que les montants TURPE apparaissent dans les notes
         notes = facture.invoice_line_ids.filtered(lambda l: l.display_type == 'line_note')
@@ -356,13 +356,13 @@ class TestFacturation(TransactionCase):
         )
 
         # Première facturation
-        facture1 = self.souscription._creer_facture_periode(periode)
+        facture1 = periode._creer_facture()
         self.assertTrue(facture1)
 
         # Pour l'instant, pas de contrôle d'anti-doublonnage implémenté
         # On supprime ce test ou on l'adapte selon l'implémentation réelle
         # Tentative de refacturation (devrait passer pour l'instant)
-        facture2 = self.souscription._creer_facture_periode(periode)
+        facture2 = periode._creer_facture()
         self.assertTrue(facture2)  # Test que ça ne plante pas
 
     def test_filename_facture_energie(self):
@@ -377,7 +377,7 @@ class TestFacturation(TransactionCase):
             }
         )
 
-        facture = self.souscription._creer_facture_periode(periode)
+        facture = periode._creer_facture()
         filename = facture._get_report_base_filename()
 
         # Vérifier le format du nom de fichier
@@ -406,7 +406,7 @@ class TestFacturation(TransactionCase):
             }
         )
 
-        facture_energie = self.souscription._creer_facture_periode(periode)
+        facture_energie = periode._creer_facture()
 
         # Vérifier les champs computed
         self.assertTrue(facture_energie.is_facture_energie)

--- a/tests/test_invoice_template.py
+++ b/tests/test_invoice_template.py
@@ -128,7 +128,7 @@ class TestInvoiceTemplate(TransactionCase):
             }
 
         periode = self.env['souscription.periode'].create(periode_data)
-        facture = souscription._creer_facture_periode(periode)
+        facture = periode._creer_facture()
 
         return periode, facture
 

--- a/tests/test_periode_composition.py
+++ b/tests/test_periode_composition.py
@@ -1,0 +1,119 @@
+"""
+Tests de la composition de facture portée par la Période (candidate A / ADR 0006).
+
+`souscription.periode._composer_lignes(grille)` renvoie les lignes de facture
+(`[(0, 0, {...})]`) à partir du snapshot figé de la période et de la grille
+passée en paramètre — sans créer de `account.move`. C'est la surface de test
+des règles de facturation (sections, abonnement proratisé, énergie par tarif,
+notes TURPE, majoration PRO).
+"""
+
+from datetime import date
+
+from odoo.tests.common import tagged
+
+from .common import ABO_ANNUEL_STD, SouscriptionsTestCase
+
+
+@tagged('souscriptions', 'souscriptions_composition', 'post_install', '-at_install')
+class TestPeriodeComposition(SouscriptionsTestCase):
+    def _periode(self, souscription, **vals):
+        base = {
+            'souscription_id': souscription.id,
+            'date_debut': date(2024, 1, 1),
+            'date_fin': date(2024, 2, 1),
+            'type_periode': 'mensuelle',
+        }
+        base.update(vals)
+        return self.env['souscription.periode'].create(base)
+
+    @staticmethod
+    def _dicts(lignes):
+        """Extrait les dicts de valeurs des commandes One2many (0, 0, vals)."""
+        return [vals for (_cmd, _id, vals) in lignes]
+
+    def test_composer_lignes_base_abonnement_prorata(self):
+        """Tarif Base : ligne d'abonnement proratisée au nombre de jours réel."""
+        periode = self._periode(self.souscription_base, provision_base_kwh=100.0)
+        self.assertEqual(periode.jours, 31)
+
+        lignes = periode._composer_lignes(self.grille_prix)
+        dicts = self._dicts(lignes)
+
+        abo = next(d for d in dicts if d.get('product_id') and 'Abonnement' in d.get('name', ''))
+        self.assertEqual(abo['quantity'], 31)
+        self.assertAlmostEqual(abo['price_unit'], ABO_ANNUEL_STD['6'] / 365.0, places=4)
+
+        sections = [d['name'] for d in dicts if d.get('display_type') == 'line_section']
+        self.assertIn('Abonnement', sections)
+
+    def test_composer_lignes_hphc_deux_lignes_energie(self):
+        """Tarif HP/HC : deux lignes énergie (HP, HC), pas de ligne Base."""
+        periode = self._periode(self.souscription_hphc, provision_hp_kwh=150.0, provision_hc_kwh=100.0)
+        produits = [d for d in self._dicts(periode._composer_lignes(self.grille_prix)) if d.get('product_id')]
+        noms = [d['name'] for d in produits]
+
+        self.assertIn('Énergie HP', noms)
+        self.assertIn('Énergie HC', noms)
+        self.assertNotIn('Énergie Base', noms)
+
+        hp = next(d for d in produits if d['name'] == 'Énergie HP')
+        hc = next(d for d in produits if d['name'] == 'Énergie HC')
+        self.assertEqual(hp['quantity'], 150.0)
+        self.assertEqual(hc['quantity'], 100.0)
+
+    def test_composer_lignes_note_turpe_uniquement_si_positif(self):
+        """Les notes TURPE n'apparaissent que si le montant est > 0."""
+        avec = self._periode(
+            self.souscription_base,
+            provision_base_kwh=100.0,
+            turpe_fixe=8.5,
+            turpe_variable=4.5,
+            date_debut=date(2024, 3, 1),
+            date_fin=date(2024, 4, 1),
+        )
+        notes = [
+            d['name']
+            for d in self._dicts(avec._composer_lignes(self.grille_prix))
+            if d.get('display_type') == 'line_note'
+        ]
+        self.assertTrue(any('turpe fixe' in n for n in notes))
+        self.assertTrue(any('turpe variable' in n for n in notes))
+
+        sans = self._periode(
+            self.souscription_base,
+            provision_base_kwh=100.0,
+            turpe_fixe=0.0,
+            turpe_variable=0.0,
+            date_debut=date(2024, 4, 1),
+            date_fin=date(2024, 5, 1),
+        )
+        notes_vides = [
+            d for d in self._dicts(sans._composer_lignes(self.grille_prix)) if d.get('display_type') == 'line_note'
+        ]
+        self.assertEqual(notes_vides, [])
+
+    def test_composer_lignes_coeff_pro_majore_abonnement(self):
+        """Un coeff PRO historisé majore le prix d'abonnement et marque la ligne PRO."""
+        self.souscription_base.coeff_pro = 10.0
+        periode = self._periode(self.souscription_base, provision_base_kwh=100.0)
+
+        abo = next(
+            d
+            for d in self._dicts(periode._composer_lignes(self.grille_prix))
+            if d.get('product_id') and 'Abonnement' in d.get('name', '')
+        )
+        self.assertIn('PRO', abo['name'])
+        self.assertAlmostEqual(abo['price_unit'], (ABO_ANNUEL_STD['6'] / 365.0) * 1.10, places=4)
+
+    def test_creer_facture_pose_periode_id_et_partner(self):
+        """La coquille _creer_facture émet le move avec periode_id et le bon partner."""
+        periode = self._periode(self.souscription_base, provision_base_kwh=100.0)
+        facture = periode._creer_facture()
+
+        self.assertEqual(facture.move_type, 'out_invoice')
+        self.assertEqual(facture.periode_id, periode)
+        self.assertEqual(facture.partner_id, self.souscription_base.partner_id)
+        self.assertEqual(facture.invoice_date, periode.date_fin)
+        # facture_id dérivé de account.move.periode_id (ADR 0004)
+        self.assertEqual(periode.facture_id, facture)

--- a/tests/test_periode_facture.py
+++ b/tests/test_periode_facture.py
@@ -33,7 +33,7 @@ class TestPeriodeFactureLien(SouscriptionsTestCase):
     def test_facture_ids_souscription_agrege_les_periodes(self):
         """souscription.facture_ids agrège automatiquement les factures des périodes."""
         periode = self.create_test_periode(self.souscription_base)
-        facture = self.souscription_base._creer_facture_periode(periode)
+        facture = periode._creer_facture()
         self.assertIn(facture, self.souscription_base.facture_ids)
 
     def test_creer_factures_ne_double_pas(self):

--- a/tests/test_portal.py
+++ b/tests/test_portal.py
@@ -58,8 +58,8 @@ class PortalTestCase(SouscriptionsTestMixin, HttpCase):
                 'turpe_variable': 14.20,
             }
         )
-        cls.facture_jan = cls.souscription_base._creer_facture_periode(cls.periode_jan)
-        cls.facture_feb = cls.souscription_base._creer_facture_periode(cls.periode_feb)
+        cls.facture_jan = cls.periode_jan._creer_facture()
+        cls.facture_feb = cls.periode_feb._creer_facture()
         (cls.facture_jan | cls.facture_feb).action_post()
 
     @classmethod
@@ -138,7 +138,7 @@ class PortalTestCase(SouscriptionsTestMixin, HttpCase):
                 'turpe_variable': 1.0,
             }
         )
-        facture_draft = self.souscription_base._creer_facture_periode(periode_draft)
+        facture_draft = periode_draft._creer_facture()
         self.assertEqual(facture_draft.state, 'draft')
 
         self.authenticate(self.portal_user.login, self.portal_user.login)
@@ -180,7 +180,7 @@ class PortalTestCase(SouscriptionsTestMixin, HttpCase):
                 'turpe_variable': 18.50,
             }
         )
-        self.souscription_hphc._creer_facture_periode(periode_hphc).action_post()
+        periode_hphc._creer_facture().action_post()
 
         response = self.url_open(self._detail_url(self.souscription_hphc))
         self.assertEqual(response.status_code, 200)

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -115,7 +115,7 @@ class TestSouscriptionsReports(SouscriptionsTestMixin, HttpCase):
                 'turpe_variable': 4.2,
             }
         )
-        cls.facture_test = cls.souscription_base._creer_facture_periode(periode)
+        cls.facture_test = periode._creer_facture()
 
     def test_facture_energie_pdf(self):
         """Test de génération du PDF de facture d'énergie."""

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -63,7 +63,7 @@ class TestWorkflow(SouscriptionsTestMixin, SavepointCase):
         # Phase 3: Génération des factures
         factures = []
         for periode in periodes:
-            facture = souscription._creer_facture_periode(periode)
+            facture = periode._creer_facture()
             factures.append(facture)
 
             # Vérifier que la période est liée à la facture
@@ -98,7 +98,7 @@ class TestWorkflow(SouscriptionsTestMixin, SavepointCase):
 
         # Créer période et facture en Base
         periode_base = self.create_test_periode(souscription, date_debut=date(2024, 1, 1), date_fin=date(2024, 1, 31))
-        facture_base = souscription._creer_facture_periode(periode_base)
+        facture_base = periode_base._creer_facture()
 
         # Savepoint avant migration
         self.env.cr.savepoint()
@@ -117,7 +117,7 @@ class TestWorkflow(SouscriptionsTestMixin, SavepointCase):
         periode_hphc = self.create_test_periode(
             souscription, date_debut=date(2024, 2, 1), date_fin=date(2024, 2, 29), hp_kwh=180.0, hc_kwh=100.0
         )
-        facture_hphc = souscription._creer_facture_periode(periode_hphc)
+        facture_hphc = periode_hphc._creer_facture()
 
         # Vérifications
         self.assertEqual(souscription.type_tarif, 'hphc')
@@ -169,7 +169,7 @@ class TestWorkflow(SouscriptionsTestMixin, SavepointCase):
         # Facturer toutes les périodes
         factures = []
         for periode in periodes:
-            facture = souscription._creer_facture_periode(periode)
+            facture = periode._creer_facture()
             factures.append(facture)
 
         # Savepoint avant régularisation
@@ -204,14 +204,14 @@ class TestWorkflow(SouscriptionsTestMixin, SavepointCase):
         )
 
         periode = self.create_test_periode(souscription)
-        facture = souscription._creer_facture_periode(periode)
+        facture = periode._creer_facture()
 
         # Savepoint avant tentative d'erreur
         sp = self.env.cr.savepoint()
 
         try:
             # Tentative de refacturation (devrait échouer)
-            souscription._creer_facture_periode(periode)
+            periode._creer_facture()
             self.fail('Devrait lever une UserError')
         except UserError:
             # Rollback vers le savepoint
@@ -249,11 +249,11 @@ class TestWorkflow(SouscriptionsTestMixin, SavepointCase):
         factures_creees = []
         erreurs = []
 
-        for i, (souscription, periode) in enumerate(zip(souscriptions, periodes, strict=False)):
+        for i, (_souscription, periode) in enumerate(zip(souscriptions, periodes, strict=False)):
             try:
                 # Savepoint pour chaque facturation
                 sp = self.env.cr.savepoint()
-                facture = souscription._creer_facture_periode(periode)
+                facture = periode._creer_facture()
                 factures_creees.append(facture)
                 sp.release()
             except Exception as e:


### PR DESCRIPTION
## Quoi

Candidate A de la revue d'architecture : on approfondit le séam de composition de facture.

La composition des lignes vivait sur `souscription.souscription._creer_facture_periode` (~175 lignes), fusionnée à la création du `account.move` — la seule surface de test possible était un move comptabilisé sur un graphe de records complet.

On déplace le séam sur la **Période** (« la Période porte ce qui est facturé », CONTEXT.md) :

- **`periode._composer_lignes(grille) → [(0, 0, vals)]`** — module profond : toutes les règles (sections, abonnement proratisé, énergie par tarif, notes TURPE conditionnelles, majoration PRO). Lit **uniquement le snapshot figé** de la période (plus de repli sur l'état live de la souscription). La liste de lignes renvoyée **est** la surface de test — sans move, sans comptabilisation.
- **`periode._creer_facture()`** — coquille fine : sélection de la grille active + `account.move.create` posant `periode_id` (ADR 0004).
- **`souscription.creer_factures()`** — réduit à l'orchestrateur (boucle + garde anti-doublon).
- Helpers produits déplacés sur la Période ; ancien `_creer_facture_periode` et replis live morts supprimés.

## Pourquoi

- **Locality** : les règles de facturation sont concentrées en un module.
- **L'interface est la surface de test** : 5 tests ciblés (`tests/test_periode_composition.py`) exercent Base/HP-HC, seuils TURPE, prorata abonnement et coeff PRO sans créer de facture.
- **Reproductibilité** : modifier la souscription après création d'une période ne change plus sa facture (snapshot fait autorité — voir **ADR 0006**, ajouté ici).

## Garanties

- Refactor à **comportement constant** (hors suppression des replis live, vérifiée observablement équivalente).
- Suite complète : **147 tests, 0 échec, 0 erreur**.
- `ruff check` + `ruff format` clean.
- ~24 appels de test migrés vers `periode._creer_facture()`, **sans shim**.

## Suite

Candidate B / #14 (snapshot typé) nettoiera le parsing dont `_composer_lignes` hérite (`float("6 kVA"…)`, `'Base' in str(...)`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)