### PR TITLE
feat: surface invoice state on the Période view + demo a draft invoice

### DIFF
--- a/demo/souscriptions_demo.xml
+++ b/demo/souscriptions_demo.xml
@@ -364,7 +364,9 @@
             <field name="price_unit">12.60</field>
         </record>
         
-        <!-- Facture mars 2024 - Admin (en attente de paiement) -->
+        <!-- Facture mars 2024 - Admin : laissée volontairement en BROUILLON
+             (cas d'une facture en cours / remise en brouillon par le·la
+             facturiste) — visible côté gestion, jamais au portail usager. -->
         <record id="demo_facture_mars_admin" model="account.move">
             <field name="move_type">out_invoice</field>
             <field name="partner_id" ref="base.partner_admin"/>
@@ -400,10 +402,12 @@
             <field name="price_unit">12.60</field>
         </record>
 
-        <!-- Comptabilisation des factures admin : côté portail, seules les
-             factures postées sont visibles de l'usager·ère (ADR 0004, issue #23). -->
+        <!-- Comptabilisation : on POSTE janvier et février (visibles au portail —
+             seules les factures postées le sont, ADR 0004 / #23) et on laisse MARS
+             en brouillon pour illustrer une facture en cours / remise en brouillon
+             par le·la facturiste, visible côté gestion (vue Période) mais pas au portail. -->
         <function model="account.move" name="action_post"
-                  eval="[[ref('demo_facture_janvier_admin'), ref('demo_facture_fevrier_admin'), ref('demo_facture_mars_admin')]]"/>
+                  eval="[[ref('demo_facture_janvier_admin'), ref('demo_facture_fevrier_admin')]]"/>
 
     </data>
 </odoo>

--- a/models/core/souscription_periode.py
+++ b/models/core/souscription_periode.py
@@ -120,6 +120,11 @@ class SouscriptionPeriode(models.Model):
         store=True,
         help='Facture (out_invoice) rattachée à cette période, dérivée du lien account.move.periode_id.',
     )
+    # État de la facture exposé sur la période. `facture_id` inclut déjà les
+    # brouillons (le compute ne filtre pas sur l'état) ; ce champ rend l'état
+    # visible côté gestion pour distinguer brouillon / postée — notamment quand
+    # une facture est remise en brouillon par le·la facturiste.
+    facture_state = fields.Selection(related='facture_id.state', string='État facture', readonly=True)
 
     @api.depends('move_ids.move_type')
     def _compute_facture_id(self):

--- a/tests/test_periode_composition.py
+++ b/tests/test_periode_composition.py
@@ -10,7 +10,7 @@ notes TURPE, majoration PRO).
 
 from datetime import date
 
-from odoo.tests.common import tagged
+from odoo.tests.common import TransactionCase, tagged
 
 from .common import ABO_ANNUEL_STD, SouscriptionsTestCase
 
@@ -117,3 +117,41 @@ class TestPeriodeComposition(SouscriptionsTestCase):
         self.assertEqual(facture.invoice_date, periode.date_fin)
         # facture_id dérivé de account.move.periode_id (ADR 0004)
         self.assertEqual(periode.facture_id, facture)
+
+    def test_periode_surface_facture_brouillon(self):
+        """Une facture en BROUILLON liée à une période reste visible côté gestion :
+        facture_id la référence, facture_state l'expose, move_ids la contient."""
+        periode = self._periode(self.souscription_base, provision_base_kwh=100.0)
+        facture = periode._creer_facture()  # créée en brouillon (non postée)
+
+        self.assertEqual(facture.state, 'draft')
+        self.assertEqual(periode.facture_id, facture)  # liée même en brouillon
+        self.assertEqual(periode.facture_state, 'draft')  # état exposé sur la période
+        self.assertIn(facture, periode.move_ids)  # présente dans les documents liés
+
+    def test_periode_facture_state_suit_la_remise_en_brouillon(self):
+        """facture_state suit l'état réel : postée puis remise en brouillon."""
+        periode = self._periode(self.souscription_base, provision_base_kwh=100.0)
+        facture = periode._creer_facture()
+
+        facture.action_post()
+        self.assertEqual(periode.facture_state, 'posted')
+
+        facture.button_draft()
+        self.assertEqual(periode.facture_state, 'draft')
+        # toujours liée et visible après remise en brouillon
+        self.assertEqual(periode.facture_id, facture)
+
+
+@tagged('souscriptions', 'souscriptions_composition', 'post_install', '-at_install')
+class TestDemoFactures(TransactionCase):
+    """Les données de démo illustrent les deux états : postée (visible portail)
+    et brouillon (visible gestion uniquement)."""
+
+    def test_demo_a_des_factures_postee_et_brouillon(self):
+        posted = self.env.ref('souscriptions_odoo.demo_facture_janvier_admin', raise_if_not_found=False)
+        if not posted:
+            self.skipTest('Données de démo non chargées')
+        draft = self.env.ref('souscriptions_odoo.demo_facture_mars_admin')
+        self.assertEqual(posted.state, 'posted')
+        self.assertEqual(draft.state, 'draft')

--- a/views/core/souscriptions_periode_views.xml
+++ b/views/core/souscriptions_periode_views.xml
@@ -17,6 +17,9 @@
                 <field name="turpe_fixe"/>
                 <field name="turpe_variable"/>
                 <field name="facture_id"/>
+                <field name="facture_state" widget="badge"
+                       decoration-success="facture_state == 'posted'"
+                       decoration-warning="facture_state == 'draft'"/>
             </list>
         </field>
     </record>
@@ -87,7 +90,21 @@
 
                     <group string="Documents">
                         <field name="facture_id"/>
+                        <field name="facture_state"/>
                     </group>
+                    <!-- Tous les documents liés (factures, avoirs…), brouillons
+                         compris : une facture remise en brouillon reste visible ici. -->
+                    <field name="move_ids" readonly="1">
+                        <list>
+                            <field name="name"/>
+                            <field name="invoice_date"/>
+                            <field name="move_type"/>
+                            <field name="state" widget="badge"
+                                   decoration-success="state == 'posted'"
+                                   decoration-warning="state == 'draft'"/>
+                            <field name="amount_total"/>
+                        </list>
+                    </field>
                 </sheet>
             </form>
         </field>


### PR DESCRIPTION
## Contexte

En investiguant « plus de factures dans run-app », découverte : les factures de démo ne sont pas cassées — elles **postent correctement sur une install fraîche** (`INV/2024/00001…`). Le DB run-app de l'utilisateur·rice était simplement **périmé** (volume persistant, démo chargée seulement au premier `-i`).

Cette PR répond aux deux demandes qui en découlent.

## 1. Démo : un exemple posté **et** un brouillon

- `janvier` / `février` admin → **postées** (visibles au portail).
- `mars` admin → laissée en **brouillon** : illustre une facture en cours / remise en brouillon par le·la facturiste, visible côté gestion mais jamais au portail (ADR 0004).

Vérifié sur install fraîche : jan/fév `posted`, mars `draft`.

## 2. Vue Période : rendre l'état visible + montrer les brouillons

La vue affichait `facture_id` sans état. `facture_id` incluait **déjà** les brouillons (le compute ne filtre pas l'état), mais rien ne le signalait.

- Nouveau `souscription.periode.facture_state` (related `facture_id.state`).
- **Liste** : badge d'état (vert posté / orange brouillon).
- **Formulaire** : état affiché + liste `move_ids` (tous les documents liés, brouillons compris) → une facture remise en brouillon reste visible.

## Tests

- `test_periode_surface_facture_brouillon` — une facture brouillon reste liée + exposée (`facture_id` / `facture_state` / `move_ids`).
- `test_periode_facture_state_suit_la_remise_en_brouillon` — l'état suit `action_post` puis `button_draft`.
- `test_demo_a_des_factures_postee_et_brouillon` — split démo (skip si démo non chargée ; le harness de test installe sans démo).

Suite complète : **152 tests, 0 échec, 0 erreur**. `ruff` clean.

> Note d'exploitation : pour voir les factures postées dans run-app existant, réinitialiser le volume (la démo ne se recharge pas sur un DB déjà installé).

🤖 Generated with [Claude Code](https://claude.com/claude-code)