### PR TITLE
chore: ignore repo-scoped .gh-token PAT

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,6 @@ odoo-server.log
 # Local agent state / caches (Serena MCP, Claude Code)
 .serena/
 .claude/
+
+# repo-scoped GitHub PAT for in-sandbox automation — never commit
+.gh-token


### PR DESCRIPTION
Adds `.gh-token` to `.gitignore` so the repo-scoped GitHub PAT used for in-sandbox automation can never be accidentally committed.

Housekeeping only — no functional changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)