### PR TITLE
feat(presta): refacturation des prestations Enedis (#8)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -84,6 +84,17 @@ Ajustement par le·la *facturiste* de ce qui est **facturé** à un·e souscript
 commerciale (ex. : RES oubliée non encore traitée par Enedis → jours facturés réduits), assumé
 comme distinct de la réalité *physique* mesurée par electricore.
 
+**Prestation (à refacturer)** :
+Poste de facturation ponctuel d'origine **Enedis** (mise en service, déplacement, changement de
+puissance, pénalité de coupure…) que le fournisseur **refacture** au·à la *souscripteur·rice*.
+Porte un *Code Enedis*, un libellé, un prix et une quantité. Son montant peut être **négatif** (au
+bénéfice de l'usager·ère, ex. pénalité de coupure due par Enedis). **Indépendante de la _Période_** :
+ce n'est pas un fait mensuel mais un **en-cours refacturable** rattaché à un·e *souscripteur·rice*,
+qu'une *Facture* **rassemble** au moment de la facturation (plusieurs *Prestations* par *Facture*).
+Distincte du *Geste commercial* (ajustement *à la baisse* de ce qui est facturé, sans contrepartie
+réseau) : la *Prestation* est un poste **refacturé** avec une contrepartie Enedis identifiée.
+_Éviter_ : « presta » seule (ambiguë à l'écrit) ; service ; confondre avec un *Geste commercial*.
+
 **Facturiste** :
 Rôle métier qui conduit la facturation mensuelle depuis Odoo et **vérifie les données avant
 émission** des factures. Public cible de l'interface de vérification.

--- a/__manifest__.py
+++ b/__manifest__.py
@@ -36,6 +36,7 @@ de facturation via son API.
         'data/souscription_etat_data.xml',
         'data/produits_abonnement_simple.xml',
         'data/produits_energie.xml',
+        'data/produits_prestation.xml',
         'data/raccordement_sequence.xml',
         'data/raccordement_stages.xml',
         'reports/souscription_contrat_report.xml',

--- a/data/produits_prestation.xml
+++ b/data/produits_prestation.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo noupdate="1">
+    <!-- Produit générique de refacturation des prestations Enedis (#8 / ADR 0009).
+         Porte la plomberie comptable ; chaque ligne de prestation surcharge
+         name/price_unit/quantity depuis la souscription.presta. Pas de catalogue
+         par code Enedis. -->
+    <record id="souscriptions_product_prestation_enedis" model="product.product">
+        <field name="name">Prestation Enedis</field>
+        <field name="type">service</field>
+        <field name="sale_ok" eval="True"/>
+        <field name="purchase_ok" eval="False"/>
+        <field name="list_price">0.0</field>
+        <field name="standard_price">0.0</field>
+    </record>
+</odoo>

--- a/docs/adr/0009-prestation-refacturer-modele-independant-rassemble-sur-facture.md
+++ b/docs/adr/0009-prestation-refacturer-modele-independant-rassemble-sur-facture.md
@@ -1,0 +1,76 @@
+# Prestation à refacturer : modèle indépendant, rassemblé sur la facture de la Période
+
+Le fournisseur paie à Enedis des prestations ponctuelles (mise en service, déplacement,
+changement de puissance, pénalité de coupure…) qu'il **refacture** au·à la *souscripteur·rice*
+(voir le terme **Prestation (à refacturer)** dans `CONTEXT.md`). On introduit un modèle
+`souscription.presta` dédié plutôt que de les porter sur la *Période* — la Période est déjà un
+gros morceau (snapshot typé + verrou, [ADR-0006](0006-snapshot-periode-fait-autorite-facturation.md),
+[ADR-0007](0007-snapshot-periode-type-verrou-facturation.md)) et une prestation n'est **pas** un
+fait mensuel mais un **en-cours refacturable** à cadence Enedis.
+
+**Décision.**
+
+1. **Modèle indépendant de la Période.** `souscription.presta` porte `code_enedis`, `libelle`,
+   `prix`, `quantite`, le taux de **TVA issu du F15**, un `souscription_id` (M2o) et un
+   `facture_id` (M2o). Aucun lien vers `souscription.periode`.
+
+2. **Alimenté par electricore, dédupliqué par référence Enedis.** Les prestations sont
+   **tirées en totalité** d'un endpoint electricore dédié (le volume est faible — ~une par PDL),
+   puis **upsert** sur une **référence Enedis unique** (contrainte d'unicité). Pas de fenêtre
+   temporelle : pull-tout-et-dédup est plus robuste qu'un curseur de date (les lignes F15
+   arrivent en retard, datées dans le passé — un curseur les manquerait). Le PDL est résolu en
+   *Souscription* au moment du sync ; les PDL **sans souscription active sont ignorés** (v1).
+
+3. **Rassemblée sur la facture de la Période, orchestrée par la Souscription.** Une *Prestation*
+   ne fabrique **pas** sa propre facture. Au moment de `souscription.creer_factures()`, après que
+   la Période a composé sa facture ([ADR-0006](0006-snapshot-periode-fait-autorite-facturation.md)),
+   la *Souscription* **ajoute les prestations en attente** comme lignes du brouillon de facture,
+   avant qu'il ne sorte du pipeline de création, puis **pose `facture_id`** sur chaque presta.
+   « Indépendante de la Période » vaut au niveau du **modèle** (table propre, cadence propre,
+   référence la *Souscription* pas la *Période*), pas au niveau du **document**.
+
+4. **Le lien `facture_id` est l'unique marqueur « facturé ».** Cohérent avec
+   [ADR-0004](0004-lien-periode-facture-source-unique.md) (lien unique, sens naturel, côté
+   « plusieurs ») : `facture_id IS NULL` **est** la file « à refacturer ». Pas de booléen à
+   synchroniser (un éventuel `facturee` serait un `compute` non stocké). `ondelete='set null'` :
+   supprimer une facture (échappatoire de correction de l'[ADR-0007](0007-snapshot-periode-type-verrou-facturation.md))
+   **re-met les prestations dans la file**.
+
+5. **Plomberie comptable minimale.** Un **produit générique unique**
+   (`souscriptions_product_prestation_enedis`) porte le compte de produits ; la **TVA vient du
+   F15** par presta (pas du défaut produit) ; la ligne **surcharge** name/price_unit/quantity
+   depuis la presta. Pas de catalogue produit par code Enedis.
+
+6. **Refacturation à prix coûtant, une seule source de prix.** `prix` = prix de refacturation,
+   par défaut le prix F15 (pass-through, marge nulle — « on n'est pas des voleurs »). **Pas** de
+   champ `cout_enedis` distinct sur le modèle : si une marge devait un jour exister, elle se
+   calcule à la demande en analytique en rejouant electricore
+   ([ADR-0002](0002-deux-sources-de-verite-marge-en-analytique.md), « une seule source »).
+
+Le montant peut être **négatif** (pénalité de coupure due par Enedis au bénéfice de l'usager·ère),
+porté comme **ligne signée** qui se nette dans la facture mensuelle.
+
+## Options écartées
+
+- **Porter les prestations sur la Période** : surcharge un modèle déjà lourd et mélange deux
+  cadences (mensuelle figée vs ponctuelle Enedis).
+- **Facture autonome par prestation (Option B)** : casse les invariants actuels
+  (`account.move.souscription_id` est un `related` de `periode_id` ; `is_facture_energie =
+  periode_id and souscription_id` ; [ADR-0004](0004-lien-periode-facture-source-unique.md)
+  « une facture naît d'une période ») et multiplie les petits documents. Une facture
+  prestations-seules (souscription sans période ce mois-là, ex. après résiliation) reste un
+  **follow-up** assumé, pas du v1.
+- **Curseur temporel `[dernière facturée → maintenant]`** : fragile (prestations en retard datées
+  avant le curseur → perdues ; relances → double-facturation). La dédup par référence Enedis
+  supprime les deux risques.
+- **Booléen `facturee`** au lieu du M2o : deux champs à désynchroniser, et perd le « où ».
+
+## Hors périmètre (follow-up)
+
+- **Facture prestations-seules** pour une souscription sans Période le mois donné (résiliation).
+- **Avoir quand le total passe négatif** : si les crédits Enedis du mois (pénalités) dépassent
+  les charges, la convention comptable veut un *avoir*, pas un `out_invoice` négatif. v1 pose des
+  lignes signées qui se nettent ; le cas « facture qui passerait négative » est laissé au jugement
+  du·de la *facturiste* dans l'instant. À retracker en issue dédiée.
+- **PDL orphelins** (prestation pour un PDL sans souscription active) : ignorés au sync en v1 ;
+  les rendre visibles « à rattacher » est une évolution.

--- a/models/core/__init__.py
+++ b/models/core/__init__.py
@@ -1,1 +1,1 @@
-from . import account_move, grille_prix, souscription, souscription_periode
+from . import account_move, grille_prix, souscription, souscription_periode, souscription_presta

--- a/models/core/souscription.py
+++ b/models/core/souscription.py
@@ -37,6 +37,7 @@ class Souscription(models.Model):
         'account.move', compute='_compute_factures_via_periodes', string='Factures', store=False
     )
     periode_ids = fields.One2many('souscription.periode', 'souscription_id', string='Périodes de facturation')
+    presta_ids = fields.One2many('souscription.presta', 'souscription_id', string='Prestations à refacturer')
     # Données métier
 
     ## Utiles facturation
@@ -151,13 +152,32 @@ class Souscription(models.Model):
                 _logger.warning(f'Souscription {souscription.name} sans partenaire, ignorée')
                 continue
 
+            premiere_facture = self.env['account.move']
             for periode in souscription.periode_ids.filtered(lambda p: not p.facture_id):
                 try:
                     facture = periode._creer_facture()
+                    premiere_facture = premiere_facture or facture
                     _logger.info(f'Facture {facture.name} créée pour période {periode.mois_annee}')
                 except Exception as e:
                     _logger.error(f'Erreur création facture pour période {periode.mois_annee}: {e}')
                     raise UserError(f'Erreur création facture pour {periode.mois_annee}: {e}')
+
+            # Rassemble les prestations en attente sur la première facture émise
+            # ce run, puis les flague (ADR 0009). Le flag les retire de la file,
+            # donc les périodes suivantes ne les re-facturent pas.
+            if premiere_facture:
+                souscription._facturer_prestations_en_attente(premiere_facture)
+
+    def _facturer_prestations_en_attente(self, facture):
+        """Ajoute les prestations en attente (`facture_id` NULL) comme lignes de
+        `facture` et pose leur `facture_id`. Responsabilité de la Souscription,
+        pas de la Période (ADR 0009)."""
+        self.ensure_one()
+        prestas = self.presta_ids.filtered(lambda p: not p.facture_id)
+        if not prestas:
+            return
+        facture.write({'invoice_line_ids': [p._composer_ligne() for p in prestas]})
+        prestas.facture_id = facture
 
     @api.model
     def ajouter_periodes_mensuelles(self):

--- a/models/core/souscription_presta.py
+++ b/models/core/souscription_presta.py
@@ -1,0 +1,64 @@
+from odoo import fields, models
+from odoo.exceptions import UserError
+
+
+class SouscriptionPresta(models.Model):
+    """Prestation Enedis à refacturer (#8 / ADR 0009).
+
+    Poste de facturation ponctuel d'origine Enedis (mise en service, déplacement,
+    pénalité de coupure…) que le fournisseur refacture au·à la souscripteur·rice.
+    Indépendante de la Période : c'est un en-cours refacturable rattaché à une
+    Souscription. `facture_id` NULL = file « à refacturer » ; il est posé quand
+    une Facture rassemble la prestation (lien côté presta, ADR 0004).
+    """
+
+    _name = 'souscription.presta'
+    _description = 'Prestation Enedis à refacturer'
+
+    souscription_id = fields.Many2one(
+        'souscription.souscription', required=True, ondelete='cascade', string='Souscription'
+    )
+    pdl = fields.Char(string='PDL')
+    reference_enedis = fields.Char(string='Référence Enedis', required=True)
+    code_enedis = fields.Char(string='Code Enedis')
+    libelle = fields.Char(string='Libellé', required=True)
+    prix = fields.Float(string='Prix (€)', help='Prix de refacturation ; peut être négatif (avoir/pénalité).')
+    quantite = fields.Float(string='Quantité', default=1.0)
+
+    # Marqueur « facturé » et unique lien Période-libre ↔ Facture : posé quand la
+    # prestation est rassemblée sur une facture (ADR 0004, lien côté « plusieurs »).
+    # `set null` : supprimer la facture re-met la prestation dans la file.
+    facture_id = fields.Many2one('account.move', string='Facture', readonly=True, ondelete='set null', copy=False)
+
+    # Clé de dédup du sync electricore (ADR 0009) : une prestation = une référence
+    # Enedis. Pull-tout-et-dédup s'appuie dessus pour rester idempotent.
+    _unique_reference_enedis = models.Constraint(
+        'UNIQUE(reference_enedis)',
+        'Une prestation existe déjà pour cette référence Enedis.',
+    )
+
+    def _get_produit_prestation(self):
+        produit = self.env.ref('souscriptions_odoo.souscriptions_product_prestation_enedis', raise_if_not_found=False)
+        if not produit:
+            raise UserError('Produit générique de prestation non trouvé')
+        return produit
+
+    def _composer_ligne(self):
+        """Compose la ligne de facture (`(0, 0, vals)`) de cette prestation.
+
+        Surface de test des règles de refacturation : produit générique pour la
+        plomberie comptable, libellé/prix/quantité de la prestation. Ne crée
+        aucun `account.move`.
+        """
+        self.ensure_one()
+        produit = self._get_produit_prestation()
+        return (
+            0,
+            0,
+            {
+                'product_id': produit.id,
+                'name': self.libelle,
+                'quantity': self.quantite,
+                'price_unit': self.prix,
+            },
+        )

--- a/security/ir.model.access.csv
+++ b/security/ir.model.access.csv
@@ -5,6 +5,8 @@ access_souscription_periode_user,souscription.periode user,model_souscription_pe
 access_souscription_periode_manager,souscription.periode manager,model_souscription_periode,group_souscriptions_manager,1,1,1,1
 access_souscription_etat_user,souscription.etat user,model_souscription_etat,group_souscriptions_user,1,0,0,0
 access_souscription_etat_manager,souscription.etat manager,model_souscription_etat,group_souscriptions_manager,1,1,1,1
+access_souscription_presta_user,souscription.presta user,model_souscription_presta,group_souscriptions_user,1,1,1,0
+access_souscription_presta_manager,souscription.presta manager,model_souscription_presta,group_souscriptions_manager,1,1,1,1
 access_grille_prix_user,grille.prix user,model_grille_prix,group_souscriptions_user,1,0,0,0
 access_grille_prix_manager,grille.prix manager,model_grille_prix,group_souscriptions_manager,1,1,1,1
 access_grille_prix_ligne_user,grille.prix.ligne user,model_grille_prix_ligne,group_souscriptions_user,1,0,0,0

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -9,6 +9,7 @@ from . import (
     test_periode_form,
     test_periode_snapshot,
     test_portal,
+    test_presta,
     test_raccordement,
     test_security,
     test_souscription,

--- a/tests/test_presta.py
+++ b/tests/test_presta.py
@@ -1,0 +1,105 @@
+"""
+Tests des Prestations à refacturer (#8 / ADR 0009).
+
+Une `souscription.presta` est un poste Enedis refacturable, indépendant de la
+Période : c'est un en-cours (`facture_id` NULL = file « à refacturer ») que la
+Souscription **rassemble** sur la facture de la période au moment de
+`creer_factures()`, puis flague (`facture_id`).
+"""
+
+from datetime import date
+
+from odoo.tests.common import tagged
+from odoo.tools import mute_logger
+from psycopg2 import IntegrityError
+
+from .common import SouscriptionsTestCase
+
+
+@tagged('souscriptions', 'souscriptions_presta', 'post_install', '-at_install')
+class TestPresta(SouscriptionsTestCase):
+    def _presta(self, souscription, **vals):
+        base = {
+            'souscription_id': souscription.id,
+            'reference_enedis': 'F15-001',
+            'libelle': 'Déplacement technicien',
+            'prix': 45.0,
+            'quantite': 1.0,
+        }
+        base.update(vals)
+        return self.env['souscription.presta'].create(base)
+
+    def test_presta_en_attente_ramassee_et_flaggee(self):
+        """Tracer bullet : une presta en attente atterrit sur la facture
+        mensuelle et reçoit son facture_id quand creer_factures() tourne."""
+        presta = self._presta(self.souscription_base)
+        self.create_test_periode(self.souscription_base, provision_base_kwh=100.0)
+        self.assertFalse(presta.facture_id, 'en attente avant facturation')
+
+        self.souscription_base.creer_factures()
+
+        self.assertTrue(presta.facture_id, 'flaggée après facturation')
+        self.assertIn('Déplacement technicien', presta.facture_id.invoice_line_ids.mapped('name'))
+
+    def test_composer_ligne_porte_libelle_prix_quantite(self):
+        """La ligne composée porte libellé/prix/quantité de la presta et le
+        produit générique de prestation."""
+        presta = self._presta(self.souscription_base, libelle='Mise en service', prix=52.30, quantite=2.0)
+        _cmd, _id, vals = presta._composer_ligne()
+
+        self.assertEqual(vals['name'], 'Mise en service')
+        self.assertEqual(vals['price_unit'], 52.30)
+        self.assertEqual(vals['quantity'], 2.0)
+        produit = self.env.ref('souscriptions_odoo.souscriptions_product_prestation_enedis')
+        self.assertEqual(vals['product_id'], produit.id)
+
+    def test_presta_negative_se_nette_dans_la_facture(self):
+        """Une prestation négative (pénalité de coupure due par Enedis) atterrit
+        comme ligne négative sur la facture mensuelle."""
+        periode = self.create_test_periode(self.souscription_base, provision_base_kwh=100.0)
+        self._presta(self.souscription_base, reference_enedis='F15-NEG', libelle='Pénalité coupure', prix=-30.0)
+
+        self.souscription_base.creer_factures()
+
+        ligne_neg = periode.facture_id.invoice_line_ids.filtered(lambda l: l.name == 'Pénalité coupure')
+        self.assertEqual(len(ligne_neg), 1)
+        self.assertEqual(ligne_neg.price_unit, -30.0)
+        self.assertLess(ligne_neg.price_subtotal, 0, 'la ligne réduit le total')
+
+    def test_presta_facturee_une_seule_fois_sur_plusieurs_periodes(self):
+        """Deux périodes facturées en un run : la presta n'atterrit que sur UNE
+        facture, jamais dupliquée (pas de double facturation)."""
+        self._presta(self.souscription_base, reference_enedis='F15-UNIQ')
+        p1 = self.create_test_periode(
+            self.souscription_base, date_debut=date(2024, 1, 1), date_fin=date(2024, 1, 31), provision_base_kwh=100.0
+        )
+        p2 = self.create_test_periode(
+            self.souscription_base, date_debut=date(2024, 2, 1), date_fin=date(2024, 2, 29), provision_base_kwh=100.0
+        )
+
+        self.souscription_base.creer_factures()
+
+        lignes = (p1.facture_id | p2.facture_id).invoice_line_ids.filtered(lambda l: l.name == 'Déplacement technicien')
+        self.assertEqual(len(lignes), 1, 'facturée exactement une fois')
+
+    def test_supprimer_facture_remet_presta_dans_la_file(self):
+        """Supprimer la facture (échappatoire de correction, ADR 0007) re-met la
+        prestation dans la file « à refacturer » (ondelete=set null)."""
+        presta = self._presta(self.souscription_base, reference_enedis='F15-DEL')
+        self.create_test_periode(self.souscription_base, provision_base_kwh=100.0)
+        self.souscription_base.creer_factures()
+        facture = presta.facture_id
+        self.assertTrue(facture)
+
+        facture.unlink()  # brouillon → suppression autorisée
+
+        self.assertFalse(presta.facture_id, 'remise dans la file après suppression de la facture')
+
+    @mute_logger('odoo.sql_db')
+    def test_reference_enedis_unique(self):
+        """Deux prestations ne peuvent partager la même référence Enedis : c'est
+        la clé de dédup du sync electricore (ADR 0009)."""
+        self._presta(self.souscription_base, reference_enedis='F15-DUP')
+        with self.assertRaises(IntegrityError), self.env.cr.savepoint():
+            self._presta(self.souscription_base, reference_enedis='F15-DUP')
+            self.env.flush_all()

--- a/views/core/souscription_views.xml
+++ b/views/core/souscription_views.xml
@@ -61,8 +61,18 @@
                                 </list>
                             </field>
                         </page>
-                        <!-- Onglets métier supprimés pour version minimale -->
-                        <!-- Historique et Prestations disponibles via module souscriptions_bridge -->
+                        <page string="Prestations à refacturer">
+                            <field name="presta_ids">
+                                <list editable="bottom">
+                                    <field name="reference_enedis"/>
+                                    <field name="code_enedis"/>
+                                    <field name="libelle"/>
+                                    <field name="quantite"/>
+                                    <field name="prix"/>
+                                    <field name="facture_id" readonly="1"/>
+                                </list>
+                            </field>
+                        </page>
                     </notebook>
                 </sheet>
                 <chatter open_attachments="True"/>


### PR DESCRIPTION
Implémente la slice AFK #36 (parent #8) : refacturation des prestations Enedis.

## Quoi
Nouveau modèle `souscription.presta` — poste Enedis ponctuel, signé, **indépendant de la Période** (ADR 0009). La file « à refacturer » (`facture_id` NULL) est **rassemblée** par la Souscription sur la facture mensuelle au moment de `creer_factures()`, puis flaguée.

- modèle + `_composer_ligne` (surface pure, miroir de `periode._composer_lignes`) + `UNIQUE(reference_enedis)`
- `souscription.creer_factures()` : sweep des prestas en attente sur la 1re facture du run, pose `facture_id` (`ondelete=set null` → re-queue si la facture est supprimée)
- produit générique de refacturation + ACL + onglet « Prestations à refacturer »
- terme **Prestation (à refacturer)** dans `CONTEXT.md`, **ADR 0009**

## Tests (TDD)
6 comportements pilotés par les tests, suite complète **verte : 0 échec / 126 tests** :
sweep+flag (tracer bullet), contenu de ligne, montant négatif qui se nette, pas de double facturation sur plusieurs périodes, re-queue à la suppression, unicité de la référence Enedis.

## Suite
- `tax_id` (TVA F15) volontairement hors périmètre → #38
- sync electricore (pull-tout + dédup) → #37

Closes #36. Base de la stack : `main`.
