### PR TITLE
docs(adr): identité Souscription (RSC/id_Affaire) + contrat pull facturation

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -24,7 +24,8 @@ Français, cohérent avec electricore.
 Le contrat de fourniture d'électricité conclu avec un·e *souscripteur·rice*, matérialisé par
 `souscription.souscription`. Système de référence de toutes les données métier/contractuelles
 côté fournisseur ; n'est *pas* stocké dans le module comptable. Porte la *RSC* electricore
-comme clé d'articulation (le PDL reste un attribut d'affichage/recherche).
+comme clé d'articulation — réconciliée depuis l'`id_Affaire` Enedis (amorce capturée au
+*raccordement*) — le PDL restant un attribut d'affichage/recherche.
 _Éviter_ : **abonnement** (collision triple — le module Odoo de facturation récurrente qu'on
 remplace, le terme pipeline d'electricore, la catégorie produit « Abonnements ») ; **devis**,
 **commande**, `sale.order` (explicitement non utilisés : pas de cycle de vente) ; contrat

--- a/docs/adr/0010-identite-souscription-rsc-cle-id-affaire-amorce.md
+++ b/docs/adr/0010-identite-souscription-rsc-cle-id-affaire-amorce.md
@@ -1,0 +1,64 @@
+# Identité de la *Souscription* : la RSC comme clé, l'`id_Affaire` comme amorce de réconciliation
+
+La *Souscription* était entièrement clée sur le **PDL**, qui n'est pas un identifiant de
+contrat : un même PDL est attribué à plusieurs *souscripteur·rice·s* successif·ves (issue #5).
+electricore travaille en **`ref_situation_contractuelle`** (RSC), unique par couple
+(PDL, usager·ère), et c'est sur la RSC que sont clées les *méta-périodes* qu'Odoo tire
+([ADR-0001](0001-odoo-systeme-ecriture-electricore-api-read-only.md)). Mais la RSC **n'est pas
+affichée dans SGE** : un humain ne peut pas la saisir à la création. L'**`id_Affaire`** Enedis —
+la référence d'affaire renvoyée dès la demande de raccordement — est, elle, **connue tôt** et
+**non ambiguë par affaire**.
+
+## Décision
+
+1. **Deux identifiants stockés sur la *Souscription*.** `ref_situation_contractuelle` est la
+   **clé d'articulation** (ce sur quoi le *pull* est clé) ; `id_affaire` est l'**amorce de
+   réconciliation** (audit + ré-résolution). Le **PDL** redevient un simple attribut
+   d'affichage/recherche.
+
+2. **`id_Affaire` capturé au raccordement.** Nouveau champ sur `raccordement.demande`, recopié
+   sur la *Souscription* qu'il engendre. C'est le seul identifiant à la fois disponible **tôt**
+   (avant tout C15) et **non ambigu**.
+
+3. **Réconciliation à la bascule « raccordement effectué ».** À cette transition — qui
+   **conditionne aussi la facturabilité** — Odoo appelle l'endpoint de résolution d'electricore
+   (`id_Affaire → RSC`, via le flux **X12** recoupé avec l'`id_Affaire` que porte aussi le C15)
+   et **inscrit la RSC** sur la *Souscription*. electricore *calcule-et-renvoie* la RSC ;
+   **Odoo écrit son propre champ** — le read-only-vers-Odoo est préservé
+   ([ADR-0001](0001-odoo-systeme-ecriture-electricore-api-read-only.md)).
+
+4. **Aucun repli flou sur le flux vif.** La facturation ne démarrant qu'après « raccordement
+   effectué » (⇒ MES ⇒ C15/X12 existent ⇒ RSC résoluble), la RSC est **toujours présente au
+   moment de facturer**. Le couple **PDL + date** ne survit **que** comme outil de **migration
+   unique** du legacy, jamais dans le flux de facturation courant.
+
+## Conséquences
+
+- Nouveaux champs `ref_situation_contractuelle` et `id_affaire` (Souscription) + `id_affaire`
+  (raccordement) ; refonte *greenfield*
+  ([ADR-0003](0003-strategie-migration-odoo19-odoo-sh.md)), pas de bascule de données legacy.
+- electricore expose un endpoint de **résolution RSC** (lecture) et **cesse de lire `sale.order`**
+  pour faire ce rapprochement (il le faisait côté legacy ; AUDIT §3.2/§3.3).
+- Réponse explicite à l'**issue #5** : la RSC est **récupérée** par l'`id_Affaire`, pas saisie à
+  la main.
+- La *Souscription* devient **facturable** uniquement raccordement effectué (donc RSC présente) —
+  pré-condition reprise par
+  [ADR-0011](0011-contrat-pull-facturation-electricore-cle-rsc-mois.md).
+
+## Options écartées
+
+- **Garder le PDL comme clé** : ambigu sur les *souscripteur·rice·s* successif·ves (le problème
+  même de #5).
+- **Saisie manuelle de la RSC** : impossible, la RSC n'est pas affichée dans SGE.
+- **Clé unique sur `id_Affaire`, RSC laissée côté electricore** : contredit l'intention « la
+  *Souscription* porte la RSC comme clé d'articulation » (`CONTEXT.md`) et couplerait **chaque**
+  *pull* à une traduction vive `id_Affaire → RSC`.
+- **Repli PDL + date sur le flux vif** : risque de router une *méta-période* vers le **mauvais·e
+  souscripteur·rice** (mésfacturation silencieuse) — réservé à la migration.
+
+## Raison
+
+L'`id_Affaire` est le **seul** identifiant à la fois connu tôt (dès la demande) et non ambigu ;
+il sert d'amorce robuste pour acquérir **une fois** la RSC, qui reste la **clé durable** de tout
+l'échange. Correction avant automatisation : un contrat non réconcilié n'est **pas** facturé
+automatiquement plutôt que facturé sur une correspondance douteuse.

--- a/docs/adr/0011-contrat-pull-facturation-electricore-cle-rsc-mois.md
+++ b/docs/adr/0011-contrat-pull-facturation-electricore-cle-rsc-mois.md
@@ -1,0 +1,86 @@
+# Contrat de facturation electricore → Odoo : *pull* facturiste, clé `(RSC, mois)`, payload physique
+
+[ADR-0001](0001-odoo-systeme-ecriture-electricore-api-read-only.md) a tranché la **direction**
+(Odoo *tire*, electricore *calcule-et-renvoie*, n'écrit jamais le nouveau module). Cet ADR fixe
+le **contrat concret** : endpoints, clé d'idempotence, format du payload, déclencheur,
+authentification, erreurs. Il répond au livrable de l'**issue #12** (« format exact des données
+de période ») et à l'**issue #4** (accise).
+
+## Décision
+
+1. **Clé d'idempotence `(RSC, mois calendaire)`.** Une *Période* par mois et par RSC ;
+   `date_debut`/`date_fin` **tronqués au MES/RES** dans les mois de bornes (d'où `jours` réels,
+   abonnement au **prorata**). Pas de découpe infra-mensuelle : la RSC distingue déjà les
+   *souscripteur·rice·s* d'un même PDL (passation en cours de mois → deux RSC, deux clés
+   distinctes).
+
+2. **Endpoints calcule-et-renvoie (Odoo → electricore).**
+   - **GET méta-périodes en masse** : Odoo passe la liste des `(RSC, mois)` **facturables**,
+     electricore renvoie les quantités physiques.
+   - **POST recompute TURPE ciblé** : prend les **cadrans courants** de la *Période* (parfois
+     saisis à la main) **en entrée** et ne renvoie **que** `turpe_fixe`/`turpe_variable` ; il
+     **ne touche jamais l'énergie**.
+   - (La résolution `id_Affaire → RSC` vit dans
+     [ADR-0010](0010-identite-souscription-rsc-cle-id-affaire-amorce.md).)
+
+3. **Déclencheur 100 % facturiste, pas de cron.** Une action « récupérer les périodes du mois »
+   lancée à la demande ; elle **ignore silencieusement** les *Souscriptions* non facturables
+   (raccordement non effectué / RSC non résolue) — aucune pression sur les raccordements
+   inachevés. **Upsert create-missing-only** : un `(RSC, mois)` déjà amorcé n'est **jamais
+   réécrit** automatiquement (protège les corrections du·de la *facturiste*). Une *Période*
+   **facturée** est gelée
+   ([ADR-0007](0007-snapshot-periode-type-verrou-facturation.md)) : toute correction passe par
+   une **régularisation**. L'énergie arrivée en retard se reprend par une **re-récupération
+   explicite** (écrasement assumé), jamais par le flux automatique.
+
+4. **Payload = physique/réseau uniquement.** Énergie par cadran au grain `config_cadrans`
+   ([ADR-0005](0005-granularite-energie-calendrier-comptage.md)), montants **TURPE**
+   ([ADR-0002](0002-deux-sources-de-verite-marge-en-analytique.md)), **accise/CTA en montant +
+   assiette**, bornes tronquées + `jours`, `config_cadrans`, drapeau `data_complete`. Les
+   paramètres **contractuels** (`puissance`, `type_tarif`, `lisse`, `provision_*`,
+   `tarif_solidaire`) **ne traversent jamais le fil** : ils sont le *snapshot* d'Odoo
+   (« référencer, pas recopier »,
+   [ADR-0002](0002-deux-sources-de-verite-marge-en-analytique.md)). electricore lit la puissance
+   dans le C15 pour **son** calcul TURPE, sans la renvoyer.
+
+5. **Authentification & erreurs.** API electricore protégée par **`X-API-Key`**, stockée comme
+   **secret** Odoo (`ir.config_parameter`), URL configurable. Pull facturiste =
+   **skip-and-report par élément** (un `(RSC, mois)` en échec n'avorte pas le lot) ; aucune
+   écriture partielle (amorçage transactionnel). **Énergie absente = `null` +
+   `data_complete=false`** — distinct de `0` (une vraie mesure) et d'une **erreur de service**.
+   Suppression des méthodes d'écriture entrante `create_billing_period` /
+   `update_consumption_data` (vestiges Option A,
+   [ADR-0001](0001-odoo-systeme-ecriture-electricore-api-read-only.md), AUDIT §5) ;
+   `get_souscriptions_by_pdl` re-clé sur la RSC.
+
+## Conséquences
+
+- Retire le cron aveugle `ajouter_periodes_mensuelles` (AUDIT §6) : la troncature vient du C15
+  (electricore), pas d'une supposition calendaire.
+- electricore expose les deux endpoints ci-dessus (+ la résolution RSC d'[ADR-0010](0010-identite-souscription-rsc-cle-id-affaire-amorce.md)) —
+  donnée qu'il calcule déjà (`ContexteMensuel.facturation_mensuelle`).
+- **Issue #4** tranchée : l'accise (montant + assiette, par catégorie) est dans le payload,
+  calculée par electricore ; Odoo n'en maintient **aucun taux**
+  ([ADR-0002](0002-deux-sources-de-verite-marge-en-analytique.md)).
+- Le **lecteur analytique** (electricore lisant `souscription.*` en read-only pour la marge) est
+  **hors périmètre** de cet ADR — issue dédiée ultérieure.
+
+## Options écartées
+
+- **electricore *upsert* les Périodes (Option A de l'audit)** : déjà écartée par
+  [ADR-0001](0001-odoo-systeme-ecriture-electricore-api-read-only.md) (read-only-vers-Odoo).
+- **Cron de pull automatique** : réécrirait les brouillons corrigés à la main et mettrait la
+  pression sur les raccordements inachevés.
+- **Recompute complet sur le bouton** : écraserait les cadrans saisis par le·la *facturiste* —
+  d'où le recompute **TURPE seul**.
+- **Périodes calées sur le mois plein** (partiels renvoyés par electricore) : casse le prorata et
+  la passation de PDL — la **troncature MES/RES au grain mois** est retenue.
+- **Envoyer les paramètres contractuels dans le payload** : viole la frontière de propriété
+  d'[ADR-0002](0002-deux-sources-de-verite-marge-en-analytique.md).
+
+## Raison
+
+Le·la *facturiste* possède le brouillon (`CONTEXT.md`), electricore possède le calcul physique.
+**Create-missing-only** et **recompute TURPE seul** protègent par défaut la saisie manuelle des
+cadrans ; `(RSC, mois)` est la clé idempotente naturelle ; le déclenchement manuel colle au
+process réel — on facture quand on est prêt, pas quand un cron l'impose.


### PR DESCRIPTION
Documente l'identité de la *Souscription* et le contrat de facturation.

- **ADR 0010** : la *RSC* est la clé d'identité de la Souscription ; l'`id_Affaire` Enedis sert d'**amorce de réconciliation** (capturée au *raccordement*).
- **ADR 0011** : contrat de facturation electricore → Odoo en **pull facturiste**, clé `(RSC, mois)`, payload physique.
- Précise le terme **Souscription** dans `CONTEXT.md` en conséquence.

⚠️ **Stack** — basée sur `feat/8-prestation-refacturer` (#39). À merger **après** #39 (la diff propre n'apparaît qu'une fois #39 dans `main`).
