### PR TITLE
chore: retire l'ignore .gh-token du .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,5 +48,3 @@ odoo-server.log
 .serena/
 .claude/
 
-# repo-scoped GitHub PAT for in-sandbox automation — never commit
-.gh-token


### PR DESCRIPTION
Retire l'ignore `.gh-token` du `.gitignore`. L'approche PAT-dans-le-dépôt est abandonnée : `gh` fonctionne en levant le sandbox, il n'y a plus de fichier à ignorer.

⚠️ **Stack** — basée sur `docs/rsc-identite-souscription` (#40). À merger en dernier.
