### PR TITLE
demo(presta): prestations à refacturer de démonstration (#8)

### DIFF
--- a/__manifest__.py
+++ b/__manifest__.py
@@ -52,6 +52,7 @@ de facturation via son API.
     'demo': [
         'demo/grille_prix_demo.xml',
         'demo/souscriptions_demo.xml',
+        'demo/prestations_demo.xml',
         'demo/raccordement_demo.xml',
     ],
 }

--- a/demo/prestations_demo.xml
+++ b/demo/prestations_demo.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <data>
+        <!-- ================================ -->
+        <!-- PRESTATIONS À REFACTURER (#8)    -->
+        <!-- ================================ -->
+        <!-- Illustre les trois cas de la file « à refacturer » (ADR 0009) sur la
+             souscription admin : en attente positive, en attente négative
+             (pénalité de coupure due par Enedis), et déjà facturée (rattachée à
+             la facture mars laissée en brouillon, avec sa ligne sur la facture). -->
+
+        <!-- En attente, positive : mise en service non encore facturée -->
+        <record id="demo_presta_mise_en_service" model="souscription.presta">
+            <field name="souscription_id" ref="demo_souscription_admin"/>
+            <field name="pdl">PDL22516914099999</field>
+            <field name="reference_enedis">F15-DEMO-0001</field>
+            <field name="code_enedis">MES</field>
+            <field name="libelle">Mise en service</field>
+            <field name="prix">45.85</field>
+            <field name="quantite">1</field>
+        </record>
+
+        <!-- En attente, négative : pénalité de coupure due par Enedis (avoir) -->
+        <record id="demo_presta_penalite_coupure" model="souscription.presta">
+            <field name="souscription_id" ref="demo_souscription_admin"/>
+            <field name="pdl">PDL22516914099999</field>
+            <field name="reference_enedis">F15-DEMO-0002</field>
+            <field name="code_enedis">PENA</field>
+            <field name="libelle">Pénalité de coupure (due par Enedis)</field>
+            <field name="prix">-30.00</field>
+            <field name="quantite">1</field>
+        </record>
+
+        <!-- Déjà facturée : rattachée à la facture mars (brouillon, éditable) -->
+        <record id="demo_presta_deplacement" model="souscription.presta">
+            <field name="souscription_id" ref="demo_souscription_admin"/>
+            <field name="pdl">PDL22516914099999</field>
+            <field name="reference_enedis">F15-DEMO-0003</field>
+            <field name="code_enedis">DEPL</field>
+            <field name="libelle">Déplacement</field>
+            <field name="prix">19.66</field>
+            <field name="quantite">1</field>
+            <field name="facture_id" ref="demo_facture_mars_admin"/>
+        </record>
+
+        <!-- Ligne correspondante sur la facture mars (brouillon) : c'est ce que
+             le sweep de creer_factures() poserait — ici figé en démo. -->
+        <record id="demo_facture_mars_admin_line_presta" model="account.move.line">
+            <field name="move_id" ref="demo_facture_mars_admin"/>
+            <field name="product_id" ref="souscriptions_product_prestation_enedis"/>
+            <field name="name">Déplacement</field>
+            <field name="quantity">1</field>
+            <field name="price_unit">19.66</field>
+        </record>
+    </data>
+</odoo>

--- a/tests/test_presta.py
+++ b/tests/test_presta.py
@@ -9,7 +9,7 @@ Souscription **rassemble** sur la facture de la période au moment de
 
 from datetime import date
 
-from odoo.tests.common import tagged
+from odoo.tests.common import TransactionCase, tagged
 from odoo.tools import mute_logger
 from psycopg2 import IntegrityError
 
@@ -103,3 +103,26 @@ class TestPresta(SouscriptionsTestCase):
         with self.assertRaises(IntegrityError), self.env.cr.savepoint():
             self._presta(self.souscription_base, reference_enedis='F15-DUP')
             self.env.flush_all()
+
+
+@tagged('souscriptions', 'souscriptions_presta', 'post_install', '-at_install')
+class TestDemoPrestas(TransactionCase):
+    """Les prestations de démonstration illustrent la file « à refacturer » :
+    en attente (positive et négative) et déjà facturée."""
+
+    def test_demo_prestas_etats_file_et_facturee(self):
+        en_attente = self.env.ref('souscriptions_odoo.demo_presta_mise_en_service', raise_if_not_found=False)
+        if not en_attente:
+            self.skipTest('Données de démo non chargées')
+
+        # En attente : pas de facture (dans la file)
+        self.assertFalse(en_attente.facture_id)
+
+        # Montant négatif : pénalité de coupure
+        negative = self.env.ref('souscriptions_odoo.demo_presta_penalite_coupure')
+        self.assertLess(negative.prix, 0)
+        self.assertFalse(negative.facture_id)
+
+        # Déjà facturée : rattachée à la facture mars (brouillon)
+        facturee = self.env.ref('souscriptions_odoo.demo_presta_deplacement')
+        self.assertEqual(facturee.facture_id, self.env.ref('souscriptions_odoo.demo_facture_mars_admin'))


### PR DESCRIPTION
Données de démonstration pour les **Prestations à refacturer** (#8 / ADR 0009) — la slice feature (#39) ne seedait rien, l'onglet « Prestations à refacturer » était vide en démo.

## Quoi
Trois prestations sur la souscription admin, couvrant les trois états de la file :
- **en attente, positive** — Mise en service (45,85 €), pas de facture → visible dans la file
- **en attente, négative** — Pénalité de coupure due par Enedis (−30 €) → illustre le montant signé
- **déjà facturée** — Déplacement (19,66 €), rattachée à la facture **mars** (laissée en brouillon), avec sa ligne sur la facture

+ un test de démo (`TestDemoPrestas`) qui *skip* si la démo n'est pas chargée, exactement comme `TestDemoFactures`.

## Validation
- Install **`--with-demo`** : `prestations_demo.xml` charge sans erreur (refs croisées + ligne sur la facture mars brouillon OK).
- Suite normale (sans démo) : verte, le test de démo skip.
- `ruff check` + `ruff format --check` : clean.

Base : `main` (la stack #8 est mergée).
