### PR TITLE
feat(presta): mise en attente manuelle + état dérivé, opt-out facturation auto

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -94,7 +94,16 @@ ce n'est pas un fait mensuel mais un **en-cours refacturable** rattaché à un·
 qu'une *Facture* **rassemble** au moment de la facturation (plusieurs *Prestations* par *Facture*).
 Distincte du *Geste commercial* (ajustement *à la baisse* de ce qui est facturé, sans contrepartie
 réseau) : la *Prestation* est un poste **refacturé** avec une contrepartie Enedis identifiée.
-_Éviter_ : « presta » seule (ambiguë à l'écrit) ; service ; confondre avec un *Geste commercial*.
+**États** (du point de vue du·de la *facturiste*) : **à refacturer** (défaut — dans la file,
+balayée par la facturation automatique), **en attente** (retirée de la file *à la main* par le·la
+*facturiste* sur un doute, donc **exclue** de la facturation automatique jusqu'à levée du doute),
+**facturée** puis **émise** (cf. *Facture* — dès qu'une *Facture* la rassemble, resp. une fois cette
+*Facture* finalisée). L'état par défaut étant *à refacturer*, c'est la **responsabilité du·de la
+_facturiste_** de vérifier les *Prestations* (montants élevés en priorité) et de mettre en attente les
+douteuses **avant** de créer les factures : il n'y a pas de garde-fou bloquant.
+_Éviter_ : « presta » seule (ambiguë à l'écrit) ; service ; confondre avec un *Geste commercial* ;
+**« en attente » pour désigner la file par défaut** (c'est *à refacturer* ; « en attente » est
+réservé au doute posé à la main par le·la *facturiste*).
 
 **Facturiste** :
 Rôle métier qui conduit la facturation mensuelle depuis Odoo et **vérifie les données avant

--- a/docs/adr/0012-prestation-etat-derive-mise-en-attente-opt-out.md
+++ b/docs/adr/0012-prestation-etat-derive-mise-en-attente-opt-out.md
@@ -1,0 +1,56 @@
+# Prestation : état dérivé et mise en attente manuelle (opt-out de la facturation automatique)
+
+Le·la *facturiste* a besoin d'un écran pour **vérifier les prestations avant facturation** (terme
+**Facturiste** dans `CONTEXT.md`) : repérer les montants élevés, et **écarter** les prestations
+douteuses de la facturation automatique le temps de lever le doute. On ajoute à
+`souscription.presta` (voir [ADR-0009](0009-prestation-refacturer-modele-independant-rassemble-sur-facture.md))
+un **état** affichable/groupables et une **mise en attente** manuelle, avec une sémantique
+**opt-out, sans garde-fou bloquant**.
+
+**Décision.**
+
+1. **`en_attente` : booléen manuel, posé par le·la facturiste.** Seule information *nouvelle* (non
+   dérivable) du modèle : « j'ai un doute, ne pas facturer pour l'instant ». C'est l'unique champ
+   ajouté que l'humain renseigne.
+
+2. **`etat` : Selection *stockée mais calculée*, dérivée — pas un doublon.** Valeurs ordonnées
+   `a_refacturer → en_attente → facturee → emise` (l'ordre pilote le tri des groupes). Calcul
+   `@api.depends('facture_id', 'facture_id.state', 'en_attente')` : `facture_id` **émise** →
+   `emise` ; `facture_id` posé (brouillon) → `facturee` ; sinon `en_attente` coché → `en_attente` ;
+   sinon `a_refacturer`. **Ne contredit pas** [ADR-0009 §4](0009-prestation-refacturer-modele-independant-rassemble-sur-facture.md) :
+   `facture_id` **reste** l'unique source de vérité du « facturé » ; `etat` ne fait que la *projeter*
+   pour le groupage et les stats (donc `facture_id` prime, l'`en_attente` d'une presta facturée est
+   ignoré et son toggle verrouillé). Stocké uniquement pour pouvoir grouper/filtrer/agréger côté SQL.
+
+3. **`a_refacturer` est l'état par défaut ; la vérification est *opt-out*, pas *opt-in*.** Toute
+   prestation est facturable tant qu'on ne l'a pas mise en attente. `souscription.creer_factures()`
+   balaie les prestations `facture_id IS NULL` **et** `not en_attente` — la méthode
+   `_facturer_prestations_en_attente` est renommée `_facturer_prestations_a_refacturer` (sa
+   sémantique : « rassembler ce qui est *à refacturer* », pas « en attente » — cf. la résolution de
+   collision de vocabulaire ci-dessous).
+
+4. **Aucun garde-fou bloquant.** Rien n'oblige à consulter l'écran avant `creer_factures` : une
+   prestation chère non vérifiée **se facturera**. C'est assumé — la responsabilité de vérifier
+   incombe au·à la *facturiste* (cohérent avec le principe « le processus principal d'abord, l'humain
+   tranche les cas limites dans l'instant »). L'atténuation est ergonomique (écran trié par prix
+   décroissant), pas systémique.
+
+## Résolution de collision de vocabulaire
+
+Avant cet ADR, le code employait « en attente » pour désigner la file `facture_id IS NULL`
+(`_facturer_prestations_en_attente`), alors que `CONTEXT.md` la nomme **à refacturer**. On tranche :
+**à refacturer** = la file par défaut ; **en attente** = la mise en attente manuelle sur doute. Le
+glossaire (`CONTEXT.md`, terme *Prestation*) et le nom de méthode sont alignés sur cette distinction.
+
+## Options écartées
+
+- **Opt-in / file d'approbation** (rien ne se facture sans validation explicite, presta par presta
+  ou par lot) : plus sûr, mais alourdit le processus mensuel et déplace le risque vers l'oubli de
+  validation. Écarté au profit de l'opt-out (KISS) — la majorité des prestations sont du
+  pass-through légitime ([ADR-0009 §6](0009-prestation-refacturer-modele-independant-rassemble-sur-facture.md)).
+- **`etat` comme champ Selection éditable** (au lieu de calculé) : permettrait un drag-and-drop
+  kanban entre colonnes, mais désynchronise l'état du `facture_id` — exactement le doublon que
+  [ADR-0009 §4](0009-prestation-refacturer-modele-independant-rassemble-sur-facture.md) refuse.
+  L'`etat` reste dérivé ; seul `en_attente` est éditable.
+- **Garde-fou bloquant** (interdire `creer_factures` tant que des prestations chères ne sont pas
+  visées) : surcoût et faux sentiment de sécurité ; non aligné avec le rôle *facturiste*.

--- a/models/core/souscription.py
+++ b/models/core/souscription.py
@@ -166,14 +166,16 @@ class Souscription(models.Model):
             # ce run, puis les flague (ADR 0009). Le flag les retire de la file,
             # donc les périodes suivantes ne les re-facturent pas.
             if premiere_facture:
-                souscription._facturer_prestations_en_attente(premiere_facture)
+                souscription._facturer_prestations_a_refacturer(premiere_facture)
 
-    def _facturer_prestations_en_attente(self, facture):
-        """Ajoute les prestations en attente (`facture_id` NULL) comme lignes de
-        `facture` et pose leur `facture_id`. Responsabilité de la Souscription,
-        pas de la Période (ADR 0009)."""
+    def _facturer_prestations_a_refacturer(self, facture):
+        """Ajoute les prestations *à refacturer* comme lignes de `facture` et
+        pose leur `facture_id`. Responsabilité de la Souscription, pas de la
+        Période (ADR 0009). Sont *à refacturer* les prestations sans facture et
+        non mises en attente : la mise en attente est un opt-out de la
+        facturation automatique (ADR 0012)."""
         self.ensure_one()
-        prestas = self.presta_ids.filtered(lambda p: not p.facture_id)
+        prestas = self.presta_ids.filtered(lambda p: not p.facture_id and not p.en_attente)
         if not prestas:
             return
         facture.write({'invoice_line_ids': [p._composer_ligne() for p in prestas]})

--- a/models/core/souscription_presta.py
+++ b/models/core/souscription_presta.py
@@ -1,4 +1,4 @@
-from odoo import fields, models
+from odoo import api, fields, models
 from odoo.exceptions import UserError
 
 
@@ -24,6 +24,37 @@ class SouscriptionPresta(models.Model):
     libelle = fields.Char(string='Libellé', required=True)
     prix = fields.Float(string='Prix (€)', help='Prix de refacturation ; peut être négatif (avoir/pénalité).')
     quantite = fields.Float(string='Quantité', default=1.0)
+
+    # Mise en attente manuelle par le·la facturiste sur un doute (ADR 0012) :
+    # opt-out de la facturation automatique. Tant que coché et non facturée, la
+    # prestation est exclue de creer_factures() (cf. _facturer_prestations_a_refacturer).
+    en_attente = fields.Boolean(string='En attente', default=False)
+
+    # État dérivé pour le groupage/les stats de l'écran de vérification (ADR 0012).
+    # L'ordre des valeurs pilote l'ordre des groupes. `facture_id` prime : il reste
+    # l'unique source de vérité du « facturé » (ADR 0009 §4) ; `etat` ne fait que la
+    # projeter. Stocké pour pouvoir grouper/filtrer/agréger côté SQL.
+    etat = fields.Selection(
+        [
+            ('a_refacturer', 'À refacturer'),
+            ('en_attente', 'En attente'),
+            ('facturee', 'Facturée'),
+            ('emise', 'Émise'),
+        ],
+        string='État',
+        compute='_compute_etat',
+        store=True,
+    )
+
+    @api.depends('facture_id', 'facture_id.state', 'en_attente')
+    def _compute_etat(self):
+        for presta in self:
+            if presta.facture_id:
+                presta.etat = 'emise' if presta.facture_id.state == 'posted' else 'facturee'
+            elif presta.en_attente:
+                presta.etat = 'en_attente'
+            else:
+                presta.etat = 'a_refacturer'
 
     # Marqueur « facturé » et unique lien Période-libre ↔ Facture : posé quand la
     # prestation est rassemblée sur une facture (ADR 0004, lien côté « plusieurs »).

--- a/tests/test_presta.py
+++ b/tests/test_presta.py
@@ -29,17 +29,60 @@ class TestPresta(SouscriptionsTestCase):
         base.update(vals)
         return self.env['souscription.presta'].create(base)
 
-    def test_presta_en_attente_ramassee_et_flaggee(self):
-        """Tracer bullet : une presta en attente atterrit sur la facture
-        mensuelle et reçoit son facture_id quand creer_factures() tourne."""
+    def test_presta_a_refacturer_ramassee_et_flaggee(self):
+        """Tracer bullet : une presta à refacturer (non mise en attente) atterrit
+        sur la facture mensuelle et reçoit son facture_id quand creer_factures()
+        tourne."""
         presta = self._presta(self.souscription_base)
         self.create_test_periode(self.souscription_base, provision_base_kwh=100.0)
-        self.assertFalse(presta.facture_id, 'en attente avant facturation')
+        self.assertFalse(presta.facture_id, 'à refacturer avant facturation')
 
         self.souscription_base.creer_factures()
 
         self.assertTrue(presta.facture_id, 'flaggée après facturation')
         self.assertIn('Déplacement technicien', presta.facture_id.invoice_line_ids.mapped('name'))
+
+    def test_presta_en_attente_exclue_de_la_facturation_auto(self):
+        """Opt-out (ADR 0012) : une prestation mise en attente par le·la
+        facturiste n'est PAS ramassée par creer_factures() — elle reste dans
+        la file, facture_id NULL."""
+        presta = self._presta(self.souscription_base, reference_enedis='F15-HOLD', en_attente=True)
+        self.create_test_periode(self.souscription_base, provision_base_kwh=100.0)
+
+        self.souscription_base.creer_factures()
+
+        self.assertFalse(presta.facture_id, 'la presta en attente reste hors facture')
+
+    def test_etat_a_refacturer_par_defaut(self):
+        """Sans facture ni mise en attente, l'état dérivé est « à refacturer »."""
+        presta = self._presta(self.souscription_base, reference_enedis='F15-ETAT-AR')
+        self.assertEqual(presta.etat, 'a_refacturer')
+
+    def test_etat_en_attente_quand_mise_en_attente(self):
+        """Mise en attente par le·la facturiste, pas encore facturée → « en attente »."""
+        presta = self._presta(self.souscription_base, reference_enedis='F15-ETAT-EA', en_attente=True)
+        self.assertEqual(presta.etat, 'en_attente')
+
+    def test_etat_facturee_sur_facture_brouillon(self):
+        """Ramassée sur une facture encore en brouillon → « facturée »."""
+        presta = self._presta(self.souscription_base, reference_enedis='F15-ETAT-FACT')
+        self.create_test_periode(self.souscription_base, provision_base_kwh=100.0)
+        self.souscription_base.creer_factures()
+        self.assertEqual(presta.facture_id.state, 'draft')
+        self.assertEqual(presta.etat, 'facturee')
+
+    def test_etat_emise_apres_emission_facture(self):
+        """Émission de la facture (brouillon → posted) : l'état dérivé passe
+        « facturée » → « émise » automatiquement (recalcul, pas de cron)."""
+        presta = self._presta(self.souscription_base, reference_enedis='F15-ETAT-EMISE')
+        self.create_test_periode(self.souscription_base, provision_base_kwh=100.0)
+        self.souscription_base.creer_factures()
+        self.assertEqual(presta.etat, 'facturee')
+
+        presta.facture_id.action_post()
+
+        self.assertEqual(presta.facture_id.state, 'posted')
+        self.assertEqual(presta.etat, 'emise')
 
     def test_composer_ligne_porte_libelle_prix_quantite(self):
         """La ligne composée porte libellé/prix/quantité de la presta et le
@@ -90,10 +133,12 @@ class TestPresta(SouscriptionsTestCase):
         self.souscription_base.creer_factures()
         facture = presta.facture_id
         self.assertTrue(facture)
+        self.assertEqual(presta.etat, 'facturee')
 
         facture.unlink()  # brouillon → suppression autorisée
 
         self.assertFalse(presta.facture_id, 'remise dans la file après suppression de la facture')
+        self.assertEqual(presta.etat, 'a_refacturer', 'état dérivé recalculé : de retour dans la file')
 
     @mute_logger('odoo.sql_db')
     def test_reference_enedis_unique(self):
@@ -108,15 +153,15 @@ class TestPresta(SouscriptionsTestCase):
 @tagged('souscriptions', 'souscriptions_presta', 'post_install', '-at_install')
 class TestDemoPrestas(TransactionCase):
     """Les prestations de démonstration illustrent la file « à refacturer » :
-    en attente (positive et négative) et déjà facturée."""
+    à refacturer (positive et négative) et déjà facturée."""
 
     def test_demo_prestas_etats_file_et_facturee(self):
-        en_attente = self.env.ref('souscriptions_odoo.demo_presta_mise_en_service', raise_if_not_found=False)
-        if not en_attente:
+        a_refacturer = self.env.ref('souscriptions_odoo.demo_presta_mise_en_service', raise_if_not_found=False)
+        if not a_refacturer:
             self.skipTest('Données de démo non chargées')
 
-        # En attente : pas de facture (dans la file)
-        self.assertFalse(en_attente.facture_id)
+        # À refacturer : pas de facture (dans la file)
+        self.assertFalse(a_refacturer.facture_id)
 
         # Montant négatif : pénalité de coupure
         negative = self.env.ref('souscriptions_odoo.demo_presta_penalite_coupure')


### PR DESCRIPTION
Closes #43.

Première tranche de l'écran de vérification des prestations : le **contrat de comportement** (modèle + facturation), avant la vue (#44).

## Ce que ça fait

- **`en_attente`** — booléen éditable : la mise en attente d'une prestation par le·la *facturiste* sur un doute.
- **`etat`** — Selection calculée *stockée* (`à refacturer → en attente → facturée → émise`). `facture_id` prime et reste l'unique source de vérité du « facturé » (ADR 0009 §4) ; `etat` ne fait que la projeter pour le groupage/les stats. Recalcul automatique au passage brouillon → émise (pas de cron).
- **Opt-out de la facturation auto** : `creer_factures()` ignore les prestations en attente. Méthode renommée `_facturer_prestations_en_attente` → `_facturer_prestations_a_refacturer`. Pas de garde-fou bloquant : c'est la responsabilité du·de la facturiste de vérifier avant de facturer.

## Décision

[ADR-0012](docs/adr/0012-prestation-etat-derive-mise-en-attente-opt-out.md) (état dérivé, mise en attente, opt-out) + mise à jour du glossaire `CONTEXT.md` (résolution de la collision « en attente » vs « à refacturer »).

## Tests

7 cycles TDD (opt-out, les 4 états, recalcul à l'émission, retour en file à la suppression de la facture). Suite complète **134/134** verte.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
