### PR TITLE
feat(presta): écran de vérification des prestations (liste groupée par état)

### DIFF
--- a/__manifest__.py
+++ b/__manifest__.py
@@ -44,6 +44,7 @@ de facturation via son API.
         'views/core/souscription_views.xml',
         'views/core/grille_prix_views.xml',
         'views/core/souscriptions_periode_views.xml',
+        'views/core/souscription_presta_views.xml',
         'views/core/souscription_portal_menu.xml',
         'views/portal_templates.xml',
         'views/raccordement/raccordement_demande_views.xml',

--- a/tests/test_presta.py
+++ b/tests/test_presta.py
@@ -140,6 +140,19 @@ class TestPresta(SouscriptionsTestCase):
         self.assertFalse(presta.facture_id, 'remise dans la file après suppression de la facture')
         self.assertEqual(presta.etat, 'a_refacturer', 'état dérivé recalculé : de retour dans la file')
 
+    def test_action_prestations_groupe_par_etat(self):
+        """L'écran de vérification : une action Prestations existe, sur le bon
+        modèle, et s'ouvre groupée par état (stats par groupe)."""
+        action = self.env.ref('souscriptions_odoo.action_souscription_presta')
+        self.assertEqual(action.res_model, 'souscription.presta')
+        self.assertIn('list', action.view_mode)
+        self.assertIn('search_default_group_etat', action.context or '')
+
+    def test_menu_prestations_sous_souscriptions(self):
+        """Le menu « Prestations » est rangé sous la racine Souscriptions."""
+        menu = self.env.ref('souscriptions_odoo.menu_souscription_presta')
+        self.assertEqual(menu.parent_id, self.env.ref('souscriptions_odoo.menu_souscription_root'))
+
     @mute_logger('odoo.sql_db')
     def test_reference_enedis_unique(self):
         """Deux prestations ne peuvent partager la même référence Enedis : c'est

--- a/views/core/souscription_presta_views.xml
+++ b/views/core/souscription_presta_views.xml
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <!-- Écran de vérification des prestations (ADR 0012) : liste groupée par
+         état, triée par prix décroissant, le prix sommé par groupe servant de
+         stats. Le·la facturiste met en attente (toggle) les prestations
+         douteuses avant de créer les factures. -->
+    <record id="view_souscription_presta_list" model="ir.ui.view">
+        <field name="name">souscription.presta.list</field>
+        <field name="model">souscription.presta</field>
+        <field name="arch" type="xml">
+            <list string="Prestations" default_order="prix desc">
+                <field name="souscription_id"/>
+                <field name="pdl"/>
+                <field name="reference_enedis"/>
+                <field name="code_enedis"/>
+                <field name="libelle"/>
+                <field name="quantite"/>
+                <field name="prix" sum="Total"/>
+                <!-- Toggle de mise en attente, verrouillé une fois la prestation
+                     sur une facture (l'état prime alors, ADR 0012). -->
+                <field name="en_attente" widget="boolean_toggle" readonly="facture_id != False"/>
+                <field name="facture_id"/>
+                <field name="etat" widget="badge"
+                       decoration-warning="etat == 'en_attente'"
+                       decoration-success="etat == 'emise'"/>
+            </list>
+        </field>
+    </record>
+
+    <record id="view_souscription_presta_form" model="ir.ui.view">
+        <field name="name">souscription.presta.form</field>
+        <field name="model">souscription.presta</field>
+        <field name="arch" type="xml">
+            <form>
+                <sheet>
+                    <group>
+                        <group string="Prestation">
+                            <field name="souscription_id"/>
+                            <field name="pdl"/>
+                            <field name="reference_enedis"/>
+                            <field name="code_enedis"/>
+                            <field name="libelle"/>
+                        </group>
+                        <group string="Refacturation">
+                            <field name="quantite"/>
+                            <field name="prix"/>
+                            <field name="etat"/>
+                            <field name="en_attente" widget="boolean_toggle" readonly="facture_id != False"/>
+                            <field name="facture_id"/>
+                        </group>
+                    </group>
+                </sheet>
+            </form>
+        </field>
+    </record>
+
+    <record id="view_souscription_presta_search" model="ir.ui.view">
+        <field name="name">souscription.presta.search</field>
+        <field name="model">souscription.presta</field>
+        <field name="arch" type="xml">
+            <search>
+                <field name="reference_enedis"/>
+                <field name="libelle"/>
+                <field name="souscription_id"/>
+                <field name="pdl"/>
+                <filter string="À refacturer" name="etat_a_refacturer" domain="[('etat', '=', 'a_refacturer')]"/>
+                <filter string="En attente" name="etat_en_attente" domain="[('etat', '=', 'en_attente')]"/>
+                <filter string="Facturée" name="etat_facturee" domain="[('etat', '=', 'facturee')]"/>
+                <filter string="Émise" name="etat_emise" domain="[('etat', '=', 'emise')]"/>
+                <separator/>
+                <filter string="Avoirs (montant négatif)" name="avoirs" domain="[('prix', '&lt;', 0)]"/>
+                <group>
+                    <filter name="group_etat" string="État" context="{'group_by': 'etat'}"/>
+                    <filter name="group_souscription" string="Souscription" context="{'group_by': 'souscription_id'}"/>
+                </group>
+            </search>
+        </field>
+    </record>
+
+    <record id="action_souscription_presta" model="ir.actions.act_window">
+        <field name="name">Prestations</field>
+        <field name="res_model">souscription.presta</field>
+        <field name="view_mode">list,form</field>
+        <field name="search_view_id" ref="view_souscription_presta_search"/>
+        <field name="context">{'search_default_group_etat': 1}</field>
+    </record>
+
+    <menuitem
+        id="menu_souscription_presta"
+        name="Prestations"
+        parent="menu_souscription_root"
+        action="action_souscription_presta"
+        sequence="30"/>
+</odoo>

--- a/views/core/souscription_views.xml
+++ b/views/core/souscription_views.xml
@@ -69,7 +69,11 @@
                                     <field name="libelle"/>
                                     <field name="quantite"/>
                                     <field name="prix"/>
+                                    <field name="en_attente" widget="boolean_toggle" readonly="facture_id != False"/>
                                     <field name="facture_id" readonly="1"/>
+                                    <field name="etat" widget="badge"
+                                           decoration-warning="etat == 'en_attente'"
+                                           decoration-success="etat == 'emise'"/>
                                 </list>
                             </field>
                         </page>


### PR DESCRIPTION
Closes #44.

L'écran de vérification des prestations pour le·la *facturiste*. **Empilée sur #43** (base = `feat/43-presta-en-attente`) : à rebaser sur `main` une fois #43 fusionnée.

## Ce que ça fait

- **Liste groupée par état** (par défaut), triée par **prix décroissant**, le **prix sommé par groupe** servant de stats par état (à refacturer / en attente / facturée / émise) — voir capture.
- **Toggle « En attente »** (`boolean_toggle`) pour mettre/retirer de la file en un clic, **verrouillé** dès que la prestation est sur une facture.
- **Recherche** : filtres par état + « Avoirs (montant négatif) » + group-by souscription.
- **Action + menu « Prestations »** sous la racine Souscriptions.
- **Onglet Prestations** de la Souscription : ajout de l'état (badge) + du toggle, par cohérence.

## Suivi possible

L'ordre des groupes suit `prix desc` (les bandes se trient aussi par montant). Si l'on veut forcer « à refacturer / en attente » toujours en tête, c'est un ajustement d'ordre à part.

## Tests

2 cycles de câblage (action groupée par état, menu) + validation à l'installation (expression `readonly`, domaine du filtre avoirs, décorations, contexte). Suite complète **134/134** verte.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
