### PR TITLE
feat(presta): TVA des prestations par nature via le produit (#38)

### DIFF
--- a/data/produits_prestation.xml
+++ b/data/produits_prestation.xml
@@ -11,5 +11,22 @@
         <field name="purchase_ok" eval="False"/>
         <field name="list_price">0.0</field>
         <field name="standard_price">0.0</field>
+        <field name="taxes_id" eval="[(6, 0, [])]"/>
+    </record>
+
+    <!-- Indemnité Enedis (#38 / ADR 0009 §5) : nature « indemnité » des prestations
+         (pénalité de coupure due par Enedis…), hors champ TVA. Produit distinct du
+         précédent uniquement pour porter un régime de TVA différent : la TVA suit le
+         produit, jamais un override de ligne. Le module livre les deux produits sans
+         taxe (pass-through) ; le·la comptable y rattache en prod la TVA réelle (0 % /
+         exonéré pour l'indemnité, afin que la base atterrisse dans la bonne case CA3). -->
+    <record id="souscriptions_product_indemnite_enedis" model="product.product">
+        <field name="name">Indemnité Enedis</field>
+        <field name="type">service</field>
+        <field name="sale_ok" eval="True"/>
+        <field name="purchase_ok" eval="False"/>
+        <field name="list_price">0.0</field>
+        <field name="standard_price">0.0</field>
+        <field name="taxes_id" eval="[(6, 0, [])]"/>
     </record>
 </odoo>

--- a/demo/prestations_demo.xml
+++ b/demo/prestations_demo.xml
@@ -29,6 +29,8 @@
             <field name="libelle">Pénalité de coupure (due par Enedis)</field>
             <field name="prix">-30.00</field>
             <field name="quantite">1</field>
+            <!-- Indemnité : hors champ TVA (#38 / ADR 0009 §5) → produit Indemnité -->
+            <field name="nature">indemnite</field>
         </record>
 
         <!-- Déjà facturée : rattachée à la facture mars (brouillon, éditable) -->

--- a/docs/adr/0009-prestation-refacturer-modele-independant-rassemble-sur-facture.md
+++ b/docs/adr/0009-prestation-refacturer-modele-independant-rassemble-sur-facture.md
@@ -11,8 +11,8 @@ fait mensuel mais un **en-cours refacturable** à cadence Enedis.
 **Décision.**
 
 1. **Modèle indépendant de la Période.** `souscription.presta` porte `code_enedis`, `libelle`,
-   `prix`, `quantite`, le taux de **TVA issu du F15**, un `souscription_id` (M2o) et un
-   `facture_id` (M2o). Aucun lien vers `souscription.periode`.
+   `prix`, `quantite`, sa **nature** (`prestation` taxée / `indemnite` hors champ TVA, cf. §5),
+   un `souscription_id` (M2o) et un `facture_id` (M2o). Aucun lien vers `souscription.periode`.
 
 2. **Alimenté par electricore, dédupliqué par référence Enedis.** Les prestations sont
    **tirées en totalité** d'un endpoint electricore dédié (le volume est faible — ~une par PDL),
@@ -36,10 +36,14 @@ fait mensuel mais un **en-cours refacturable** à cadence Enedis.
    supprimer une facture (échappatoire de correction de l'[ADR-0007](0007-snapshot-periode-type-verrou-facturation.md))
    **re-met les prestations dans la file**.
 
-5. **Plomberie comptable minimale.** Un **produit générique unique**
-   (`souscriptions_product_prestation_enedis`) porte le compte de produits ; la **TVA vient du
-   F15** par presta (pas du défaut produit) ; la ligne **surcharge** name/price_unit/quantity
-   depuis la presta. Pas de catalogue produit par code Enedis.
+5. **Plomberie comptable minimale, la TVA suit le produit choisi par la nature** (amendée par
+   #38, cf. ci-dessous). Deux **produits génériques** portent le compte de produits **et le régime
+   de TVA** : `souscriptions_product_prestation_enedis` (prestation taxée) et
+   `souscriptions_product_indemnite_enedis` (indemnité hors champ TVA — pénalité de coupure…). La
+   `nature` de la presta choisit le produit ; la **ligne hérite de la TVA du produit** via le
+   mécanisme Odoo standard (`_compute_tax_ids` + position fiscale), **sans override de `tax_ids`**.
+   La ligne **surcharge** seulement name/price_unit/quantity depuis la presta. Pas de catalogue
+   produit par code Enedis, pas de taux de TVA par presta.
 
 6. **Refacturation à prix coûtant, une seule source de prix.** `prix` = prix de refacturation,
    par défaut le prix F15 (pass-through, marge nulle — « on n'est pas des voleurs »). **Pas** de
@@ -74,3 +78,26 @@ porté comme **ligne signée** qui se nette dans la facture mensuelle.
   du·de la *facturiste* dans l'instant. À retracker en issue dédiée.
 - **PDL orphelins** (prestation pour un PDL sans souscription active) : ignorés au sync en v1 ;
   les rendre visibles « à rattacher » est une évolution.
+
+## Amendement (#38) — la TVA suit le produit, par *nature* (pas un taux par presta)
+
+La décision initiale (#8) prévoyait un **taux de TVA par presta, issu du F15**, appliqué en
+surchargeant `tax_ids` sur la ligne. En préparant l'implémentation, deux problèmes :
+
+1. **Impédance taux → enregistrement.** Le F15 donne un *taux* (un nombre) ; Odoo facture avec un
+   `account.tax` *configuré par le·la comptable* (bons comptes de taxe, bonnes grilles CA3).
+   Résoudre « 20 % » → « la bonne taxe » par le montant est fragile (plusieurs taxes au même taux).
+2. **Court-circuit des positions fiscales.** Forcer `tax_ids` sur la ligne contourne
+   `_compute_tax_ids → fiscal_position.map_tax` (clients exonérés / DOM-TOM / autoliquidation).
+
+**Résolution.** La TVA n'est plus un champ de la presta : elle vient du **produit**, comme pour les
+lignes d'énergie (qui ne posent déjà aucun `tax_ids`). Le sync ne résout plus un taux mais classe la
+presta dans une **nature** (`prestation` / `indemnite`), qui choisit le produit ; chaque produit
+porte la taxe que le·la comptable a configurée. Un produit unique ne suffit pas car les
+**indemnités** (pénalités de coupure dues par Enedis) sont **hors champ TVA**, régime distinct des
+prestations taxées — d'où deux produits. Le module les livre tous deux **sans taxe** (pass-through,
+`taxes_id = []`) ; le·la comptable y rattache en prod la TVA réelle (p. ex. 20 % sur la prestation,
+0 %/exonéré sur l'indemnité pour que la base atterrisse dans la bonne case CA3).
+
+Bénéfices : plus de mapping taux→enregistrement, positions fiscales respectées, et la « TVA pas
+depuis le défaut produit » d'origine devient « TVA *depuis* le bon produit, choisi par nature ».

--- a/models/core/souscription_presta.py
+++ b/models/core/souscription_presta.py
@@ -25,6 +25,21 @@ class SouscriptionPresta(models.Model):
     prix = fields.Float(string='Prix (€)', help='Prix de refacturation ; peut être négatif (avoir/pénalité).')
     quantite = fields.Float(string='Quantité', default=1.0)
 
+    # Régime de TVA porté par la *nature*, pas par un taux par presta (ADR 0009 §5).
+    # La nature choisit le produit de refacturation ; la TVA suit le produit
+    # (configuré par le·la comptable), jamais un override de ligne — on ne
+    # contourne donc pas les positions fiscales. Les `indemnité` (pénalités de
+    # coupure dues par Enedis) sont hors champ TVA. Alimenté par le sync F15 (#37).
+    nature = fields.Selection(
+        [
+            ('prestation', 'Prestation (TVA)'),
+            ('indemnite', 'Indemnité (sans TVA)'),
+        ],
+        string='Nature',
+        default='prestation',
+        required=True,
+    )
+
     # Mise en attente manuelle par le·la facturiste sur un doute (ADR 0012) :
     # opt-out de la facturation automatique. Tant que coché et non facturée, la
     # prestation est exclue de creer_factures() (cf. _facturer_prestations_a_refacturer).
@@ -69,7 +84,17 @@ class SouscriptionPresta(models.Model):
     )
 
     def _get_produit_prestation(self):
-        produit = self.env.ref('souscriptions_odoo.souscriptions_product_prestation_enedis', raise_if_not_found=False)
+        """Produit de refacturation porté par la *nature* (ADR 0009 §5) : il
+        porte le compte de produits **et la TVA** (prestation taxée vs indemnité
+        hors champ). La ligne hérite de cette TVA via le produit ; pas de taux
+        par presta, pas d'override de ligne."""
+        self.ensure_one()
+        xmlid = (
+            'souscriptions_odoo.souscriptions_product_indemnite_enedis'
+            if self.nature == 'indemnite'
+            else 'souscriptions_odoo.souscriptions_product_prestation_enedis'
+        )
+        produit = self.env.ref(xmlid, raise_if_not_found=False)
         if not produit:
             raise UserError('Produit générique de prestation non trouvé')
         return produit

--- a/tests/test_presta.py
+++ b/tests/test_presta.py
@@ -96,6 +96,47 @@ class TestPresta(SouscriptionsTestCase):
         produit = self.env.ref('souscriptions_odoo.souscriptions_product_prestation_enedis')
         self.assertEqual(vals['product_id'], produit.id)
 
+    def test_composer_ligne_indemnite_utilise_produit_sans_tva(self):
+        """Une presta de nature « indemnité » (pénalité hors champ TVA) compose
+        sa ligne avec le produit Indemnité dédié, pas le produit Prestation
+        (TVA). La TVA suit le produit choisi par la nature (ADR 0009), jamais un
+        override de ligne."""
+        presta = self._presta(self.souscription_base, reference_enedis='F15-IND', nature='indemnite')
+        _cmd, _id, vals = presta._composer_ligne()
+
+        produit_indemnite = self.env.ref('souscriptions_odoo.souscriptions_product_indemnite_enedis')
+        self.assertEqual(vals['product_id'], produit_indemnite.id)
+
+    def test_facture_postee_porte_la_tva_du_produit_par_nature(self):
+        """Sur une facture posée : la ligne d'une presta « prestation » hérite de
+        la TVA configurée sur le produit Prestation ; la ligne d'une « indemnité »
+        n'en porte aucune (hors champ). La TVA vient du produit (ADR 0009 §5),
+        jamais d'un override de ligne — et la facture se pose proprement."""
+        tva = self.env['account.tax'].create(
+            {'name': 'TVA F15 20%', 'amount': 20.0, 'amount_type': 'percent', 'type_tax_use': 'sale'}
+        )
+        self.env.ref('souscriptions_odoo.souscriptions_product_prestation_enedis').taxes_id = tva
+
+        self._presta(self.souscription_base, reference_enedis='F15-TVA', libelle='Déplacement', prix=50.0)
+        self._presta(
+            self.souscription_base,
+            reference_enedis='F15-IND2',
+            libelle='Pénalité coupure',
+            prix=-30.0,
+            nature='indemnite',
+        )
+        self.create_test_periode(self.souscription_base, provision_base_kwh=100.0)
+
+        self.souscription_base.creer_factures()
+        facture = self.souscription_base.presta_ids.filtered(lambda p: p.reference_enedis == 'F15-TVA').facture_id
+        facture.action_post()
+
+        self.assertEqual(facture.state, 'posted', 'la facture avec lignes prestation + indemnité se pose')
+        ligne_presta = facture.invoice_line_ids.filtered(lambda l: l.name == 'Déplacement')
+        ligne_indemnite = facture.invoice_line_ids.filtered(lambda l: l.name == 'Pénalité coupure')
+        self.assertEqual(ligne_presta.tax_ids, tva, 'la prestation hérite de la TVA du produit')
+        self.assertFalse(ligne_indemnite.tax_ids, "l'indemnité reste hors champ TVA")
+
     def test_presta_negative_se_nette_dans_la_facture(self):
         """Une prestation négative (pénalité de coupure due par Enedis) atterrit
         comme ligne négative sur la facture mensuelle."""

--- a/views/core/souscription_presta_views.xml
+++ b/views/core/souscription_presta_views.xml
@@ -14,6 +14,7 @@
                 <field name="reference_enedis"/>
                 <field name="code_enedis"/>
                 <field name="libelle"/>
+                <field name="nature"/>
                 <field name="quantite"/>
                 <field name="prix" sum="Total"/>
                 <!-- Toggle de mise en attente, verrouillé une fois la prestation
@@ -42,6 +43,7 @@
                             <field name="libelle"/>
                         </group>
                         <group string="Refacturation">
+                            <field name="nature"/>
                             <field name="quantite"/>
                             <field name="prix"/>
                             <field name="etat"/>
@@ -69,8 +71,10 @@
                 <filter string="Émise" name="etat_emise" domain="[('etat', '=', 'emise')]"/>
                 <separator/>
                 <filter string="Avoirs (montant négatif)" name="avoirs" domain="[('prix', '&lt;', 0)]"/>
+                <filter string="Indemnités (hors TVA)" name="nature_indemnite" domain="[('nature', '=', 'indemnite')]"/>
                 <group>
                     <filter name="group_etat" string="État" context="{'group_by': 'etat'}"/>
+                    <filter name="group_nature" string="Nature" context="{'group_by': 'nature'}"/>
                     <filter name="group_souscription" string="Souscription" context="{'group_by': 'souscription_id'}"/>
                 </group>
             </search>


### PR DESCRIPTION
Closes #38.

## Pivot par rapport à l'issue
L'issue prévoyait un champ `tax_id` (M2o `account.tax`) par presta et un override de `tax_ids` sur la ligne. **Volontairement non implémenté tel quel** : ça rouvrait deux trous —
1. **impédance taux → enregistrement** : le F15 donne un taux, Odoo facture avec un `account.tax` configuré par le·la comptable (comptes/grilles CA3) ; matcher par montant est fragile ;
2. **court-circuit des positions fiscales** : forcer `tax_ids` contourne `fiscal_position.map_tax` (exonérés / DOM-TOM / autoliquidation).

## À la place : la TVA suit le produit, choisi par la *nature*
- `nature` (`prestation` taxée / `indemnite` hors champ) sur `souscription.presta` ; `_get_produit_prestation()` choisit le produit.
- Deux produits génériques (`…_prestation_enedis`, `…_indemnite_enedis`), un par régime de TVA — un seul ne suffit pas, les indemnités (pénalité de coupure) sont hors champ.
- La ligne **hérite** de la TVA du produit via le mécanisme Odoo standard, comme les lignes d'énergie : **pas d'override**, positions fiscales respectées.
- Les deux produits sont livrés **sans taxe** (pass-through, `taxes_id = []`) → déterministe (pas de fuite du défaut société).
- `nature` visible en liste/formulaire + filtre & group-by Indemnités ; demo pénalité → `indemnite`.
- ADR 0009 amendée (§1, §5 + note d'amendement).

## Tests (TDD)
- `test_composer_ligne_indemnite_utilise_produit_sans_tva` — la nature choisit le produit.
- `test_facture_postee_porte_la_tva_du_produit_par_nature` — facture posée : ligne prestation = TVA du produit, ligne indemnité = aucune, la facture se pose proprement.
- Back-compat couverte par le test composer existant (défaut `prestation`).
- Suite complète : **0 failed, 0 error of 134 tests**.

## Suites opérationnelles (hors code)
- En prod, le·la comptable rattache la TVA réelle aux deux produits (p. ex. 20 % prestation, 0 %/exonéré indemnité).
- Le sync F15 (#37) doit positionner `nature` depuis le code Enedis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)