### PR TITLE
feat(releve): relevés d'index justificatifs de la Période (#54 #55 #56 #57)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -43,9 +43,29 @@ travail facturable** : amorcé par les quantités calculées par electricore (m�
 le flux Enedis manque, *gestes commerciaux*, ajustements. À la facturation, ses valeurs (quantités
 par cadran, jours, puissance, taxes) sont **figées** (historisation) et liées à la facture. Porte
 ce qui est **facturé** — pas une copie du coût réseau ; la marge se calcule à la demande côté
-analytique en rejouant electricore.
+analytique en rejouant electricore. Elle est la **source analytique** typée : ses champs se lisent
+et s'agrègent **directement**, jamais reconstruits depuis les lignes de facture (`ligne → produit →
+catégorie`) ; la *Facture* en est une **projection** (dérive manuelle bornée tolérée, ADR 0014).
 _Éviter_ : méta-période (concept amont, côté electricore), mois ; « instantané fidèle » (la Période
 est un brouillon facturable, pas une copie figée d'electricore).
+
+**Relevé (d'index)** :
+Événement de lecture **daté** du compteur, enfant d'une *Période* (`souscription.releve`,
+`periode_id`). Porte un **index** (compteur cumulé) **par cadran réseau** — même axe *mesuré* que
+les `energie_*` (registres physiques : HPH/HPB/HCH/HCB, ou HP/HC, ou Base selon le *calendrier de
+comptage*), jamais par cadran **facturé**. Consigne **tous les index qu'electricore a utilisés**
+pour le calcul d'énergie de la Période — **obligation légale** sur la *Facture* et support de
+**vérification** par le·la *souscripteur·rice*. Chaque relevé déclare sa **nature** : *réel*
+(mesure Enedis) ou *estimé* (estimation electricore ou *facturiste*), étiquetée sur la facture.
+**Figé** avec le snapshot de la Période et verrouillé après facturation (ADR 0006/0014) ; le relevé
+**frontière** est dupliqué entre deux Périodes consécutives — assumé : chaque facture est
+auto-portante. Source : electricore (pull, ADR 0011), saisi à la main par le·la *facturiste* tant
+que l'intégration manque (#12). C'est un **justificatif**, pas la quantité facturée : l'énergie
+facturée reste pilotée par `energie_*`/provision (un contrat *lissé* facture la provision, pas
+`fin − début`).
+_Éviter_ : confondre **index** (la valeur cumulée d'un registre) et **relevé** (l'événement daté qui
+en porte plusieurs) ; confondre avec `energie_*` (la *consommation* dérivée des relevés) ; cadran
+facturé.
 
 **Grille de prix** :
 Barème **fournisseur** daté (`grille.prix`) : prix d'abonnement par puissance, prix de l'énergie

--- a/__manifest__.py
+++ b/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Souscriptions Électricité',
-    'version': '19.0.1.3.0',
+    'version': '19.0.1.4.0',
     'depends': ['base', 'mail', 'contacts', 'account', 'portal'],
     'author': 'Virgile Daugé',
     'category': 'Energy',

--- a/demo/souscriptions_demo.xml
+++ b/demo/souscriptions_demo.xml
@@ -4,7 +4,7 @@
         <!-- ================================ -->
         <!-- CLIENTS DE DÉMONSTRATION        -->
         <!-- ================================ -->
-        
+
         <!-- Client particulier BASE -->
         <record id="demo_client_particulier_base" model="res.partner">
             <field name="name">Marie Dupont</field>
@@ -16,7 +16,7 @@
             <field name="email">marie.dupont@email.fr</field>
             <field name="phone">02.99.12.34.56</field>
         </record>
-        
+
         <!-- Client particulier HP/HC -->
         <record id="demo_client_particulier_hphc" model="res.partner">
             <field name="name">Jean Martin</field>
@@ -28,7 +28,7 @@
             <field name="email">jean.martin@email.fr</field>
             <field name="phone">02.40.78.90.12</field>
         </record>
-        
+
         <!-- Client PRO -->
         <record id="demo_client_pro" model="res.partner">
             <field name="name">Boulangerie Bio du Coin</field>
@@ -40,7 +40,7 @@
             <field name="email">contact@boulangerie-bio.fr</field>
             <field name="phone">02.99.56.78.90</field>
         </record>
-        
+
         <!-- Client solidaire -->
         <record id="demo_client_solidaire" model="res.partner">
             <field name="name">Sophie Leroy</field>
@@ -52,11 +52,11 @@
             <field name="email">sophie.leroy@email.fr</field>
             <field name="phone">02.97.34.56.78</field>
         </record>
-        
+
         <!-- ================================ -->
         <!-- SOUSCRIPTIONS DE DÉMONSTRATION  -->
         <!-- ================================ -->
-        
+
         <!-- Souscription particulier BASE 6 kVA -->
         <record id="demo_souscription_particulier_base" model="souscription.souscription">
             <field name="partner_id" ref="demo_client_particulier_base"/>
@@ -70,7 +70,7 @@
             <field name="etat_facturation_id" ref="etat_a_facturer"/>
             <field name="ref_compteur">85234567</field>
         </record>
-        
+
         <!-- Souscription particulier HP/HC 9 kVA -->
         <record id="demo_souscription_particulier_hphc" model="souscription.souscription">
             <field name="partner_id" ref="demo_client_particulier_hphc"/>
@@ -84,7 +84,7 @@
             <field name="etat_facturation_id" ref="etat_a_facturer"/>
             <field name="ref_compteur">85987654</field>
         </record>
-        
+
         <!-- Souscription PRO avec majoration -->
         <record id="demo_souscription_pro" model="souscription.souscription">
             <field name="partner_id" ref="demo_client_pro"/>
@@ -99,7 +99,7 @@
             <field name="etat_facturation_id" ref="etat_a_facturer"/>
             <field name="ref_compteur">85123456</field>
         </record>
-        
+
         <!-- Souscription solidaire -->
         <record id="demo_souscription_solidaire" model="souscription.souscription">
             <field name="partner_id" ref="demo_client_solidaire"/>
@@ -114,7 +114,7 @@
             <field name="etat_facturation_id" ref="etat_a_facturer"/>
             <field name="ref_compteur">85111222</field>
         </record>
-        
+
         <!-- Souscription pour l'administrateur (portal testing) -->
         <record id="demo_souscription_admin" model="souscription.souscription">
             <field name="partner_id" ref="base.partner_admin"/>
@@ -129,11 +129,11 @@
             <field name="ref_compteur">85999888</field>
             <field name="numero_depannage">09 726 750 35</field>
         </record>
-        
+
         <!-- ================================ -->
         <!-- PÉRIODES DE DÉMONSTRATION       -->
         <!-- ================================ -->
-        
+
         <!-- Période janvier 2024 - Particulier BASE -->
         <record id="demo_periode_janvier_base" model="souscription.periode">
             <field name="souscription_id" ref="demo_souscription_particulier_base"/>
@@ -145,7 +145,7 @@
             <field name="turpe_fixe">8.50</field>
             <field name="turpe_variable">12.30</field>
         </record>
-        
+
         <!-- Période février 2024 - Particulier BASE -->
         <record id="demo_periode_fevrier_base" model="souscription.periode">
             <field name="souscription_id" ref="demo_souscription_particulier_base"/>
@@ -157,7 +157,7 @@
             <field name="turpe_fixe">8.50</field>
             <field name="turpe_variable">13.75</field>
         </record>
-        
+
         <!-- Période mars 2024 - Particulier HP/HC -->
         <record id="demo_periode_mars_hphc" model="souscription.periode">
             <field name="souscription_id" ref="demo_souscription_particulier_hphc"/>
@@ -175,7 +175,7 @@
             <field name="turpe_fixe">12.75</field>
             <field name="turpe_variable">18.20</field>
         </record>
-        
+
         <!-- Période février 2024 - PRO -->
         <record id="demo_periode_fevrier_pro" model="souscription.periode">
             <field name="souscription_id" ref="demo_souscription_pro"/>
@@ -186,7 +186,7 @@
             <field name="turpe_fixe">18.90</field>
             <field name="turpe_variable">32.50</field>
         </record>
-        
+
         <!-- Période avril 2024 - Solidaire -->
         <record id="demo_periode_avril_solidaire" model="souscription.periode">
             <field name="souscription_id" ref="demo_souscription_solidaire"/>
@@ -198,11 +198,11 @@
             <field name="turpe_fixe">4.25</field>
             <field name="turpe_variable">6.80</field>
         </record>
-        
+
         <!-- ================================ -->
         <!-- PÉRIODES ADMIN (PORTAL TESTING) -->
         <!-- ================================ -->
-        
+
         <!-- Période janvier 2024 - Admin -->
         <record id="demo_periode_janvier_admin" model="souscription.periode">
             <field name="souscription_id" ref="demo_souscription_admin"/>
@@ -220,7 +220,7 @@
             <field name="turpe_fixe">8.50</field>
             <field name="turpe_variable">14.20</field>
         </record>
-        
+
         <!-- Période février 2024 - Admin -->
         <record id="demo_periode_fevrier_admin" model="souscription.periode">
             <field name="souscription_id" ref="demo_souscription_admin"/>
@@ -238,7 +238,7 @@
             <field name="turpe_fixe">8.50</field>
             <field name="turpe_variable">16.10</field>
         </record>
-        
+
         <!-- Période mars 2024 - Admin -->
         <record id="demo_periode_mars_admin" model="souscription.periode">
             <field name="souscription_id" ref="demo_souscription_admin"/>
@@ -256,11 +256,123 @@
             <field name="turpe_fixe">8.50</field>
             <field name="turpe_variable">13.90</field>
         </record>
-        
+
+        <!-- ================================ -->
+        <!-- RELEVÉS D'INDEX (ADR 0015)      -->
+        <!-- ================================ -->
+        <!-- ORDRE DE CHARGEMENT CRITIQUE : ces relevés sont définis AVANT les
+             factures admin (plus bas). Le verrou #56 rejette tout relevé créé /
+             modifié sur une Période DÉJÀ facturée ; les relevés des périodes
+             facturées doivent donc être chargés tant que ces périodes sont encore
+             libres. Déplacer ce bloc après les factures casserait l'install démo. -->
+
+        <!-- Période NON facturée — Base, cas normal (2 relevés début/fin) ;
+             restent éditables (aucune facture ne les référence). Conso = 10265−10000 = 265. -->
+        <record id="demo_releve_janvier_base_debut" model="souscription.releve">
+            <field name="periode_id" ref="demo_periode_janvier_base"/>
+            <field name="date">2024-01-01</field>
+            <field name="nature">reel</field>
+            <field name="index_base">10000</field>
+        </record>
+        <record id="demo_releve_janvier_base_fin" model="souscription.releve">
+            <field name="periode_id" ref="demo_periode_janvier_base"/>
+            <field name="date">2024-01-31</field>
+            <field name="nature">reel</field>
+            <field name="index_base">10265</field>
+        </record>
+
+        <!-- Période NON facturée — Base, CHANGEMENT DE COMPTEUR (3 relevés). Le 3e
+             index « repart » bas (nouveau compteur posé à 0) : un fin−début naïf
+             serait faux. Conso = (10425−10265) + (135−0) = 295. Le bloc liste les
+             relevés bruts, sans conso synthétique. -->
+        <record id="demo_releve_fevrier_base_1" model="souscription.releve">
+            <field name="periode_id" ref="demo_periode_fevrier_base"/>
+            <field name="date">2024-02-01</field>
+            <field name="nature">reel</field>
+            <field name="index_base">10265</field>
+        </record>
+        <record id="demo_releve_fevrier_base_2" model="souscription.releve">
+            <field name="periode_id" ref="demo_periode_fevrier_base"/>
+            <field name="date">2024-02-15</field>
+            <field name="nature">reel</field>
+            <field name="index_base">10425</field>
+        </record>
+        <record id="demo_releve_fevrier_base_3" model="souscription.releve">
+            <field name="periode_id" ref="demo_periode_fevrier_base"/>
+            <field name="date">2024-02-29</field>
+            <field name="nature">reel</field>
+            <field name="index_base">135</field>
+        </record>
+
+        <!-- Période FACTURÉE & POSTÉE — Admin janvier (4 cadrans). Visible sur le
+             PDF de facture ET au portail. Chargée AVANT demo_facture_janvier_admin. -->
+        <record id="demo_releve_janvier_admin_debut" model="souscription.releve">
+            <field name="periode_id" ref="demo_periode_janvier_admin"/>
+            <field name="date">2024-01-01</field>
+            <field name="nature">reel</field>
+            <field name="index_hph">5000</field>
+            <field name="index_hpb">3000</field>
+            <field name="index_hch">2000</field>
+            <field name="index_hcb">1000</field>
+        </record>
+        <record id="demo_releve_janvier_admin_fin" model="souscription.releve">
+            <field name="periode_id" ref="demo_periode_janvier_admin"/>
+            <field name="date">2024-01-31</field>
+            <field name="nature">reel</field>
+            <field name="index_hph">5130</field>
+            <field name="index_hpb">3085</field>
+            <field name="index_hch">2060</field>
+            <field name="index_hcb">1035</field>
+        </record>
+
+        <!-- Période FACTURÉE & POSTÉE — Admin février (4 cadrans). Le début reprend
+             le fin de janvier (relevé FRONTIÈRE dupliqué, assumé — ADR 0015) ; fin
+             ESTIMÉ (badge Estimé). Chargée AVANT demo_facture_fevrier_admin. -->
+        <record id="demo_releve_fevrier_admin_debut" model="souscription.releve">
+            <field name="periode_id" ref="demo_periode_fevrier_admin"/>
+            <field name="date">2024-02-01</field>
+            <field name="nature">reel</field>
+            <field name="index_hph">5130</field>
+            <field name="index_hpb">3085</field>
+            <field name="index_hch">2060</field>
+            <field name="index_hcb">1035</field>
+        </record>
+        <record id="demo_releve_fevrier_admin_fin" model="souscription.releve">
+            <field name="periode_id" ref="demo_periode_fevrier_admin"/>
+            <field name="date">2024-02-29</field>
+            <field name="nature">estime</field>
+            <field name="index_hph">5280</field>
+            <field name="index_hpb">3180</field>
+            <field name="index_hch">2130</field>
+            <field name="index_hcb">1070</field>
+        </record>
+
+        <!-- Période FACTURÉE mais BROUILLON — Admin mars (4 cadrans). Relevés FIGÉS
+             par le verrou (facture existe), mais ABSENTS du portail (facture non
+             émise). Chargée AVANT demo_facture_mars_admin. -->
+        <record id="demo_releve_mars_admin_debut" model="souscription.releve">
+            <field name="periode_id" ref="demo_periode_mars_admin"/>
+            <field name="date">2024-03-01</field>
+            <field name="nature">reel</field>
+            <field name="index_hph">5280</field>
+            <field name="index_hpb">3180</field>
+            <field name="index_hch">2130</field>
+            <field name="index_hcb">1070</field>
+        </record>
+        <record id="demo_releve_mars_admin_fin" model="souscription.releve">
+            <field name="periode_id" ref="demo_periode_mars_admin"/>
+            <field name="date">2024-03-31</field>
+            <field name="nature">estime</field>
+            <field name="index_hph">5415</field>
+            <field name="index_hpb">3265</field>
+            <field name="index_hch">2185</field>
+            <field name="index_hcb">1100</field>
+        </record>
+
         <!-- ================================ -->
         <!-- GRILLE DE PRIX COMPLÈTE         -->
         <!-- ================================ -->
-        
+
         <!-- Grille de prix réaliste 2024 -->
         <record id="demo_grille_prix_complete_2024" model="grille.prix">
             <field name="name">Tarifs électricité 2024 - Complets</field>
@@ -268,30 +380,30 @@
             <field name="date_fin">2024-12-31</field>
             <field name="active">True</field>
         </record>
-        
+
         <!-- Prix énergies réalistes -->
         <record id="demo_prix_energie_base_2024" model="grille.prix.ligne">
             <field name="grille_id" ref="demo_grille_prix_complete_2024"/>
             <field name="product_id" ref="souscriptions_product_energie_base"/>
             <field name="prix_interne">0.2276</field>
         </record>
-        
+
         <record id="demo_prix_energie_hp_2024" model="grille.prix.ligne">
             <field name="grille_id" ref="demo_grille_prix_complete_2024"/>
             <field name="product_id" ref="souscriptions_product_energie_hp"/>
             <field name="prix_interne">0.2516</field>
         </record>
-        
+
         <record id="demo_prix_energie_hc_2024" model="grille.prix.ligne">
             <field name="grille_id" ref="demo_grille_prix_complete_2024"/>
             <field name="product_id" ref="souscriptions_product_energie_hc"/>
             <field name="prix_interne">0.2032</field>
         </record>
-        
+
         <!-- ================================ -->
         <!-- FACTURES ADMIN (PORTAL TESTING) -->
         <!-- ================================ -->
-        
+
         <!-- Facture janvier 2024 - Admin -->
         <record id="demo_facture_janvier_admin" model="account.move">
             <field name="move_type">out_invoice</field>
@@ -300,7 +412,7 @@
             <field name="invoice_date_due">2024-02-20</field>
             <field name="periode_id" ref="demo_periode_janvier_admin"/>
         </record>
-        
+
         <!-- Ligne facture janvier - Énergie HP -->
         <record id="demo_facture_janvier_admin_line_hp" model="account.move.line">
             <field name="move_id" ref="demo_facture_janvier_admin"/>
@@ -309,7 +421,7 @@
             <field name="quantity">215</field>
             <field name="price_unit">0.2516</field>
         </record>
-        
+
         <!-- Ligne facture janvier - Énergie HC -->
         <record id="demo_facture_janvier_admin_line_hc" model="account.move.line">
             <field name="move_id" ref="demo_facture_janvier_admin"/>
@@ -318,7 +430,7 @@
             <field name="quantity">95</field>
             <field name="price_unit">0.2032</field>
         </record>
-        
+
         <!-- Ligne facture janvier - Abonnement -->
         <record id="demo_facture_janvier_admin_line_abo" model="account.move.line">
             <field name="move_id" ref="demo_facture_janvier_admin"/>
@@ -327,7 +439,7 @@
             <field name="quantity">1</field>
             <field name="price_unit">12.60</field>
         </record>
-        
+
         <!-- Facture février 2024 - Admin -->
         <record id="demo_facture_fevrier_admin" model="account.move">
             <field name="move_type">out_invoice</field>
@@ -336,7 +448,7 @@
             <field name="invoice_date_due">2024-03-20</field>
             <field name="periode_id" ref="demo_periode_fevrier_admin"/>
         </record>
-        
+
         <!-- Ligne facture février - Énergie HP -->
         <record id="demo_facture_fevrier_admin_line_hp" model="account.move.line">
             <field name="move_id" ref="demo_facture_fevrier_admin"/>
@@ -345,7 +457,7 @@
             <field name="quantity">245</field>
             <field name="price_unit">0.2516</field>
         </record>
-        
+
         <!-- Ligne facture février - Énergie HC -->
         <record id="demo_facture_fevrier_admin_line_hc" model="account.move.line">
             <field name="move_id" ref="demo_facture_fevrier_admin"/>
@@ -354,7 +466,7 @@
             <field name="quantity">105</field>
             <field name="price_unit">0.2032</field>
         </record>
-        
+
         <!-- Ligne facture février - Abonnement -->
         <record id="demo_facture_fevrier_admin_line_abo" model="account.move.line">
             <field name="move_id" ref="demo_facture_fevrier_admin"/>
@@ -363,7 +475,7 @@
             <field name="quantity">1</field>
             <field name="price_unit">12.60</field>
         </record>
-        
+
         <!-- Facture mars 2024 - Admin : laissée volontairement en BROUILLON
              (cas d'une facture en cours / remise en brouillon par le·la
              facturiste) — visible côté gestion, jamais au portail usager. -->
@@ -374,7 +486,7 @@
             <field name="invoice_date_due">2024-04-20</field>
             <field name="periode_id" ref="demo_periode_mars_admin"/>
         </record>
-        
+
         <!-- Ligne facture mars - Énergie HP -->
         <record id="demo_facture_mars_admin_line_hp" model="account.move.line">
             <field name="move_id" ref="demo_facture_mars_admin"/>
@@ -383,7 +495,7 @@
             <field name="quantity">220</field>
             <field name="price_unit">0.2516</field>
         </record>
-        
+
         <!-- Ligne facture mars - Énergie HC -->
         <record id="demo_facture_mars_admin_line_hc" model="account.move.line">
             <field name="move_id" ref="demo_facture_mars_admin"/>
@@ -392,7 +504,7 @@
             <field name="quantity">85</field>
             <field name="price_unit">0.2032</field>
         </record>
-        
+
         <!-- Ligne facture mars - Abonnement -->
         <record id="demo_facture_mars_admin_line_abo" model="account.move.line">
             <field name="move_id" ref="demo_facture_mars_admin"/>

--- a/docs/adr/0014-pas-de-verrou-lignes-facture-confiance-facturiste.md
+++ b/docs/adr/0014-pas-de-verrou-lignes-facture-confiance-facturiste.md
@@ -1,0 +1,69 @@
+# Pas de verrou des lignes de facture : confiance au·à la facturiste, dérive Facture↔Période tolérée
+
+[ADR-0007](0007-snapshot-periode-type-verrou-facturation.md) a figé la *Période* à la facturation
+(le modèle `souscription.periode` devient lecture seule dès qu'une *Facture* le référence). Reste la
+question **distincte** (issue #35) de l'éditabilité de la *Facture* elle-même (`account.move` /
+`account.move.line`) : faut-il **verrouiller** les lignes générées depuis la Période pour qu'elles ne
+soient pas retouchées à la main ? Cet ADR tranche : **non**.
+
+## Décision
+
+1. **Aucun verrou des lignes de facture.** `account.move.line` n'est **ni étendu** d'un drapeau de
+   provenance (`généré-période`) **ni gardé** par un `write()` surchargé. Le **brouillon** de facture
+   reste librement éditable par le·la *facturiste* — ajout de lignes, *gestes commerciaux*,
+   corrections. L'**émission** (`posted`) la fige, mais c'est déjà acquis (immutabilité légale
+   anti-fraude), pas un mécanisme du module.
+
+2. **La Période est la source analytique ; la Facture en est une projection.** Les champs **typés**
+   de la Période ([#14](https://github.com/Energie-De-Nantes/souscriptions_odoo/issues/14)), alimentés
+   par electricore ([#18](https://github.com/Energie-De-Nantes/souscriptions_odoo/issues/18)), sont lus
+   et **agrégés directement** par l'analytique. L'analytique **ne reconstruit jamais** les faits de
+   facturation depuis les lignes (`account.move.line → product_id → categ_id → name`)
+   ([ADR-0002](0002-deux-sources-de-verite-marge-en-analytique.md)).
+
+3. **Dérive tolérée et bornée.** Une retouche manuelle d'une ligne vit sur la **Facture**, pas sur la
+   **Période** : la Facture peut **diverger** ; la Période reste correcte-à-la-génération. La dérive
+   vaut la **somme des éditions manuelles** — un *budget d'erreur humaine* assumé. Elle est
+   **directionnelle** : une correction sur facture sous-représente dans l'analytique exactement les cas
+   où la Période était fausse. Conséquence : la **réconciliation/audit par contrat lit la Facture**,
+   l'analytique **générale** lit la Période.
+
+4. **Geste commercial au jugement du·de la facturiste.** Réalisé soit comme **ligne de remise dédiée**,
+   soit comme **édition directe** d'une ligne (ex. jours facturés réduits). Aucune des deux formes
+   n'est imposée (KISS) : `CONTEXT.md` conserve l'exemple « jours facturés réduits ».
+
+## Conséquences
+
+- **Le verrou de la Période ([ADR-0007](0007-snapshot-periode-type-verrou-facturation.md)) reste le
+  seul verrou.** Il vit sur un modèle **propre** (`souscription.periode`), peu coûteux à garder ; il
+  protège la **source**, ce qui suffit.
+- **Pas d'override de `write()` sur un modèle cœur très sollicité.** `account.move.line` est la table la
+  plus chaude d'Odoo et l'ORM la réécrit en permanence (taxes, soldes, lettrage, distribution
+  analytique). On évite de **combattre les recomputes** et la **dette de re-validation à chaque montée
+  de version** Odoo.
+- **L'analytique fine/par-contrat doit lire la Facture** (la projection légale réellement émise), pas
+  la Période. C'est le prix assumé de la dérive.
+
+## Options écartées
+
+- **Drapeau de provenance + `write()`-guard sur `account.move.line`** (lecture « dure » de #35) :
+  protège un couplage (Facture == Période) dont l'analytique **n'a pas besoin** — elle lit la Période.
+  Coût : garde fragile sur la table la plus chaude d'Odoo, risque de casser les recomputes ORM, dette
+  d'upgrade. Le gain (zéro dérive) ne vaut pas ce coût pour de l'analytique générale.
+- **Inférer la provenance via `product_id` / catégorie** : reconstruit **exactement** le parcours
+  `ligne → produit → catégorie` que la Période typée **supprime** (cf. l'ancien lecteur
+  `lignes_factures_du_mois` côté electricore). Rebâtir cette friction dans le verrou serait un comble.
+- **Verrou à l'émission seulement** : sans objet — `posted` est déjà immuable (anti-fraude) ; il n'y a
+  rien à ajouter.
+
+## Raison
+
+La Période est **déjà** la source analytique **par construction** ; le verrou ne sécurisait qu'un
+**couplage superflu**. Test de suppression : retirer le verrou n'enlève **rien** à l'analytique (elle
+lit la Période) et la complexité supprimée — une garde sur le cœur comptable — ne réapparaît nulle
+part. KISS : on préfère un **budget d'erreur humaine borné** à une garde fragile et coûteuse à
+maintenir sur `account.move.line`.
+
+Résout les trois questions ouvertes de
+[#35](https://github.com/Energie-De-Nantes/souscriptions_odoo/issues/35) (verrou à la création/émission ;
+modélisation du geste commercial ; remise vs régularisation).

--- a/docs/adr/0015-releves-index-enfant-fige-periode-projete-facture.md
+++ b/docs/adr/0015-releves-index-enfant-fige-periode-projete-facture.md
@@ -1,0 +1,92 @@
+# Relevés d'index : enfant figé de la Période, projeté sur la facture (pas de bundle)
+
+La facture d'énergie doit **afficher tous les index qu'electricore a utilisés** pour son calcul :
+c'est une **obligation légale** et le support de **vérification** par le·la *souscripteur·rice*
+(re-jouer le calcul de conso). Aujourd'hui le module ne porte **aucun** index : la *Période*
+n'historise que l'énergie en kWh **par cadran** (`energie_*`). L'index — le relevé cumulé d'un
+registre de compteur — est un **nouveau** concept.
+
+## Décision
+
+Introduire **`souscription.releve`**, modèle **enfant de la _Période_** (One2many `periode_id`),
+et non de la *Souscription*.
+
+- **Forme large, par cadran réseau.** Un record = un **relevé daté** portant un index par
+  **registre** du compteur — même axe *mesuré* que `energie_hph/hpb/hch/hcb` (ou HP/HC, ou Base),
+  jamais par cadran **facturé** (un compteur 4-cadrans facturé Base n'a pas d'`index_base`
+  physique). Les colonnes affichées suivent `config_cadrans` ([ADR-0005](0005-granularite-energie-calendrier-comptage.md)).
+- **Cardinalité variable.** ~2 relevés par Période normale (début / fin), 3–4 lors d'un
+  **changement de compteur** ou d'un relevé réel intermédiaire — représentés fidèlement, sans
+  branche spéciale (un `index_fin − index_debut` naïf serait *faux* à travers un changement de
+  compteur, d'où le refus d'une paire fixe).
+- **Nature `reel` / `estime`** par relevé (mesure Enedis vs estimation electricore/facturiste),
+  étiquetée sur la facture — exigence légale d'affichage de l'index estimé, et honnêteté de la
+  vérification.
+- **Figé avec le snapshot de la Période** ([ADR-0006](0006-snapshot-periode-fait-autorite-facturation.md)).
+  Le **verrou de facturation** (#14 / [ADR-0014](0014-pas-de-verrou-lignes-facture-confiance-facturiste.md))
+  **s'étend à l'enfant** : `create` / `write` / `unlink` sur `souscription.releve` sont rejetés
+  dès que `periode.facture_id` existe. Sans cela, le figement fuit.
+- **Relevé frontière dupliqué** entre deux Périodes consécutives (`fin` de mars = `début` d'avril) :
+  assumé. Chaque facture est **auto-portante** (obligation légale : imprimer son propre début et sa
+  propre fin), et le cas « réel arrivé en retard » se résout naturellement — mars garde son `fin`
+  *estimé* figé, le réel devient le `début` d'avril, l'écart est soldé en *régularisation*.
+- **Source.** Saisie à la main par le·la *facturiste* tant que l'intégration manque (#12), comme
+  l'énergie aujourd'hui ; peuplé plus tard par le **pull electricore**
+  ([ADR-0011](0011-contrat-pull-facturation-electricore-cle-rsc-mois.md)) au moment du snapshot.
+- **Rendu par projection, pas par lignes de facture.** Le relevé n'est **jamais** matérialisé en
+  `account.move.line`. Un **bloc QWeb « Justificatif de calcul — relevés utilisés »** itère
+  `o.periode_id.releve_ids`, sur la facture **PDF** *et* dans le détail souscription du **portail**.
+  Le `move` reste purement financier ([ADR-0014](0014-pas-de-verrou-lignes-facture-confiance-facturiste.md),
+  facture = projection de la Période).
+- **Pas de modèle « bundle » intermédiaire.** Le jeu de relevés d'une Période **est** la Période :
+  celle-ci est déjà le conteneur figé 1:1. La métadonnée propre au *set* — le **`source_hash`**
+  (qui permet, en re-pullant le même mois, de détecter de nouvelles données) et, plus tard,
+  `calc_ref` / `pulled_at` / `source` — est portée en **champs sur la Période**, pas dans une table
+  dédiée — `source_hash` étant peuplé par le pull à venir, pas pendant la saisie manuelle.
+
+## Conséquences
+
+- Nouveau modèle `souscription.releve` (+ vues, sécurité) ; champ `source_hash` sur
+  `souscription.periode`. Migration : aucune donnée existante à reprendre (concept neuf).
+- Le verrou #14 doit couvrir un **troisième** point (move, Période, **relevé**) : implémenter le
+  blocage sur `create`/`write`/`unlink` de `souscription.releve` quand la Période est facturée.
+- **Re-pull avant facturation** = **remplacement en bloc** de `releve_ids`
+  (`[(5, 0, 0), (0, 0, …)]`) + mise à jour de `source_hash`. Pas de FK à échanger, pas de bundle.
+- La **conso** par cadran reste portée par `energie_*` (la ligne de facture) ; le bloc justificatif
+  **liste les relevés bruts** plutôt que de recalculer une conso (à travers un changement de
+  compteur, le brut *est* la piste d'audit). En **lissé**, le bloc est informatif et visiblement
+  séparé de la provision facturée ; la *régularisation* solde l'écart.
+- Deux surfaces à maintenir (PDF + portail) lisent la même source `releve_ids`.
+
+## Options écartées
+
+- **Relevés enfants de la _Souscription_** (timeline PDL partagée) : une correction de relevé
+  réagirait sur les factures passées — casse la reproductibilité d'[ADR-0006](0006-snapshot-periode-fait-autorite-facturation.md).
+  La duplication frontière est le prix assumé de l'auto-portance.
+- **Modèle « bundle » intermédiaire** (Période → bundle → relevés) : wrapper **1:1** avec la
+  Période, sans identité ni cycle de vie propres — *middle-man*. Les deux justifications réelles
+  d'un agrégat (jeu **partagé**, jeu **pluriel/versionné**) ont été **écartées par conception**
+  (copie figée par période ; correction = régularisation, [ADR-0006](0006-snapshot-periode-fait-autorite-facturation.md)).
+  La troisième (métadonnée propre au set) est absorbée par le parent 1:1 (`source_hash`).
+  **Tripwire** : promouvoir le jeu en modèle propre **le jour où il faut retenir ≥ 2 jeux
+  simultanés par Période** (vrai versioning) — et seulement ce jour-là. Un `source_hash` qui change
+  au re-pull n'est *pas* cette condition tant que la politique reste « non facturée → remplacer ;
+  facturée → régularisation ».
+- **Relevés en `account.move.line`** (notes/sections, comme le TURPE) : pollue le move de lignes
+  non financières (quantités/prix factices), dédouble la source (move *et* Période).
+- **Paire `index_debut` / `index_fin` fixe par cadran** (champs sur la Période) : simple, mais
+  incapable de représenter fidèlement un changement de compteur — exactement un cas où l'usager·ère
+  voudrait vérifier.
+- **Payload opaque d'electricore** (JSON brut stocké tel quel) : fidélité maximale mais non
+  requêtable / non agrégeable et fragile au format amont.
+
+## Raison
+
+« Tous les index utilisés » est une **contrainte légale** doublée d'un **droit de vérification** :
+la facture doit exposer, fidèlement, la matière première du calcul d'electricore. Loger ce jeu sur
+la **Période** — l'unité de snapshot déjà figée et déjà autoritaire à la facturation
+([ADR-0006](0006-snapshot-periode-fait-autorite-facturation.md)) — donne la reproductibilité sans
+nouvelle frontière, et le rendre **par projection** garde le move purement comptable
+([ADR-0014](0014-pas-de-verrou-lignes-facture-confiance-facturiste.md)). Refuser le bundle, c'est
+appliquer YAGNI avec un **déclencheur nommé** : on n'abstrait le jeu qu'à l'apparition du deuxième
+exemplaire, pas avant.

--- a/models/core/__init__.py
+++ b/models/core/__init__.py
@@ -5,4 +5,5 @@ from . import (
     souscription_periode,
     souscription_produit,
     souscription_refacturation,
+    souscription_releve,
 )

--- a/models/core/souscription_periode.py
+++ b/models/core/souscription_periode.py
@@ -111,6 +111,11 @@ class SouscriptionPeriode(models.Model):
         help='Coefficient PRO au moment de la création de cette période',
     )
 
+    # Relevés d'index utilisés pour le calcul d'énergie (ADR 0015). Justificatif
+    # légal, figé avec le snapshot et verrouillé après facturation (#56). Saisi à
+    # la main par le·la facturiste tant que le pull electricore manque (#12).
+    releve_ids = fields.One2many('souscription.releve', 'periode_id', string="Relevés d'index utilisés")
+
     # Lien Période ↔ Facture : `account.move.periode_id` est l'unique source de
     # vérité (ADR 0004). `facture_id` en est dérivé — calculé/stocké, non écrit.
     move_ids = fields.One2many('account.move', 'periode_id', string='Documents liés', readonly=True)
@@ -219,6 +224,28 @@ class SouscriptionPeriode(models.Model):
                         'Supprimez la facture pour corriger, ou créez une régularisation.'
                     )
         return super().write(vals)
+
+    # Mapping cadran réseau → colonne d'index, source unique pour le justificatif
+    # PDF (#55) et portail (#57) — ADR 0015. Suit le calendrier de comptage
+    # (ADR 0005) ; point d'extension nommé pour Tempo/EJP (hors périmètre).
+    _RELEVE_COLONNES = {
+        'base': [{'label': 'Base', 'field': 'index_base'}],
+        'hp_hc': [{'label': 'HP', 'field': 'index_hp'}, {'label': 'HC', 'field': 'index_hc'}],
+        '4_cadrans': [
+            {'label': 'HPH', 'field': 'index_hph'},
+            {'label': 'HPB', 'field': 'index_hpb'},
+            {'label': 'HCH', 'field': 'index_hch'},
+            {'label': 'HCB', 'field': 'index_hcb'},
+        ],
+    }
+
+    def releve_colonnes(self):
+        """Colonnes d'index réseau (`label`, `field`) à afficher pour le
+        justificatif des relevés de cette Période, selon son calendrier de
+        comptage. Itérées par les rendus PDF et portail — un seul endroit où vit
+        le mapping cadran→colonne (ADR 0015)."""
+        self.ensure_one()
+        return self._RELEVE_COLONNES.get(self.config_cadrans, [])
 
     @api.depends('date_debut', 'date_fin')
     def _compute_jours(self):

--- a/models/core/souscription_releve.py
+++ b/models/core/souscription_releve.py
@@ -1,0 +1,84 @@
+from odoo import api, fields, models
+from odoo.exceptions import UserError
+
+
+class SouscriptionReleve(models.Model):
+    """Relevé d'index : événement de lecture daté du compteur, enfant d'une
+    *Période* (ADR 0015). Forme **large, par cadran réseau** — un record porte un
+    index par registre physique du compteur (HPH/HPB/HCH/HCB, ou HP/HC, ou Base),
+    jamais par cadran *facturé*. Cardinalité variable (≈2 en régime normal, 3–4
+    lors d'un changement de compteur), représentée fidèlement sans branche
+    spéciale. Justificatif légal du calcul d'énergie, support de vérification par
+    le·la souscripteur·rice ; jamais matérialisé en account.move.line.
+    """
+
+    _name = 'souscription.releve'
+    _description = "Relevé d'index"
+    _order = 'date, id'
+
+    periode_id = fields.Many2one(
+        'souscription.periode',
+        string='Période',
+        required=True,
+        ondelete='cascade',
+        index=True,
+    )
+
+    # Calendrier de comptage de la Période (ADR 0005) : pilote les colonnes
+    # d'index pertinentes à la saisie / à l'affichage.
+    config_cadrans = fields.Selection(related='periode_id.config_cadrans', readonly=True)
+
+    date = fields.Date(required=True)
+
+    # Mesure Enedis (reel) vs estimation electricore/facturiste (estime) :
+    # étiquetée sur la facture (obligation légale d'affichage de l'index estimé).
+    nature = fields.Selection(
+        [('reel', 'Réel'), ('estime', 'Estimé')],
+        string='Nature',
+        required=True,
+        default='reel',
+    )
+
+    # Index par cadran réseau (même axe mesuré que energie_*) — colonnes
+    # pertinentes selon config_cadrans : 4_cadrans → HPH/HPB/HCH/HCB ;
+    # hp_hc → HP/HC ; base → Base.
+    index_hph = fields.Float(string='Index HPH', help='Heures Pleines saison Haute')
+    index_hpb = fields.Float(string='Index HPB', help='Heures Pleines saison Basse')
+    index_hch = fields.Float(string='Index HCH', help='Heures Creuses saison Haute')
+    index_hcb = fields.Float(string='Index HCB', help='Heures Creuses saison Basse')
+    index_hp = fields.Float(string='Index HP')
+    index_hc = fields.Float(string='Index HC')
+    index_base = fields.Float(string='Index Base')
+
+    # Verrou de facturation étendu à l'enfant (#56 / ADR 0014-0015). Symétrique du
+    # verrou _LOCKED_FIELDS de la Période : dès qu'une Période est facturée
+    # (facture_id existe, brouillon de facture compris), ses relevés sont figés —
+    # sinon le justificatif d'index pourrait diverger silencieusement de la facture
+    # émise. Pour corriger : supprimer la facture (défige) ou émettre une
+    # régularisation.
+    def _check_periode_non_facturee(self, periodes):
+        for periode in periodes:
+            if periode.facture_id:
+                raise UserError(
+                    f'Période {periode.mois_annee} : déjà facturée, modification des relevés '
+                    'interdite. Supprimez la facture pour corriger, ou créez une régularisation.'
+                )
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        periodes = self.env['souscription.periode'].browse(
+            [vals['periode_id'] for vals in vals_list if vals.get('periode_id')]
+        )
+        self._check_periode_non_facturee(periodes)
+        return super().create(vals_list)
+
+    def write(self, vals):
+        self._check_periode_non_facturee(self.periode_id)
+        # Un déplacement vers une autre Période facturée est aussi interdit.
+        if vals.get('periode_id'):
+            self._check_periode_non_facturee(self.env['souscription.periode'].browse(vals['periode_id']))
+        return super().write(vals)
+
+    def unlink(self):
+        self._check_periode_non_facturee(self.periode_id)
+        return super().unlink()

--- a/reports/facture_energie_template.xml
+++ b/reports/facture_energie_template.xml
@@ -32,7 +32,7 @@
                                                 <strong>Puissance souscrite:</strong> <span t-field="o.souscription_id.puissance_souscrite"/> kVA
                                             </div>
                                             <div class="col-6">
-                                                <strong>Type de tarif:</strong> 
+                                                <strong>Type de tarif:</strong>
                                                 <span t-if="o.souscription_id.type_tarif == 'base'">Base</span>
                                                 <span t-elif="o.souscription_id.type_tarif == 'hphc'">Heures Pleines / Heures Creuses</span>
                                                 <span t-else="" t-field="o.souscription_id.type_tarif"/><br/>
@@ -101,7 +101,7 @@
                                         <div class="mt-3 p-3" style="background-color: #f8f9fa; border-left: 3px solid #2E7D32;">
                                             <p class="mb-0">
                                                 <strong style="color: #2E7D32;">Information réglementaire :</strong><br/>
-                                                Les montants TURPE (Tarif d'Utilisation des Réseaux Publics d'Électricité) 
+                                                Les montants TURPE (Tarif d'Utilisation des Réseaux Publics d'Électricité)
                                                 correspondent aux coûts d'acheminement de l'électricité et sont indiqués à titre informatif.
                                             </p>
                                         </div>
@@ -123,6 +123,44 @@
                                         </table>
                                     </div>
                                 </div>
+                            </div>
+
+                            <!-- Justificatif de calcul — relevés d'index utilisés (ADR 0015).
+                                 Rendu PAR PROJECTION depuis la Période : aucun relevé n'est une
+                                 ligne de facture (le move reste purement financier, ADR 0014).
+                                 Visiblement séparé des lignes facturées — en lissé, la conso
+                                 fin − début diffère de la provision facturée (régularisation). -->
+                            <t t-set="releves" t-value="o.periode_id.releve_ids.sorted('date')"/>
+                            <div t-if="releves" class="mt-4">
+                                <h5 style="color: #2E7D32;">Justificatif de calcul — relevés utilisés</h5>
+                                <p class="text-muted" style="font-size: 0.85em;">
+                                    Index ayant servi au calcul de votre consommation, par cadran de comptage.
+                                    Vous pouvez les comparer aux index affichés sur votre compteur.
+                                </p>
+                                <t t-set="colonnes" t-value="o.periode_id.releve_colonnes()"/>
+                                <table class="table table-sm">
+                                    <thead>
+                                        <tr>
+                                            <th>Date</th>
+                                            <th>Nature</th>
+                                            <th t-foreach="colonnes" t-as="col" class="text-end">
+                                                Index <span t-out="col['label']"/>
+                                            </th>
+                                        </tr>
+                                    </thead>
+                                    <tbody>
+                                        <t t-foreach="releves" t-as="releve">
+                                            <tr>
+                                                <td t-out="releve.date.strftime('%d/%m/%Y') if releve.date else ''"/>
+                                                <td>
+                                                    <span t-if="releve.nature == 'reel'" class="badge" style="background-color: #2E7D32; color: white;">Réel</span>
+                                                    <span t-else="" class="badge" style="background-color: #9E9E9E; color: white;">Estimé</span>
+                                                </td>
+                                                <td t-foreach="colonnes" t-as="col" class="text-end" t-out="releve[col['field']]"/>
+                                            </tr>
+                                        </t>
+                                    </tbody>
+                                </table>
                             </div>
 
                             <!-- Pied de page énergie -->

--- a/security/ir.model.access.csv
+++ b/security/ir.model.access.csv
@@ -3,6 +3,8 @@ access_souscription_user,souscription.souscription user,model_souscription_sousc
 access_souscription_manager,souscription.souscription manager,model_souscription_souscription,group_souscriptions_manager,1,1,1,1
 access_souscription_periode_user,souscription.periode user,model_souscription_periode,group_souscriptions_user,1,1,1,0
 access_souscription_periode_manager,souscription.periode manager,model_souscription_periode,group_souscriptions_manager,1,1,1,1
+access_souscription_releve_user,souscription.releve user,model_souscription_releve,group_souscriptions_user,1,1,1,0
+access_souscription_releve_manager,souscription.releve manager,model_souscription_releve,group_souscriptions_manager,1,1,1,1
 access_souscription_etat_user,souscription.etat user,model_souscription_etat,group_souscriptions_user,1,0,0,0
 access_souscription_etat_manager,souscription.etat manager,model_souscription_etat,group_souscriptions_manager,1,1,1,1
 access_souscription_refacturation_user,souscription.refacturation user,model_souscription_refacturation,group_souscriptions_user,1,1,1,0
@@ -17,5 +19,6 @@ access_raccordement_stage_user,raccordement.stage user,model_raccordement_stage,
 access_raccordement_stage_manager,raccordement.stage manager,model_raccordement_stage,group_souscriptions_manager,1,1,1,1
 access_souscription_portal,souscription.souscription portal,model_souscription_souscription,base.group_portal,1,0,0,0
 access_souscription_periode_portal,souscription.periode portal,model_souscription_periode,base.group_portal,1,0,0,0
+access_souscription_releve_portal,souscription.releve portal,model_souscription_releve,base.group_portal,1,0,0,0
 access_souscription_etat_portal,souscription.etat portal,model_souscription_etat,base.group_portal,1,0,0,0
 access_account_move_portal,account.move portal,account.model_account_move,base.group_portal,1,0,0,0

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -12,6 +12,7 @@ from . import (
     test_portal,
     test_raccordement,
     test_refacturation,
+    test_releve,
     test_security,
     test_souscription,
 )

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -13,6 +13,7 @@ from . import (
     test_raccordement,
     test_refacturation,
     test_releve,
+    test_releve_demo,
     test_security,
     test_souscription,
 )

--- a/tests/test_portal.py
+++ b/tests/test_portal.py
@@ -325,3 +325,85 @@ class PortalIntegrationTestCase(SouscriptionsTestMixin, HttpCase):
         self.assertTrue(access, 'Accès portal aux périodes requis')
         self.assertTrue(access.perm_read, 'Lecture autorisée')
         self.assertFalse(access.perm_write, 'Écriture interdite')
+
+
+@tagged('post_install', '-at_install', 'portal', 'souscriptions_releve')
+class PortalReleveTestCase(SouscriptionsTestMixin, HttpCase):
+    """Bloc justificatif des relevés dans le détail souscription du portail
+    (#57 / ADR 0015) : visible pour les périodes dont la facture est ÉMISE
+    (postée) uniquement — un brouillon ne fuite jamais côté usager."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.setUpSouscriptionsData()
+
+        cls.portal_user = cls.env['res.users'].create(
+            {
+                'name': 'Portal Releve User',
+                'login': 'portal_releve',
+                'email': 'portal_releve@test.com',
+                'group_ids': [(6, 0, [cls.env.ref('base.group_portal').id])],
+            }
+        )
+        cls.partner_test.user_ids = [(6, 0, [cls.portal_user.id])]
+
+        # Période ÉMISE (postée) avec relevés saisis avant facturation.
+        cls.periode_postee = cls.env['souscription.periode'].create(
+            {
+                'souscription_id': cls.souscription_base.id,
+                'date_debut': date(2024, 1, 1),
+                'date_fin': date(2024, 1, 31),
+                'type_periode': 'mensuelle',
+                'energie_base_kwh': 280.0,
+                'turpe_fixe': 8.50,
+                'turpe_variable': 12.30,
+            }
+        )
+        cls.env['souscription.releve'].create(
+            {'periode_id': cls.periode_postee.id, 'date': date(2024, 1, 1), 'nature': 'reel', 'index_base': 71000.0}
+        )
+        cls.env['souscription.releve'].create(
+            {'periode_id': cls.periode_postee.id, 'date': date(2024, 1, 31), 'nature': 'estime', 'index_base': 71280.0}
+        )
+        cls.periode_postee._creer_facture().action_post()
+
+        # Période en BROUILLON (facture non postée) avec un relevé : ne doit pas fuiter.
+        cls.periode_brouillon = cls.env['souscription.periode'].create(
+            {
+                'souscription_id': cls.souscription_base.id,
+                'date_debut': date(2024, 2, 1),
+                'date_fin': date(2024, 2, 29),
+                'type_periode': 'mensuelle',
+                'energie_base_kwh': 300.0,
+                'turpe_fixe': 8.50,
+                'turpe_variable': 14.0,
+            }
+        )
+        cls.env['souscription.releve'].create(
+            {'periode_id': cls.periode_brouillon.id, 'date': date(2024, 2, 1), 'nature': 'reel', 'index_base': 99999.0}
+        )
+        cls.facture_brouillon = cls.periode_brouillon._creer_facture()  # reste draft
+
+    def _detail_url(self):
+        return f'/my/souscription/{self.souscription_base.id}'
+
+    def test_releves_periode_emise_visibles(self):
+        """Les relevés (date, nature, index) d'une période émise sont visibles."""
+        self.authenticate(self.portal_user.login, self.portal_user.login)
+        response = self.url_open(self._detail_url())
+        self.assertEqual(response.status_code, 200)
+
+        self.assertIn('71000', response.text)
+        self.assertIn('71280', response.text)
+        self.assertIn('Réel', response.text)
+        self.assertIn('Estimé', response.text)
+
+    def test_releves_periode_brouillon_ne_fuitent_pas(self):
+        """Aucun relevé d'une période non émise (facture brouillon) n'apparaît."""
+        self.assertEqual(self.facture_brouillon.state, 'draft')
+        self.authenticate(self.portal_user.login, self.portal_user.login)
+        response = self.url_open(self._detail_url())
+        self.assertEqual(response.status_code, 200)
+
+        self.assertNotIn('99999', response.text)

--- a/tests/test_releve.py
+++ b/tests/test_releve.py
@@ -1,0 +1,231 @@
+"""
+Relevés d'index (#54 / ADR 0015) : modèle enfant `souscription.releve` de la
+Période, saisie backend. Forme large par cadran réseau, nature réel/estimé,
+cardinalité variable. Pas de verrou ici (#56) ni de rendu (#55/#57).
+"""
+
+from datetime import date
+
+from odoo.exceptions import UserError
+from odoo.tests.common import tagged
+
+from .common import SouscriptionsTestCase
+
+
+@tagged('souscriptions', 'souscriptions_releve', 'post_install', '-at_install')
+class TestReleveModel(SouscriptionsTestCase):
+    def test_releve_base_persiste_et_se_lit_via_periode(self):
+        """Un relevé Base créé sur une Période est lisible via periode.releve_ids."""
+        periode = self.create_test_periode(self.souscription_base)
+
+        releve = self.env['souscription.releve'].create(
+            {
+                'periode_id': periode.id,
+                'date': date(2024, 1, 1),
+                'nature': 'reel',
+                'index_base': 12345.0,
+            }
+        )
+
+        self.assertIn(releve, periode.releve_ids)
+        self.assertEqual(releve.index_base, 12345.0)
+        self.assertEqual(releve.nature, 'reel')
+
+    def test_releve_hp_hc_porte_les_index_par_registre(self):
+        """En config hp_hc, un relevé porte index_hp et index_hc."""
+        # config_cadrans est figé sur la Période depuis la Souscription (ADR 0005).
+        self.souscription_hphc.config_cadrans = 'hp_hc'
+        periode = self.create_test_periode(self.souscription_hphc)
+
+        releve = self.env['souscription.releve'].create(
+            {
+                'periode_id': periode.id,
+                'date': date(2024, 1, 31),
+                'nature': 'estime',
+                'index_hp': 8000.0,
+                'index_hc': 4000.0,
+            }
+        )
+
+        self.assertEqual(releve.index_hp, 8000.0)
+        self.assertEqual(releve.index_hc, 4000.0)
+        self.assertEqual(releve.nature, 'estime')
+        # config_cadrans est exposé (related) pour piloter l'affichage.
+        self.assertEqual(releve.config_cadrans, 'hp_hc')
+
+    def test_releve_4_cadrans_porte_les_quatre_index(self):
+        """En config 4_cadrans, un relevé porte les 4 index saisonniers."""
+        self.souscription_hphc.config_cadrans = '4_cadrans'
+        periode = self.create_test_periode(self.souscription_hphc)
+
+        releve = self.env['souscription.releve'].create(
+            {
+                'periode_id': periode.id,
+                'date': date(2024, 1, 1),
+                'nature': 'reel',
+                'index_hph': 1000.0,
+                'index_hpb': 2000.0,
+                'index_hch': 3000.0,
+                'index_hcb': 4000.0,
+            }
+        )
+
+        self.assertEqual(
+            (releve.index_hph, releve.index_hpb, releve.index_hch, releve.index_hcb),
+            (1000.0, 2000.0, 3000.0, 4000.0),
+        )
+        self.assertEqual(releve.config_cadrans, '4_cadrans')
+
+    def test_releves_ordonnes_chronologiquement(self):
+        """Relu depuis la base (comme au rendu PDF/portail), releve_ids est trié
+        par date — support du « justificatif chronologique » (#55/#57)."""
+        periode = self.create_test_periode(self.souscription_base)
+        Releve = self.env['souscription.releve']
+        fin = Releve.create({'periode_id': periode.id, 'date': date(2024, 1, 31), 'index_base': 500.0})
+        debut = Releve.create({'periode_id': periode.id, 'date': date(2024, 1, 1), 'index_base': 200.0})
+
+        # Le rendu lit l'enregistrement à neuf : le _order du modèle s'applique
+        # (le cache One2many garderait, lui, l'ordre de création).
+        periode.invalidate_recordset(['releve_ids'])
+        self.assertEqual(list(periode.releve_ids), [debut, fin])
+
+
+@tagged('souscriptions', 'souscriptions_releve', 'post_install', '-at_install')
+class TestReleveVerrou(SouscriptionsTestCase):
+    """Verrou de facturation étendu à l'enfant (#56 / ADR 0014-0015) : dès qu'une
+    Période est facturée, create / write / unlink d'un relevé sont rejetés."""
+
+    def _periode_avec_releve(self):
+        """Une Période non facturée portant un relevé."""
+        periode = self.create_test_periode(self.souscription_base)
+        releve = self.env['souscription.releve'].create(
+            {'periode_id': periode.id, 'date': date(2024, 1, 1), 'index_base': 100.0}
+        )
+        return periode, releve
+
+    def test_write_releve_periode_facturee_rejete(self):
+        """write sur un relevé d'une Période facturée lève UserError."""
+        periode, releve = self._periode_avec_releve()
+        periode._creer_facture()  # facture_id existe → période figée
+
+        with self.assertRaises(UserError):
+            releve.index_base = 999.0
+
+    def test_create_releve_periode_facturee_rejete(self):
+        """create d'un relevé sur une Période facturée lève UserError."""
+        periode, _releve = self._periode_avec_releve()
+        periode._creer_facture()
+
+        with self.assertRaises(UserError):
+            self.env['souscription.releve'].create(
+                {'periode_id': periode.id, 'date': date(2024, 1, 31), 'index_base': 500.0}
+            )
+
+    def test_unlink_releve_periode_facturee_rejete(self):
+        """unlink d'un relevé d'une Période facturée lève UserError."""
+        periode, releve = self._periode_avec_releve()
+        periode._creer_facture()
+
+        with self.assertRaises(UserError):
+            releve.unlink()
+
+    def test_releves_libres_avant_facturation(self):
+        """Avant facturation : create / write / unlink restent libres."""
+        periode, releve = self._periode_avec_releve()
+        self.assertFalse(periode.facture_id)
+
+        releve.index_base = 222.0  # write OK
+        self.assertEqual(releve.index_base, 222.0)
+        autre = self.env['souscription.releve'].create(  # create OK
+            {'periode_id': periode.id, 'date': date(2024, 1, 31), 'index_base': 600.0}
+        )
+        autre.unlink()  # unlink OK
+        self.assertFalse(autre.exists())
+
+    def test_suppression_facture_defige_les_releves(self):
+        """Supprimer la facture défige les relevés (édition de nouveau possible)."""
+        periode, releve = self._periode_avec_releve()
+        facture = periode._creer_facture()
+
+        facture.unlink()  # la période et ses relevés se défigent
+        self.assertFalse(periode.facture_id)
+
+        releve.index_base = 333.0  # write de nouveau autorisé
+        self.assertEqual(releve.index_base, 333.0)
+
+
+@tagged('souscriptions', 'souscriptions_releve', 'post_install', '-at_install')
+class TestReleveFacturePDF(SouscriptionsTestCase):
+    """Bloc « Justificatif de calcul — relevés utilisés » sur la facture PDF
+    (#55 / ADR 0015) : rendu par projection depuis periode_id.releve_ids, jamais
+    matérialisé en account.move.line."""
+
+    def _render_facture(self, facture):
+        context = {'docs': facture, 'doc_ids': facture.ids, 'doc_model': 'account.move'}
+        return str(self.env['ir.qweb']._render('souscriptions_odoo.report_facture_energie', context))
+
+    def test_bloc_justificatif_liste_les_releves_chronologiquement(self):
+        """Le bloc liste chaque relevé : date, nature étiquetée, index, par ordre de date."""
+        periode = self.create_test_periode(self.souscription_base)
+        Releve = self.env['souscription.releve']
+        Releve.create({'periode_id': periode.id, 'date': date(2024, 1, 31), 'nature': 'estime', 'index_base': 10250.0})
+        Releve.create({'periode_id': periode.id, 'date': date(2024, 1, 1), 'nature': 'reel', 'index_base': 10000.0})
+        facture = periode._creer_facture()
+
+        html = self._render_facture(facture)
+
+        self.assertIn('relevés utilisés', html)
+        self.assertIn('01/01/2024', html)
+        self.assertIn('31/01/2024', html)
+        self.assertIn('10000', html)
+        self.assertIn('10250', html)
+        self.assertIn('Réel', html)
+        self.assertIn('Estimé', html)
+        # Ordre chronologique : le relevé de début précède celui de fin dans le rendu.
+        self.assertLess(html.index('01/01/2024'), html.index('31/01/2024'))
+
+    def test_releves_non_materialises_en_lignes_de_facture(self):
+        """Le move reste purement financier : aucune ligne ne provient des relevés."""
+        periode = self.create_test_periode(self.souscription_base)
+        self.env['souscription.releve'].create(
+            {'periode_id': periode.id, 'date': date(2024, 1, 1), 'nature': 'reel', 'index_base': 88888.0}
+        )
+        facture = periode._creer_facture()
+
+        # Base : composition = 1 ligne abonnement + 1 ligne énergie, inchangée par les relevés.
+        product_lines = facture.invoice_line_ids.filtered(lambda line: line.display_type == 'product')
+        self.assertEqual(len(product_lines), 2)
+        self.assertNotIn('88888', ''.join(facture.invoice_line_ids.mapped('name') or []))
+
+    def test_bloc_present_en_contrat_lisse(self):
+        """En lissé, le bloc justificatif apparaît aussi (séparé des lignes facturées)."""
+        self.assertTrue(self.souscription_hphc.lisse)
+        self.souscription_hphc.config_cadrans = 'hp_hc'
+        periode = self.create_test_periode(self.souscription_hphc)
+        self.env['souscription.releve'].create(
+            {
+                'periode_id': periode.id,
+                'date': date(2024, 1, 1),
+                'nature': 'reel',
+                'index_hp': 4000.0,
+                'index_hc': 2000.0,
+            }
+        )
+        facture = periode._creer_facture()
+
+        html = self._render_facture(facture)
+        self.assertIn('relevés utilisés', html)
+        self.assertIn('4000', html)
+
+    def test_changement_compteur_trois_releves_tous_listes(self):
+        """≥3 relevés (changement de compteur) : tous listés, sans conso synthétique."""
+        periode = self.create_test_periode(self.souscription_base)
+        Releve = self.env['souscription.releve']
+        Releve.create({'periode_id': periode.id, 'date': date(2024, 1, 1), 'nature': 'reel', 'index_base': 9000.0})
+        Releve.create({'periode_id': periode.id, 'date': date(2024, 1, 15), 'nature': 'reel', 'index_base': 9100.0})
+        Releve.create({'periode_id': periode.id, 'date': date(2024, 1, 31), 'nature': 'reel', 'index_base': 50.0})
+        facture = periode._creer_facture()
+
+        html = self._render_facture(facture)
+        for jalon in ('01/01/2024', '15/01/2024', '31/01/2024'):
+            self.assertIn(jalon, html)

--- a/tests/test_releve_demo.py
+++ b/tests/test_releve_demo.py
@@ -1,0 +1,70 @@
+"""
+Validation des données de démo des relevés (#54-#57).
+
+L'enjeu central est l'INVARIANT D'ORDRE DE CHARGEMENT : dans
+`demo/souscriptions_demo.xml`, les relevés des périodes facturées doivent être
+définis AVANT les factures (`account.move`) — sinon le verrou (#56) rejetterait
+leur création et l'installation avec démo échouerait. Ce test lit le XML et
+vérifie l'ordre, **sans dépendre** du chargement effectif de la démo (que le
+runner de test n'active pas). Des contrôles « live » complètent si la démo est
+présente.
+"""
+
+import os
+
+from lxml import etree
+from odoo.exceptions import UserError
+from odoo.tests.common import TransactionCase, tagged
+
+
+@tagged('souscriptions', 'souscriptions_releve', 'post_install', '-at_install')
+class TestReleveDemoOrdre(TransactionCase):
+    """Invariant structurel : tout relevé démo précède la 1re facture démo."""
+
+    def test_releves_definis_avant_les_factures(self):
+        demo_path = os.path.join(os.path.dirname(os.path.dirname(__file__)), 'demo', 'souscriptions_demo.xml')
+        tree = etree.parse(demo_path)
+        models_in_order = [rec.get('model') for rec in tree.iter('record')]
+
+        self.assertIn('souscription.releve', models_in_order, 'Aucun relevé de démo trouvé')
+        self.assertIn('account.move', models_in_order, 'Aucune facture de démo trouvée')
+
+        derniere_releve = max(i for i, m in enumerate(models_in_order) if m == 'souscription.releve')
+        premiere_facture = min(i for i, m in enumerate(models_in_order) if m == 'account.move')
+
+        self.assertLess(
+            derniere_releve,
+            premiere_facture,
+            'Les relevés de démo doivent être définis AVANT les factures, sinon le '
+            "verrou (#56) ferait échouer l'installation avec démo.",
+        )
+
+
+@tagged('souscriptions', 'souscriptions_releve', 'post_install', '-at_install')
+class TestReleveDemoLive(TransactionCase):
+    """Contrôles sur la démo chargée (skippés si la base n'a pas la démo)."""
+
+    def _ref(self, xmlid):
+        return self.env.ref(f'souscriptions_odoo.{xmlid}', raise_if_not_found=False)
+
+    def setUp(self):
+        super().setUp()
+        if not self._ref('demo_periode_janvier_admin'):
+            self.skipTest('Données de démo non chargées sur cette base')
+
+    def test_periode_non_facturee_a_des_releves_editables(self):
+        periode = self._ref('demo_periode_janvier_base')
+        self.assertFalse(periode.facture_id)
+        self.assertTrue(periode.releve_ids)
+        periode.releve_ids[0].index_base = 12345.0  # pas de verrou avant facture
+
+    def test_periode_facturee_a_des_releves_figes(self):
+        periode = self._ref('demo_periode_janvier_admin')
+        self.assertTrue(periode.facture_id)
+        self.assertTrue(periode.releve_ids)
+        with self.assertRaises(UserError):
+            periode.releve_ids[0].index_hph = 99999.0
+
+    def test_changement_compteur_trois_releves(self):
+        periode = self._ref('demo_periode_fevrier_base')
+        self.assertEqual(len(periode.releve_ids), 3)

--- a/views/core/souscriptions_periode_views.xml
+++ b/views/core/souscriptions_periode_views.xml
@@ -87,6 +87,34 @@
                         </group>
                     </group>
 
+                    <!-- Relevés d'index utilisés (ADR 0015) : justificatif légal du
+                         calcul d'énergie, saisi à la main par le·la facturiste.
+                         Forme large par cadran réseau ; les colonnes d'index
+                         suivent le calendrier de comptage (config_cadrans). -->
+                    <group string="Relevés d'index utilisés">
+                        <field name="releve_ids" nolabel="1" colspan="2">
+                            <list editable="bottom">
+                                <field name="config_cadrans" column_invisible="1"/>
+                                <field name="date"/>
+                                <field name="nature"/>
+                                <field name="index_base"
+                                       column_invisible="parent.config_cadrans != 'base'"/>
+                                <field name="index_hp"
+                                       column_invisible="parent.config_cadrans != 'hp_hc'"/>
+                                <field name="index_hc"
+                                       column_invisible="parent.config_cadrans != 'hp_hc'"/>
+                                <field name="index_hph"
+                                       column_invisible="parent.config_cadrans != '4_cadrans'"/>
+                                <field name="index_hpb"
+                                       column_invisible="parent.config_cadrans != '4_cadrans'"/>
+                                <field name="index_hch"
+                                       column_invisible="parent.config_cadrans != '4_cadrans'"/>
+                                <field name="index_hcb"
+                                       column_invisible="parent.config_cadrans != '4_cadrans'"/>
+                            </list>
+                        </field>
+                    </group>
+
                     <group string="Documents">
                         <field name="facture_id"/>
                         <field name="facture_state"/>

--- a/views/portal_templates.xml
+++ b/views/portal_templates.xml
@@ -15,18 +15,18 @@
     <template id="portal_my_souscriptions" name="Mes Souscriptions">
         <t t-call="portal.portal_layout">
             <t t-set="breadcrumbs_searchbar" t-value="True"/>
-            
+
             <t t-call="portal.portal_searchbar">
                 <t t-set="title">Mes Souscriptions Électriques</t>
             </t>
-            
+
             <t t-if="not souscriptions">
                 <div class="alert alert-warning mt8" role="alert">
                     <p class="mb-0">Aucune souscription électrique trouvée.</p>
                     <p class="mb-0">Contactez votre fournisseur pour plus d'informations.</p>
                 </div>
             </t>
-            
+
             <t t-else="">
                 <div class="table-responsive">
                     <table class="table table-striped">
@@ -72,7 +72,7 @@
                         </tbody>
                     </table>
                 </div>
-                
+
                 <div t-if="pager" class="o_portal_pager text-center">
                     <t t-call="portal.pager"/>
                 </div>
@@ -84,7 +84,7 @@
     <template id="portal_souscription_page" name="Détail Souscription">
         <t t-call="portal.portal_layout">
             <t t-set="breadcrumbs_searchbar" t-value="True"/>
-            
+
             <div class="row mt16">
                 <!-- Sidebar -->
                 <div class="col-lg-3 d-print-none">
@@ -104,12 +104,12 @@
                                     <span class="text-muted"> - En cours</span>
                                 </t>
                             </div>
-                            
+
                             <div class="mb-3">
                                 <small class="text-muted d-block">État de facturation</small>
                                 <span t-esc="souscription.etat_facturation_id.name" class="badge rounded-pill text-bg-primary"/>
                             </div>
-                            
+
                             <div>
                                 <small class="text-muted d-block">Mode de paiement</small>
                                 <t t-if="souscription.mode_paiement">
@@ -135,7 +135,7 @@
                                 </div>
                             </div>
                         </div>
-                        
+
                         <div class="card-body">
                             <!-- Informations techniques -->
                             <div class="row mb-4">
@@ -170,7 +170,7 @@
                                         </tr>
                                     </table>
                                 </div>
-                                
+
                                 <div class="col-md-6">
                                     <h5>Facturation</h5>
                                     <t t-if="souscription.lisse">
@@ -186,7 +186,7 @@
                                     <t t-else="">
                                         <p class="text-muted">Facturation au réel</p>
                                     </t>
-                                    
+
                                     <t t-if="souscription.coeff_pro > 0">
                                         <div class="alert alert-warning">
                                             <p class="mb-0">
@@ -298,6 +298,50 @@
                                             <i class="fa fa-chevron-down"/> Voir plus
                                         </button>
                                     </div>
+                                </t>
+
+                                <!-- Justificatif — relevés d'index utilisés (#57 / ADR 0015).
+                                     Même source que le PDF (periode_id.releve_ids). `periodes`
+                                     est déjà filtré aux factures ÉMISES (postées) par le
+                                     contrôleur : aucun brouillon ne fuite côté usager. -->
+                                <t t-set="periodes_avec_releves" t-value="periodes.filtered(lambda p: p.releve_ids)"/>
+                                <t t-if="periodes_avec_releves">
+                                    <h5 class="mt-4">Justificatif — relevés d'index utilisés</h5>
+                                    <p class="text-muted" style="font-size: 0.9em;">
+                                        Index ayant servi au calcul de votre consommation, par cadran de comptage.
+                                        Vous pouvez les comparer aux index affichés sur votre compteur.
+                                    </p>
+                                    <t t-foreach="periodes_avec_releves" t-as="periode">
+                                        <t t-set="colonnes" t-value="periode.releve_colonnes()"/>
+                                        <div class="mb-3">
+                                            <strong t-out="periode.mois_annee"/>
+                                            <div class="table-responsive">
+                                                <table class="table table-sm table-striped align-middle">
+                                                    <thead>
+                                                        <tr>
+                                                            <th>Date</th>
+                                                            <th>Nature</th>
+                                                            <th t-foreach="colonnes" t-as="col" class="text-end">
+                                                                Index <span t-out="col['label']"/>
+                                                            </th>
+                                                        </tr>
+                                                    </thead>
+                                                    <tbody>
+                                                        <t t-foreach="periode.releve_ids.sorted('date')" t-as="releve">
+                                                            <tr>
+                                                                <td t-out="releve.date.strftime('%d/%m/%Y') if releve.date else ''"/>
+                                                                <td>
+                                                                    <span t-if="releve.nature == 'reel'" class="badge rounded-pill text-bg-success">Réel</span>
+                                                                    <span t-else="" class="badge rounded-pill text-bg-secondary">Estimé</span>
+                                                                </td>
+                                                                <td t-foreach="colonnes" t-as="col" class="text-end" t-out="releve[col['field']]"/>
+                                                            </tr>
+                                                        </t>
+                                                    </tbody>
+                                                </table>
+                                            </div>
+                                        </div>
+                                    </t>
                                 </t>
 
                                 <!-- Totaux (sur toutes les périodes facturées) + glossaire -->


### PR DESCRIPTION
Implémente la feature **Relevés d'index** (ADR 0015) en TDD, en un seul PR couvrant les 4 issues liées.

## Quoi

Nouveau modèle `souscription.releve`, **enfant de la _Période_** : un record = un relevé daté portant un **index par cadran réseau** (HPH/HPB/HCH/HCB, HP/HC ou Base selon `config_cadrans`, ADR 0005), de **nature** réel/estimé. Justificatif légal du calcul d'énergie et support de vérification par le·la souscripteur·rice ; **jamais** matérialisé en `account.move.line` (le `move` reste purement financier, ADR 0014).

| Issue | Tranche |
|---|---|
| #54 | Modèle + saisie backend : One2many `periode.releve_ids` éditable, colonnes pilotées par `config_cadrans`, `ir.model.access` calqués sur la Période |
| #56 | Verrou : `create`/`write`/`unlink` rejetés (`UserError`) dès que la Période est facturée — symétrique de `_LOCKED_FIELDS`. Supprimer la facture défige ; sinon régularisation |
| #55 | Justificatif PDF : bloc « relevés utilisés » par **projection** depuis `periode_id.releve_ids`, chronologique, visible en lissé et au changement de compteur (≥3 relevés) |
| #57 | Justificatif portail : même source, périodes à facture **émise** uniquement (pas de fuite de brouillon) |

## Notes de conception

- **Forme large par cadran réseau**, cardinalité variable représentée fidèlement (pas de paire `debut`/`fin` fixe — un `fin − debut` naïf serait faux à travers un changement de compteur).
- **Refactor** : le mapping cadran→colonne vit en un seul endroit, `Periode.releve_colonnes()`, itéré par les deux surfaces de rendu (PDF + portail). Point d'extension nommé pour Tempo/EJP.
- **Hors périmètre** (non demandé par les issues) : `source_hash` sur la Période et le peuplement auto au snapshot — ils relèvent du futur pull electricore (#12).
- Docs embarquées : ADR 0014, ADR 0015, terme « Relevé (d'index) » dans `CONTEXT.md`.

## Tests

15 nouveaux tests (modèle par config ; verrou create/write/unlink + défigement par suppression de facture ; rendu PDF base/lissé/changement-compteur ; portail émise vs brouillon via HttpCase). **Suite complète : 0 failed, 0 error of 153.**

Closes #54
Closes #55
Closes #56
Closes #57

🤖 Generated with [Claude Code](https://claude.com/claude-code)