### PR TITLE
docs: conditions particulières, attestation et chaîne de consentement RGPD

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -36,6 +36,28 @@ La personne ou l'organisation titulaire d'une *Souscription*. Désigné·e *usag
 contexte du *portail*.
 _Éviter_ : client, abonné·e.
 
+**Conditions particulières** :
+Le document (PDF) qui récapitule au·à la *souscripteur·rice* les conditions **propres à sa
+*Souscription*** — *PDL*, puissance, *Configuration fournisseur*, prix engagés (*Grille de prix*),
+lissage/provisions, mode de paiement — **et porte ses déclarations/consentements** (choix EDN,
+adhésion association, acceptation CGV, courbe de charge, renonciation rétractation) **et la
+signature électronique**. Il **complète** les *conditions générales* (CGV — cadre légal générique,
+**référencées** et non reproduites), pas l'inverse. C'est une **projection** de la *Souscription*
+(les consentements et la date de signature sont **portés par la *Souscription***), jamais un
+enregistrement distinct ni un acte de vente. Lève l'ambiguïté du terme « contrat » : le cadre
+contractuel = *CGV* + *conditions particulières* ; l'enregistrement = la *Souscription*.
+_Éviter_ : « contrat » seul (préciser *conditions particulières*, *CGV* ou *Souscription*) ;
+**devis**, **offre** (pas de cycle de vente, cf. *Souscription*).
+
+**Attestation de fourniture** :
+Document **court** prouvant qu'un·e *souscripteur·rice* est titulaire d'un contrat de fourniture
+**actif** — titulaire, *PDL*, adresse, **date d'effet** (« actif depuis »), puissance —, destiné aux
+tiers (bailleur, CAF, assurance). **Attestée par le fournisseur** : ne porte **ni** prix, **ni**
+consentements, **ni** signature de l'usager·ère (à la différence des *conditions particulières*).
+Comme la CP, c'est une **projection** de la *Souscription*.
+_Éviter_ : confondre avec les *conditions particulières* (l'acte d'adhésion complet) ; « attestation
+de contrat » au sens du rapport prod (qui est en réalité la CP, pas une attestation).
+
 **Période** :
 Période mensuelle de facturation d'une *Souscription* (`souscription.periode`). **Brouillon de
 travail facturable** : amorcé par les quantités calculées par electricore (méta-période), puis
@@ -118,6 +140,21 @@ facturation* existe en deux exemplaires parallèles — standard et solidaire �
 sélectionne le bon selon ce drapeau (ADR 0013).
 _Éviter_ : réduire le solidaire à une **remise** (ce n'est pas qu'un prix : c'est une comptabilité isolée).
 
+**Consentement (données de consommation)** :
+La base légale RGPD (art. 6-1-a) par laquelle un·e *souscripteur·rice* autorise EDN à faire
+**collecter auprès d'*Enedis*** ses données de consommation **plus fines que l'index de
+facturation** (consommations quotidiennes transmises au fournisseur, courbe de charge). Distinct de
+l'**acceptation contractuelle** (CGV / *conditions particulières*) et du **mandat SEPA**. Capté par
+un **acte positif** au *raccordement* (formulaire public, cases **non** pré-cochées, **par
+finalité**), tracé dans un **journal append-only** possédé par la *Souscription* — preuve opposable
+(*accountability*, art. 7-1) à la CNIL **et** à Enedis (à qui EDN **déclare** détenir le
+consentement), retrait compris (art. 7-3). L'**index** seul, pour facturer, relève de l'**exécution
+du contrat** (art. 6-1-b) et **ne requiert pas** de consentement.
+_Éviter_ : le confondre avec l'acceptation des CGV (contractuel) ou avec une « signature » (il n'y
+en a pas, cf. *conditions particulières*) ; le réduire à un **booléen** (la preuve exige horodatage
++ version du texte + retrait) ; « consentement » pour l'index de facturation (c'est l'exécution du
+contrat).
+
 **Geste commercial** :
 Ajustement par le·la *facturiste* de ce qui est **facturé** à un·e souscripteur·rice pour raison
 commerciale (ex. : RES oubliée non encore traitée par Enedis → jours facturés réduits), assumé
@@ -149,6 +186,17 @@ pour la file par défaut** (c'est *à refacturer*).
 **Facturiste** :
 Rôle métier qui conduit la facturation mensuelle depuis Odoo et **vérifie les données avant
 émission** des factures. Public cible de l'interface de vérification.
+
+**Raccordement** :
+Le workflow d'**entrée** (kanban `raccordement.demande`) qui instruit une demande de fourniture,
+de la demande jusqu'à l'étape **« Souscrit »** ; à sa clôture il **crée** le·la
+*souscripteur·rice*, le compte bancaire et la *Souscription*. C'est le point de **capture** des
+données saisies à l'adhésion — **dont les consentements et la signature** (équivalent du *LSD* de
+prod) —, **recopiées** sur la *Souscription* qui en devient **propriétaire** (système de
+référence) ; la *demande* reste un intake transitoire. Les *conditions particulières* lisent ces
+données sur la *Souscription*, jamais sur la demande.
+_Éviter_ : confondre la **demande de raccordement** (intake) et la *Souscription* (l'enregistrement
+qu'elle engendre) ; « raccordement » au sens réseau Enedis (mise en service physique du PDL).
 
 **Portail** :
 Espace en ligne en lecture du·de la *souscripteur·rice* (contrats, factures, infos utiles),

--- a/docs/adr/0016-documents-contractuels-projection-souscription-consentements-raccordement.md
+++ b/docs/adr/0016-documents-contractuels-projection-souscription-consentements-raccordement.md
@@ -1,0 +1,32 @@
+# Documents contractuels : projections de la Souscription, consentements captés au raccordement
+
+Les documents contractuels remis au·à la *souscripteur·rice* — **conditions particulières**
+(l'acte d'adhésion complet : coordonnées, lieu de consommation, options, tarifs engagés,
+déclarations/consentements, signature électronique) et **attestation de fourniture** (preuve
+courte sans prix ni consentements) — sont des **rapports QWeb projetés de la *Souscription***, pas
+un modèle de données distinct. La *Souscription* reste le système de référence ; elle est enrichie
+des **consentements** (autorisation courbe de charge, renonciation au délai de rétractation) et de
+la **date de signature électronique**, qui sont **captés au *raccordement*** (équivalent du *LSD*
+de prod) puis **recopiés** sur la *Souscription* à sa création (`_create_souscription`), laquelle
+en devient **propriétaire**.
+
+## Options considérées
+
+- **Copier les consentements sur la Souscription** (retenu) — cohérent avec le snapshot typé des
+  *Périodes* (même geste « capter à l'entrée, puis posséder ») ; la *Souscription* reste
+  auto-portante ; une *Souscription* née hors raccordement (migration prod, saisie manuelle) peut
+  porter ses consentements.
+- **Lire en transparence depuis la demande de raccordement** (rejeté) — la *Souscription* ne serait
+  plus auto-portante, les rapports seraient couplés à l'intake, et toute *Souscription* sans
+  demande associée n'aurait aucun consentement à afficher.
+
+## Conséquences
+
+- Les champs de consentement / signature existent en double : sur `raccordement.demande` (capture)
+  et sur `souscription.souscription` (référence lue par les rapports), avec mapping dans
+  `_create_souscription`.
+- Les tarifs des documents sont rendus **depuis la *Grille de prix*** (data-driven, TTC pour les
+  particuliers / HT pour les sociétés via `is_company`), jamais une image figée comme en prod.
+- La CP supersède les deux rapports prod (« Contrat V1 » à image, « Attestation de contrat »
+  data-driven) ; le rapport prod nommé « Attestation de contrat » n'est **pas** l'*attestation de
+  fourniture* définie ici.

--- a/docs/adr/0017-consentement-donnees-conso-formulaire-odoo-journal-append-only.md
+++ b/docs/adr/0017-consentement-donnees-conso-formulaire-odoo-journal-append-only.md
@@ -1,0 +1,34 @@
+# Consentement aux données de consommation : formulaire Odoo public + journal append-only, EDN seul responsable
+
+EDN **internalise la capture du consentement** RGPD (collecte auprès d'*Enedis* des données de
+consommation plus fines que l'index : consommations quotidiennes transmises au fournisseur, courbe
+de charge) dans un **formulaire public du module *raccordement*** (Odoo), au lieu du chaînage prod
+*formulaire externe → LSD → abonnement*. Le consentement est tracé dans un **journal append-only**
+(`souscription.consentement` : finalité, horodatage, version du texte affiché, source/IP, état
+donné|retiré, date de retrait), **possédé par la *Souscription***.
+
+Motif : co-localiser la **preuve** (accountability, RGPD art. 7-1) avec le système de référence,
+sous un **responsable de traitement unique** (EDN), supprimer le maillon de capture externe, et
+garantir l'**intégrité entre le texte affiché et la preuve**. EDN **déclare à Enedis** détenir le
+consentement (mécanisme admis par Enedis pour la courbe de charge) et doit pouvoir le **démontrer** ;
+un booléen coché en back-office par un·e *facturiste* ne vaut **pas** consentement — l'acte positif
+du·de la *souscripteur·rice* est requis, d'où le **formulaire public**.
+
+## Options considérées
+
+- **Formulaire externe → LSD** (prod) — la preuve vit hors du système de référence ; le PDF
+  re-affiche les consentements en texte statique, rendu par un *autre* système que la capture →
+  intégrité texte↔preuve fragile ; maillon supplémentaire. Rejeté.
+- **Booléen + preuve archivée** (`ir.attachment`) — insuffisant pour l'**historique de retrait** et
+  la **version du texte** ; un booléen mutable perd l'histoire. Rejeté.
+
+## Conséquences
+
+- Nouveau modèle `souscription.consentement` (append-only) ; l'état courant d'une finalité = sa
+  dernière ligne ; le retrait crée une ligne, n'écrase rien.
+- **Finalités granulaires** (consommations quotidiennes ≠ courbe de charge) : pas de consentement
+  groupé (exigence de spécificité, art. 4-11).
+- **Index de facturation** = exécution du contrat (art. 6-1-b), **hors** consentement.
+- Restent des chantiers **distincts** : le formulaire public lui-même, l'activation/désactivation de
+  la collecte chez Enedis (via *electricore* / SGE), et l'UI de **retrait** au *portail*.
+- Conservation de la preuve : durée du contrat + délai de prescription (cf. doc dédié).

--- a/docs/consentement-chaine-responsabilite.excalidraw
+++ b/docs/consentement-chaine-responsabilite.excalidraw
@@ -1,0 +1,514 @@
+{
+  "type": "excalidraw",
+  "version": 2,
+  "source": "https://excalidraw.com",
+  "elements": [
+    {
+      "type": "text", "id": "title", "x": 60, "y": 28, "width": 1320, "height": 40,
+      "text": "Consentement aux données de consommation — chaîne de responsabilité (RGPD / CNIL)",
+      "originalText": "Consentement aux données de consommation — chaîne de responsabilité (RGPD / CNIL)",
+      "fontSize": 28, "fontFamily": 3, "textAlign": "left", "verticalAlign": "top",
+      "strokeColor": "#1e40af", "backgroundColor": "transparent", "fillStyle": "solid",
+      "strokeWidth": 1, "strokeStyle": "solid", "roughness": 0, "opacity": 100, "angle": 0,
+      "seed": 100001, "version": 1, "versionNonce": 100002, "isDeleted": false, "groupIds": [],
+      "boundElements": null, "link": null, "locked": false, "containerId": null, "lineHeight": 1.25
+    },
+    {
+      "type": "text", "id": "subtitle", "x": 60, "y": 76, "width": 1320, "height": 22,
+      "text": "Souscrire en ligne = pas de signature.",
+      "originalText": "Souscrire en ligne = pas de signature.",
+      "fontSize": 15, "fontFamily": 3, "textAlign": "left", "verticalAlign": "top",
+      "strokeColor": "#64748b", "backgroundColor": "transparent", "fillStyle": "solid",
+      "strokeWidth": 1, "strokeStyle": "solid", "roughness": 0, "opacity": 100, "angle": 0,
+      "seed": 100003, "version": 1, "versionNonce": 100004, "isDeleted": false, "groupIds": [],
+      "boundElements": null, "link": null, "locked": false, "containerId": null, "lineHeight": 1.25
+    },
+
+    {
+      "type": "ellipse", "id": "souscripteur", "x": 60, "y": 212, "width": 175, "height": 108,
+      "strokeColor": "#c2410c", "backgroundColor": "#fed7aa", "fillStyle": "solid",
+      "strokeWidth": 2, "strokeStyle": "solid", "roughness": 0, "opacity": 100, "angle": 0,
+      "seed": 100010, "version": 1, "versionNonce": 100011, "isDeleted": false, "groupIds": [],
+      "boundElements": [{"id": "souscripteur_t", "type": "text"}], "link": null, "locked": false
+    },
+    {
+      "type": "text", "id": "souscripteur_t", "x": 70, "y": 244, "width": 155, "height": 44,
+      "text": "Souscripteur·rice\n(personne concernée)",
+      "originalText": "Souscripteur·rice\n(personne concernée)",
+      "fontSize": 14, "fontFamily": 3, "textAlign": "center", "verticalAlign": "middle",
+      "strokeColor": "#374151", "backgroundColor": "transparent", "fillStyle": "solid",
+      "strokeWidth": 1, "strokeStyle": "solid", "roughness": 0, "opacity": 100, "angle": 0,
+      "seed": 100012, "version": 1, "versionNonce": 100013, "isDeleted": false, "groupIds": [],
+      "boundElements": null, "link": null, "locked": false, "containerId": "souscripteur", "lineHeight": 1.25
+    },
+
+    {
+      "type": "rectangle", "id": "edn_zone", "x": 300, "y": 168, "width": 772, "height": 198,
+      "strokeColor": "#1e40af", "backgroundColor": "#dbeafe", "fillStyle": "solid",
+      "strokeWidth": 2, "strokeStyle": "dashed", "roughness": 0, "opacity": 100, "angle": 0,
+      "seed": 100020, "version": 1, "versionNonce": 100021, "isDeleted": false, "groupIds": [],
+      "boundElements": null, "link": null, "locked": false, "roundness": {"type": 3}
+    },
+    {
+      "type": "text", "id": "edn_zone_t", "x": 318, "y": 178, "width": 400, "height": 22,
+      "text": "EDN — responsable de traitement",
+      "originalText": "EDN — responsable de traitement",
+      "fontSize": 16, "fontFamily": 3, "textAlign": "left", "verticalAlign": "top",
+      "strokeColor": "#1e40af", "backgroundColor": "transparent", "fillStyle": "solid",
+      "strokeWidth": 1, "strokeStyle": "solid", "roughness": 0, "opacity": 100, "angle": 0,
+      "seed": 100022, "version": 1, "versionNonce": 100023, "isDeleted": false, "groupIds": [],
+      "boundElements": null, "link": null, "locked": false, "containerId": null, "lineHeight": 1.25
+    },
+
+    {
+      "type": "rectangle", "id": "form", "x": 322, "y": 240, "width": 196, "height": 104,
+      "strokeColor": "#1e3a5f", "backgroundColor": "#3b82f6", "fillStyle": "solid",
+      "strokeWidth": 2, "strokeStyle": "solid", "roughness": 0, "opacity": 100, "angle": 0,
+      "seed": 100030, "version": 1, "versionNonce": 100031, "isDeleted": false, "groupIds": [],
+      "boundElements": [{"id": "form_t", "type": "text"}], "link": null, "locked": false, "roundness": {"type": 3}
+    },
+    {
+      "type": "text", "id": "form_t", "x": 330, "y": 262, "width": 180, "height": 60,
+      "text": "Formulaire public\n(raccordement)\ncapture de l'acte positif",
+      "originalText": "Formulaire public\n(raccordement)\ncapture de l'acte positif",
+      "fontSize": 13, "fontFamily": 3, "textAlign": "center", "verticalAlign": "middle",
+      "strokeColor": "#ffffff", "backgroundColor": "transparent", "fillStyle": "solid",
+      "strokeWidth": 1, "strokeStyle": "solid", "roughness": 0, "opacity": 100, "angle": 0,
+      "seed": 100032, "version": 1, "versionNonce": 100033, "isDeleted": false, "groupIds": [],
+      "boundElements": null, "link": null, "locked": false, "containerId": "form", "lineHeight": 1.25
+    },
+
+    {
+      "type": "rectangle", "id": "souscription", "x": 556, "y": 240, "width": 216, "height": 104,
+      "strokeColor": "#1e3a5f", "backgroundColor": "#3b82f6", "fillStyle": "solid",
+      "strokeWidth": 2, "strokeStyle": "solid", "roughness": 0, "opacity": 100, "angle": 0,
+      "seed": 100040, "version": 1, "versionNonce": 100041, "isDeleted": false, "groupIds": [],
+      "boundElements": [{"id": "souscription_t", "type": "text"}], "link": null, "locked": false, "roundness": {"type": 3}
+    },
+    {
+      "type": "text", "id": "souscription_t", "x": 564, "y": 262, "width": 200, "height": 60,
+      "text": "Souscription\n+ journal consentement\n(la preuve)",
+      "originalText": "Souscription\n+ journal consentement\n(la preuve)",
+      "fontSize": 13, "fontFamily": 3, "textAlign": "center", "verticalAlign": "middle",
+      "strokeColor": "#ffffff", "backgroundColor": "transparent", "fillStyle": "solid",
+      "strokeWidth": 1, "strokeStyle": "solid", "roughness": 0, "opacity": 100, "angle": 0,
+      "seed": 100042, "version": 1, "versionNonce": 100043, "isDeleted": false, "groupIds": [],
+      "boundElements": null, "link": null, "locked": false, "containerId": "souscription", "lineHeight": 1.25
+    },
+
+    {
+      "type": "rectangle", "id": "electricore", "x": 812, "y": 240, "width": 196, "height": 104,
+      "strokeColor": "#1e3a5f", "backgroundColor": "#3b82f6", "fillStyle": "solid",
+      "strokeWidth": 2, "strokeStyle": "solid", "roughness": 0, "opacity": 100, "angle": 0,
+      "seed": 100050, "version": 1, "versionNonce": 100051, "isDeleted": false, "groupIds": [],
+      "boundElements": [{"id": "electricore_t", "type": "text"}], "link": null, "locked": false, "roundness": {"type": 3}
+    },
+    {
+      "type": "text", "id": "electricore_t", "x": 820, "y": 270, "width": 180, "height": 44,
+      "text": "electricore\nexécute la collecte",
+      "originalText": "electricore\nexécute la collecte",
+      "fontSize": 13, "fontFamily": 3, "textAlign": "center", "verticalAlign": "middle",
+      "strokeColor": "#ffffff", "backgroundColor": "transparent", "fillStyle": "solid",
+      "strokeWidth": 1, "strokeStyle": "solid", "roughness": 0, "opacity": 100, "angle": 0,
+      "seed": 100052, "version": 1, "versionNonce": 100053, "isDeleted": false, "groupIds": [],
+      "boundElements": null, "link": null, "locked": false, "containerId": "electricore", "lineHeight": 1.25
+    },
+
+    {
+      "type": "ellipse", "id": "enedis", "x": 1120, "y": 228, "width": 200, "height": 124,
+      "strokeColor": "#1e3a5f", "backgroundColor": "#60a5fa", "fillStyle": "solid",
+      "strokeWidth": 2, "strokeStyle": "solid", "roughness": 0, "opacity": 100, "angle": 0,
+      "seed": 100060, "version": 1, "versionNonce": 100061, "isDeleted": false, "groupIds": [],
+      "boundElements": [{"id": "enedis_t", "type": "text"}], "link": null, "locked": false
+    },
+    {
+      "type": "text", "id": "enedis_t", "x": 1130, "y": 262, "width": 180, "height": 60,
+      "text": "Enedis (GRD)\nresponsable distinct\nsource des données",
+      "originalText": "Enedis (GRD)\nresponsable distinct\nsource des données",
+      "fontSize": 13, "fontFamily": 3, "textAlign": "center", "verticalAlign": "middle",
+      "strokeColor": "#ffffff", "backgroundColor": "transparent", "fillStyle": "solid",
+      "strokeWidth": 1, "strokeStyle": "solid", "roughness": 0, "opacity": 100, "angle": 0,
+      "seed": 100062, "version": 1, "versionNonce": 100063, "isDeleted": false, "groupIds": [],
+      "boundElements": null, "link": null, "locked": false, "containerId": "enedis", "lineHeight": 1.25
+    },
+
+    {
+      "type": "ellipse", "id": "cnil", "x": 812, "y": 66, "width": 188, "height": 74,
+      "strokeColor": "#b45309", "backgroundColor": "#fef3c7", "fillStyle": "solid",
+      "strokeWidth": 2, "strokeStyle": "solid", "roughness": 0, "opacity": 100, "angle": 0,
+      "seed": 100070, "version": 1, "versionNonce": 100071, "isDeleted": false, "groupIds": [],
+      "boundElements": [{"id": "cnil_t", "type": "text"}], "link": null, "locked": false
+    },
+    {
+      "type": "text", "id": "cnil_t", "x": 822, "y": 88, "width": 168, "height": 30,
+      "text": "CNIL\n(autorité de contrôle)",
+      "originalText": "CNIL\n(autorité de contrôle)",
+      "fontSize": 13, "fontFamily": 3, "textAlign": "center", "verticalAlign": "middle",
+      "strokeColor": "#374151", "backgroundColor": "transparent", "fillStyle": "solid",
+      "strokeWidth": 1, "strokeStyle": "solid", "roughness": 0, "opacity": 100, "angle": 0,
+      "seed": 100072, "version": 1, "versionNonce": 100073, "isDeleted": false, "groupIds": [],
+      "boundElements": null, "link": null, "locked": false, "containerId": "cnil", "lineHeight": 1.25
+    },
+
+    {
+      "type": "arrow", "id": "a_sous_form", "x": 238, "y": 266, "width": 82, "height": 22,
+      "strokeColor": "#c2410c", "backgroundColor": "transparent", "fillStyle": "solid",
+      "strokeWidth": 2, "strokeStyle": "solid", "roughness": 0, "opacity": 100, "angle": 0,
+      "seed": 100080, "version": 1, "versionNonce": 100081, "isDeleted": false, "groupIds": [],
+      "boundElements": null, "link": null, "locked": false,
+      "points": [[0, 0], [82, 22]],
+      "startBinding": {"elementId": "souscripteur", "focus": 0, "gap": 4},
+      "endBinding": {"elementId": "form", "focus": 0, "gap": 4},
+      "startArrowhead": null, "endArrowhead": "arrow"
+    },
+    {
+      "type": "text", "id": "a_sous_form_t", "x": 232, "y": 222, "width": 96, "height": 18,
+      "text": "acte positif",
+      "originalText": "acte positif",
+      "fontSize": 12, "fontFamily": 3, "textAlign": "center", "verticalAlign": "top",
+      "strokeColor": "#c2410c", "backgroundColor": "transparent", "fillStyle": "solid",
+      "strokeWidth": 1, "strokeStyle": "solid", "roughness": 0, "opacity": 100, "angle": 0,
+      "seed": 100082, "version": 1, "versionNonce": 100083, "isDeleted": false, "groupIds": [],
+      "boundElements": null, "link": null, "locked": false, "containerId": null, "lineHeight": 1.25
+    },
+    {
+      "type": "arrow", "id": "a_form_sous", "x": 518, "y": 292, "width": 38, "height": 0,
+      "strokeColor": "#1e3a5f", "backgroundColor": "transparent", "fillStyle": "solid",
+      "strokeWidth": 2, "strokeStyle": "solid", "roughness": 0, "opacity": 100, "angle": 0,
+      "seed": 100084, "version": 1, "versionNonce": 100085, "isDeleted": false, "groupIds": [],
+      "boundElements": null, "link": null, "locked": false,
+      "points": [[0, 0], [38, 0]],
+      "startBinding": {"elementId": "form", "focus": 0, "gap": 2},
+      "endBinding": {"elementId": "souscription", "focus": 0, "gap": 2},
+      "startArrowhead": null, "endArrowhead": "arrow"
+    },
+    {
+      "type": "text", "id": "a_form_sous_t", "x": 510, "y": 266, "width": 54, "height": 18,
+      "text": "écrit",
+      "originalText": "écrit",
+      "fontSize": 12, "fontFamily": 3, "textAlign": "center", "verticalAlign": "top",
+      "strokeColor": "#64748b", "backgroundColor": "transparent", "fillStyle": "solid",
+      "strokeWidth": 1, "strokeStyle": "solid", "roughness": 0, "opacity": 100, "angle": 0,
+      "seed": 100086, "version": 1, "versionNonce": 100087, "isDeleted": false, "groupIds": [],
+      "boundElements": null, "link": null, "locked": false, "containerId": null, "lineHeight": 1.25
+    },
+    {
+      "type": "arrow", "id": "a_sous_elec", "x": 772, "y": 292, "width": 40, "height": 0,
+      "strokeColor": "#1e3a5f", "backgroundColor": "transparent", "fillStyle": "solid",
+      "strokeWidth": 2, "strokeStyle": "solid", "roughness": 0, "opacity": 100, "angle": 0,
+      "seed": 100088, "version": 1, "versionNonce": 100089, "isDeleted": false, "groupIds": [],
+      "boundElements": null, "link": null, "locked": false,
+      "points": [[0, 0], [40, 0]],
+      "startBinding": {"elementId": "souscription", "focus": 0, "gap": 2},
+      "endBinding": {"elementId": "electricore", "focus": 0, "gap": 2},
+      "startArrowhead": null, "endArrowhead": "arrow"
+    },
+    {
+      "type": "arrow", "id": "a_decl", "x": 1008, "y": 268, "width": 112, "height": 12,
+      "strokeColor": "#1e3a5f", "backgroundColor": "transparent", "fillStyle": "solid",
+      "strokeWidth": 2, "strokeStyle": "solid", "roughness": 0, "opacity": 100, "angle": 0,
+      "seed": 100090, "version": 1, "versionNonce": 100091, "isDeleted": false, "groupIds": [],
+      "boundElements": null, "link": null, "locked": false,
+      "points": [[0, 0], [112, -12]],
+      "startBinding": {"elementId": "electricore", "focus": 0, "gap": 2},
+      "endBinding": {"elementId": "enedis", "focus": 0, "gap": 2},
+      "startArrowhead": null, "endArrowhead": "arrow"
+    },
+    {
+      "type": "text", "id": "a_decl_t", "x": 1000, "y": 200, "width": 132, "height": 36,
+      "text": "déclare détenir\nle consentement",
+      "originalText": "déclare détenir\nle consentement",
+      "fontSize": 12, "fontFamily": 3, "textAlign": "center", "verticalAlign": "top",
+      "strokeColor": "#1e40af", "backgroundColor": "transparent", "fillStyle": "solid",
+      "strokeWidth": 1, "strokeStyle": "solid", "roughness": 0, "opacity": 100, "angle": 0,
+      "seed": 100092, "version": 1, "versionNonce": 100093, "isDeleted": false, "groupIds": [],
+      "boundElements": null, "link": null, "locked": false, "containerId": null, "lineHeight": 1.25
+    },
+    {
+      "type": "arrow", "id": "a_pull", "x": 1008, "y": 320, "width": 112, "height": 6,
+      "strokeColor": "#1e3a5f", "backgroundColor": "transparent", "fillStyle": "solid",
+      "strokeWidth": 2, "strokeStyle": "solid", "roughness": 0, "opacity": 100, "angle": 0,
+      "seed": 100094, "version": 1, "versionNonce": 100095, "isDeleted": false, "groupIds": [],
+      "boundElements": null, "link": null, "locked": false,
+      "points": [[0, 0], [112, 6]],
+      "startBinding": {"elementId": "electricore", "focus": 0, "gap": 2},
+      "endBinding": {"elementId": "enedis", "focus": 0, "gap": 2},
+      "startArrowhead": null, "endArrowhead": "arrow"
+    },
+    {
+      "type": "text", "id": "a_pull_t", "x": 1012, "y": 348, "width": 150, "height": 18,
+      "text": "pull (données consenties)",
+      "originalText": "pull (données consenties)",
+      "fontSize": 12, "fontFamily": 3, "textAlign": "center", "verticalAlign": "top",
+      "strokeColor": "#64748b", "backgroundColor": "transparent", "fillStyle": "solid",
+      "strokeWidth": 1, "strokeStyle": "solid", "roughness": 0, "opacity": 100, "angle": 0,
+      "seed": 100096, "version": 1, "versionNonce": 100097, "isDeleted": false, "groupIds": [],
+      "boundElements": null, "link": null, "locked": false, "containerId": null, "lineHeight": 1.25
+    },
+    {
+      "type": "arrow", "id": "a_cnil", "x": 702, "y": 240, "width": 204, "height": 108,
+      "strokeColor": "#b45309", "backgroundColor": "transparent", "fillStyle": "solid",
+      "strokeWidth": 2, "strokeStyle": "dashed", "roughness": 0, "opacity": 100, "angle": 0,
+      "seed": 100098, "version": 1, "versionNonce": 100099, "isDeleted": false, "groupIds": [],
+      "boundElements": null, "link": null, "locked": false,
+      "points": [[0, 0], [204, -108]],
+      "startBinding": {"elementId": "souscription", "focus": 0, "gap": 2},
+      "endBinding": {"elementId": "cnil", "focus": 0, "gap": 2},
+      "startArrowhead": null, "endArrowhead": "arrow"
+    },
+    {
+      "type": "text", "id": "a_cnil_t", "x": 726, "y": 150, "width": 200, "height": 18,
+      "text": "doit démontrer (art. 7-1)",
+      "originalText": "doit démontrer (art. 7-1)",
+      "fontSize": 12, "fontFamily": 3, "textAlign": "left", "verticalAlign": "top",
+      "strokeColor": "#b45309", "backgroundColor": "transparent", "fillStyle": "solid",
+      "strokeWidth": 1, "strokeStyle": "solid", "roughness": 0, "opacity": 100, "angle": 0,
+      "seed": 100100, "version": 1, "versionNonce": 100101, "isDeleted": false, "groupIds": [],
+      "boundElements": null, "link": null, "locked": false, "containerId": null, "lineHeight": 1.25
+    },
+
+    {
+      "type": "text", "id": "grad_title", "x": 60, "y": 470, "width": 460, "height": 24,
+      "text": "Quelle donnée → quel régime ?",
+      "originalText": "Quelle donnée → quel régime ?",
+      "fontSize": 18, "fontFamily": 3, "textAlign": "left", "verticalAlign": "top",
+      "strokeColor": "#1e40af", "backgroundColor": "transparent", "fillStyle": "solid",
+      "strokeWidth": 1, "strokeStyle": "solid", "roughness": 0, "opacity": 100, "angle": 0,
+      "seed": 300001, "version": 1, "versionNonce": 300002, "isDeleted": false, "groupIds": [],
+      "boundElements": null, "link": null, "locked": false, "containerId": null, "lineHeight": 1.25
+    },
+    {
+      "type": "rectangle", "id": "grad_index", "x": 60, "y": 504, "width": 452, "height": 56,
+      "strokeColor": "#047857", "backgroundColor": "#a7f3d0", "fillStyle": "solid",
+      "strokeWidth": 2, "strokeStyle": "solid", "roughness": 0, "opacity": 100, "angle": 0,
+      "seed": 300010, "version": 1, "versionNonce": 300011, "isDeleted": false, "groupIds": [],
+      "boundElements": [{"id": "grad_index_t", "type": "text"}], "link": null, "locked": false, "roundness": {"type": 3}
+    },
+    {
+      "type": "text", "id": "grad_index_t", "x": 70, "y": 514, "width": 432, "height": 38,
+      "text": "Index (relevé) → facturer\nPAS de consentement · exécution du contrat (RGPD art. 6.1.b)",
+      "originalText": "Index (relevé) → facturer\nPAS de consentement · exécution du contrat (RGPD art. 6.1.b)",
+      "fontSize": 13, "fontFamily": 3, "textAlign": "center", "verticalAlign": "middle",
+      "strokeColor": "#374151", "backgroundColor": "transparent", "fillStyle": "solid",
+      "strokeWidth": 1, "strokeStyle": "solid", "roughness": 0, "opacity": 100, "angle": 0,
+      "seed": 300012, "version": 1, "versionNonce": 300013, "isDeleted": false, "groupIds": [],
+      "boundElements": null, "link": null, "locked": false, "containerId": "grad_index", "lineHeight": 1.25
+    },
+    {
+      "type": "text", "id": "grad_seuil_t", "x": 130, "y": 566, "width": 300, "height": 16,
+      "text": "— seuil du consentement —",
+      "originalText": "— seuil du consentement —",
+      "fontSize": 12, "fontFamily": 3, "textAlign": "center", "verticalAlign": "top",
+      "strokeColor": "#dc2626", "backgroundColor": "transparent", "fillStyle": "solid",
+      "strokeWidth": 1, "strokeStyle": "solid", "roughness": 0, "opacity": 100, "angle": 0,
+      "seed": 300020, "version": 1, "versionNonce": 300021, "isDeleted": false, "groupIds": [],
+      "boundElements": null, "link": null, "locked": false, "containerId": null, "lineHeight": 1.25
+    },
+    {
+      "type": "line", "id": "grad_seuil", "x": 60, "y": 584, "width": 452, "height": 0,
+      "strokeColor": "#dc2626", "backgroundColor": "transparent", "fillStyle": "solid",
+      "strokeWidth": 2, "strokeStyle": "dashed", "roughness": 0, "opacity": 100, "angle": 0,
+      "seed": 300022, "version": 1, "versionNonce": 300023, "isDeleted": false, "groupIds": [],
+      "boundElements": null, "link": null, "locked": false,
+      "points": [[0, 0], [452, 0]]
+    },
+    {
+      "type": "rectangle", "id": "grad_quot", "x": 60, "y": 592, "width": 452, "height": 56,
+      "strokeColor": "#b45309", "backgroundColor": "#fef3c7", "fillStyle": "solid",
+      "strokeWidth": 2, "strokeStyle": "solid", "roughness": 0, "opacity": 100, "angle": 0,
+      "seed": 300030, "version": 1, "versionNonce": 300031, "isDeleted": false, "groupIds": [],
+      "boundElements": [{"id": "grad_quot_t", "type": "text"}], "link": null, "locked": false, "roundness": {"type": 3}
+    },
+    {
+      "type": "text", "id": "grad_quot_t", "x": 70, "y": 602, "width": 432, "height": 38,
+      "text": "Conso quotidienne (transmise au fournisseur)\nConsentement requis (RGPD art. 6.1.a)",
+      "originalText": "Conso quotidienne (transmise au fournisseur)\nConsentement requis (RGPD art. 6.1.a)",
+      "fontSize": 13, "fontFamily": 3, "textAlign": "center", "verticalAlign": "middle",
+      "strokeColor": "#374151", "backgroundColor": "transparent", "fillStyle": "solid",
+      "strokeWidth": 1, "strokeStyle": "solid", "roughness": 0, "opacity": 100, "angle": 0,
+      "seed": 300032, "version": 1, "versionNonce": 300033, "isDeleted": false, "groupIds": [],
+      "boundElements": null, "link": null, "locked": false, "containerId": "grad_quot", "lineHeight": 1.25
+    },
+    {
+      "type": "rectangle", "id": "grad_courbe", "x": 60, "y": 662, "width": 452, "height": 56,
+      "strokeColor": "#dc2626", "backgroundColor": "#fee2e2", "fillStyle": "solid",
+      "strokeWidth": 2, "strokeStyle": "solid", "roughness": 0, "opacity": 100, "angle": 0,
+      "seed": 300040, "version": 1, "versionNonce": 300041, "isDeleted": false, "groupIds": [],
+      "boundElements": [{"id": "grad_courbe_t", "type": "text"}], "link": null, "locked": false, "roundness": {"type": 3}
+    },
+    {
+      "type": "text", "id": "grad_courbe_t", "x": 70, "y": 672, "width": 432, "height": 38,
+      "text": "Courbe de charge (30 min)\nConsentement explicite",
+      "originalText": "Courbe de charge (30 min)\nConsentement explicite",
+      "fontSize": 13, "fontFamily": 3, "textAlign": "center", "verticalAlign": "middle",
+      "strokeColor": "#374151", "backgroundColor": "transparent", "fillStyle": "solid",
+      "strokeWidth": 1, "strokeStyle": "solid", "roughness": 0, "opacity": 100, "angle": 0,
+      "seed": 300042, "version": 1, "versionNonce": 300043, "isDeleted": false, "groupIds": [],
+      "boundElements": null, "link": null, "locked": false, "containerId": "grad_courbe", "lineHeight": 1.25
+    },
+
+    {
+      "type": "text", "id": "log_title", "x": 558, "y": 470, "width": 340, "height": 22,
+      "text": "La preuve : journal append-only",
+      "originalText": "La preuve : journal append-only",
+      "fontSize": 16, "fontFamily": 3, "textAlign": "left", "verticalAlign": "top",
+      "strokeColor": "#1e40af", "backgroundColor": "transparent", "fillStyle": "solid",
+      "strokeWidth": 1, "strokeStyle": "solid", "roughness": 0, "opacity": 100, "angle": 0,
+      "seed": 400001, "version": 1, "versionNonce": 400002, "isDeleted": false, "groupIds": [],
+      "boundElements": null, "link": null, "locked": false, "containerId": null, "lineHeight": 1.25
+    },
+    {
+      "type": "rectangle", "id": "log_box", "x": 558, "y": 502, "width": 330, "height": 152,
+      "strokeColor": "#1e293b", "backgroundColor": "#1e293b", "fillStyle": "solid",
+      "strokeWidth": 1, "strokeStyle": "solid", "roughness": 0, "opacity": 100, "angle": 0,
+      "seed": 400010, "version": 1, "versionNonce": 400011, "isDeleted": false, "groupIds": [],
+      "boundElements": null, "link": null, "locked": false, "roundness": {"type": 3}
+    },
+    {
+      "type": "text", "id": "log_t", "x": 576, "y": 516, "width": 300, "height": 126,
+      "text": "souscription.consentement\n{ finalite: 'courbe_de_charge',\n  date, version_texte,\n  source, ip,\n  etat: 'donne' | 'retire',\n  date_retrait }",
+      "originalText": "souscription.consentement\n{ finalite: 'courbe_de_charge',\n  date, version_texte,\n  source, ip,\n  etat: 'donne' | 'retire',\n  date_retrait }",
+      "fontSize": 13, "fontFamily": 3, "textAlign": "left", "verticalAlign": "top",
+      "strokeColor": "#22c55e", "backgroundColor": "transparent", "fillStyle": "solid",
+      "strokeWidth": 1, "strokeStyle": "solid", "roughness": 0, "opacity": 100, "angle": 0,
+      "seed": 400012, "version": 1, "versionNonce": 400013, "isDeleted": false, "groupIds": [],
+      "boundElements": null, "link": null, "locked": false, "containerId": null, "lineHeight": 1.35
+    },
+    {
+      "type": "arrow", "id": "a_log", "x": 664, "y": 346, "width": 40, "height": 156,
+      "strokeColor": "#64748b", "backgroundColor": "transparent", "fillStyle": "solid",
+      "strokeWidth": 1, "strokeStyle": "dashed", "roughness": 0, "opacity": 100, "angle": 0,
+      "seed": 400020, "version": 1, "versionNonce": 400021, "isDeleted": false, "groupIds": [],
+      "boundElements": null, "link": null, "locked": false,
+      "points": [[0, 0], [40, 156]],
+      "startBinding": {"elementId": "souscription", "focus": 0, "gap": 2},
+      "endBinding": {"elementId": "log_box", "focus": 0, "gap": 2},
+      "startArrowhead": null, "endArrowhead": "arrow"
+    },
+
+    {
+      "type": "text", "id": "form_title", "x": 920, "y": 470, "width": 430, "height": 24,
+      "text": "L'autre fil : la formation du contrat",
+      "originalText": "L'autre fil : la formation du contrat",
+      "fontSize": 16, "fontFamily": 3, "textAlign": "left", "verticalAlign": "top",
+      "strokeColor": "#1e40af", "backgroundColor": "transparent", "fillStyle": "solid",
+      "strokeWidth": 1, "strokeStyle": "solid", "roughness": 0, "opacity": 100, "angle": 0,
+      "seed": 500001, "version": 1, "versionNonce": 500002, "isDeleted": false, "groupIds": [],
+      "boundElements": null, "link": null, "locked": false, "containerId": null, "lineHeight": 1.25
+    },
+    {
+      "type": "text", "id": "form_bul", "x": 920, "y": 508, "width": 432, "height": 170,
+      "text": "•  Le clic forme un contrat valide (consensualisme, art. 1172)\n•  Double-clic : vérifier / corriger / confirmer (art. 1127-2)\n•  Confirmation sur support durable avant fourniture (L221-13)\n•  Le PDF des conditions particulières = cette confirmation,\n     et non une signature\n•  Preuve = journaux + confirmation",
+      "originalText": "•  Le clic forme un contrat valide (consensualisme, art. 1172)\n•  Double-clic : vérifier / corriger / confirmer (art. 1127-2)\n•  Confirmation sur support durable avant fourniture (L221-13)\n•  Le PDF des conditions particulières = cette confirmation,\n     et non une signature\n•  Preuve = journaux + confirmation",
+      "fontSize": 13, "fontFamily": 3, "textAlign": "left", "verticalAlign": "top",
+      "strokeColor": "#374151", "backgroundColor": "transparent", "fillStyle": "solid",
+      "strokeWidth": 1, "strokeStyle": "solid", "roughness": 0, "opacity": 100, "angle": 0,
+      "seed": 500010, "version": 1, "versionNonce": 500011, "isDeleted": false, "groupIds": [],
+      "boundElements": null, "link": null, "locked": false, "containerId": null, "lineHeight": 1.5
+    },
+
+    {
+      "type": "line", "id": "cmp_div", "x": 60, "y": 752, "width": 1290, "height": 0,
+      "strokeColor": "#64748b", "backgroundColor": "transparent", "fillStyle": "solid",
+      "strokeWidth": 1, "strokeStyle": "dashed", "roughness": 0, "opacity": 100, "angle": 0,
+      "seed": 600000, "version": 1, "versionNonce": 600001, "isDeleted": false, "groupIds": [],
+      "boundElements": null, "link": null, "locked": false,
+      "points": [[0, 0], [1290, 0]]
+    },
+    {
+      "type": "text", "id": "cmp_title", "x": 60, "y": 770, "width": 600, "height": 22,
+      "text": "Prod vs cible — où vit la preuve ?",
+      "originalText": "Prod vs cible — où vit la preuve ?",
+      "fontSize": 16, "fontFamily": 3, "textAlign": "left", "verticalAlign": "top",
+      "strokeColor": "#1e40af", "backgroundColor": "transparent", "fillStyle": "solid",
+      "strokeWidth": 1, "strokeStyle": "solid", "roughness": 0, "opacity": 100, "angle": 0,
+      "seed": 600010, "version": 1, "versionNonce": 600011, "isDeleted": false, "groupIds": [],
+      "boundElements": null, "link": null, "locked": false, "containerId": null, "lineHeight": 1.25
+    },
+    {
+      "type": "text", "id": "cmp_prod", "x": 60, "y": 804, "width": 1290, "height": 20,
+      "text": "✕  Prod : formulaire EXTERNE → LSD (Odoo) → abonnement   ·   preuve hors du système, PDF en texte statique (divergence)",
+      "originalText": "✕  Prod : formulaire EXTERNE → LSD (Odoo) → abonnement   ·   preuve hors du système, PDF en texte statique (divergence)",
+      "fontSize": 14, "fontFamily": 3, "textAlign": "left", "verticalAlign": "top",
+      "strokeColor": "#b91c1c", "backgroundColor": "transparent", "fillStyle": "solid",
+      "strokeWidth": 1, "strokeStyle": "solid", "roughness": 0, "opacity": 100, "angle": 0,
+      "seed": 600020, "version": 1, "versionNonce": 600021, "isDeleted": false, "groupIds": [],
+      "boundElements": null, "link": null, "locked": false, "containerId": null, "lineHeight": 1.25
+    },
+    {
+      "type": "text", "id": "cmp_cible", "x": 60, "y": 832, "width": 1290, "height": 20,
+      "text": "✓  Cible : formulaire INTERNE (raccordement) → souscription + journal   ·   preuve co-localisée, un seul responsable",
+      "originalText": "✓  Cible : formulaire INTERNE (raccordement) → souscription + journal   ·   preuve co-localisée, un seul responsable",
+      "fontSize": 14, "fontFamily": 3, "textAlign": "left", "verticalAlign": "top",
+      "strokeColor": "#047857", "backgroundColor": "transparent", "fillStyle": "solid",
+      "strokeWidth": 1, "strokeStyle": "solid", "roughness": 0, "opacity": 100, "angle": 0,
+      "seed": 600030, "version": 1, "versionNonce": 600031, "isDeleted": false, "groupIds": [],
+      "boundElements": null, "link": null, "locked": false, "containerId": null, "lineHeight": 1.25
+    },
+
+    {
+      "type": "rectangle", "id": "doc_conf", "x": 300, "y": 386, "width": 300, "height": 60,
+      "strokeColor": "#1e40af", "backgroundColor": "#dbeafe", "fillStyle": "solid",
+      "strokeWidth": 2, "strokeStyle": "solid", "roughness": 0, "opacity": 100, "angle": 0,
+      "seed": 700001, "version": 1, "versionNonce": 700002, "isDeleted": false, "groupIds": [],
+      "boundElements": [{"id": "doc_conf_t", "type": "text"}], "link": null, "locked": false, "roundness": {"type": 3}
+    },
+    {
+      "type": "text", "id": "doc_conf_t", "x": 308, "y": 397, "width": 284, "height": 38,
+      "text": "Confirmation sur support durable\n= Conditions Particulières (PDF)",
+      "originalText": "Confirmation sur support durable\n= Conditions Particulières (PDF)",
+      "fontSize": 13, "fontFamily": 3, "textAlign": "center", "verticalAlign": "middle",
+      "strokeColor": "#1e40af", "backgroundColor": "transparent", "fillStyle": "solid",
+      "strokeWidth": 1, "strokeStyle": "solid", "roughness": 0, "opacity": 100, "angle": 0,
+      "seed": 700003, "version": 1, "versionNonce": 700004, "isDeleted": false, "groupIds": [],
+      "boundElements": null, "link": null, "locked": false, "containerId": "doc_conf", "lineHeight": 1.25
+    },
+    {
+      "type": "arrow", "id": "a_emet", "x": 575, "y": 344, "width": 125, "height": 42,
+      "strokeColor": "#047857", "backgroundColor": "transparent", "fillStyle": "solid",
+      "strokeWidth": 2, "strokeStyle": "solid", "roughness": 0, "opacity": 100, "angle": 0,
+      "seed": 700010, "version": 1, "versionNonce": 700011, "isDeleted": false, "groupIds": [],
+      "boundElements": null, "link": null, "locked": false,
+      "points": [[0, 0], [-125, 42]],
+      "startBinding": {"elementId": "souscription", "focus": 0, "gap": 2},
+      "endBinding": {"elementId": "doc_conf", "focus": 0, "gap": 2},
+      "startArrowhead": null, "endArrowhead": "arrow"
+    },
+    {
+      "type": "text", "id": "a_emet_t", "x": 470, "y": 356, "width": 110, "height": 16,
+      "text": "EDN émet",
+      "originalText": "EDN émet",
+      "fontSize": 11, "fontFamily": 3, "textAlign": "center", "verticalAlign": "top",
+      "strokeColor": "#047857", "backgroundColor": "transparent", "fillStyle": "solid",
+      "strokeWidth": 1, "strokeStyle": "solid", "roughness": 0, "opacity": 100, "angle": 0,
+      "seed": 700012, "version": 1, "versionNonce": 700013, "isDeleted": false, "groupIds": [],
+      "boundElements": null, "link": null, "locked": false, "containerId": null, "lineHeight": 1.25
+    },
+    {
+      "type": "arrow", "id": "a_conf_sous", "x": 300, "y": 416, "width": 108, "height": 96,
+      "strokeColor": "#047857", "backgroundColor": "transparent", "fillStyle": "solid",
+      "strokeWidth": 2, "strokeStyle": "solid", "roughness": 0, "opacity": 100, "angle": 0,
+      "seed": 700020, "version": 1, "versionNonce": 700021, "isDeleted": false, "groupIds": [],
+      "boundElements": null, "link": null, "locked": false,
+      "points": [[0, 0], [-108, -96]],
+      "startBinding": {"elementId": "doc_conf", "focus": 0, "gap": 2},
+      "endBinding": {"elementId": "souscripteur", "focus": 0, "gap": 2},
+      "startArrowhead": null, "endArrowhead": "arrow"
+    },
+    {
+      "type": "text", "id": "a_conf_sous_t", "x": 58, "y": 388, "width": 230, "height": 48,
+      "text": "remis au·à la souscripteur·rice\nsur support durable,\navant fourniture (L221-13 / L221-5)",
+      "originalText": "remis au·à la souscripteur·rice\nsur support durable,\navant fourniture (L221-13 / L221-5)",
+      "fontSize": 11, "fontFamily": 3, "textAlign": "left", "verticalAlign": "top",
+      "strokeColor": "#047857", "backgroundColor": "transparent", "fillStyle": "solid",
+      "strokeWidth": 1, "strokeStyle": "solid", "roughness": 0, "opacity": 100, "angle": 0,
+      "seed": 700022, "version": 1, "versionNonce": 700023, "isDeleted": false, "groupIds": [],
+      "boundElements": null, "link": null, "locked": false, "containerId": null, "lineHeight": 1.3
+    }
+  ],
+  "appState": {
+    "viewBackgroundColor": "#ffffff",
+    "gridSize": 20
+  },
+  "files": {}
+}

--- a/docs/consentement-donnees-conso.md
+++ b/docs/consentement-donnees-conso.md
@@ -1,0 +1,166 @@
+# Consentement aux données de consommation — chaîne de responsabilité (RGPD / CNIL)
+
+> Note de référence. Le glossaire ([CONTEXT.md](../CONTEXT.md)) définit le terme
+> *Consentement (données de consommation)* ; la décision d'architecture est
+> [ADR 0017](adr/0017-consentement-donnees-conso-formulaire-odoo-journal-append-only.md).
+> Ce document n'est pas un avis juridique : faire valider le périmètre et les libellés par le·la DPO.
+
+## Résumé (TL;DR)
+
+1. **Il n'y a pas de signature.** Souscrire en ligne forme un contrat valide par simple échange des
+   consentements (consensualisme). Le « Signé électroniquement le… » de prod est en réalité une
+   **date de validation de formulaire**, pas une signature.
+2. **Deux régimes à ne jamais confondre** : l'**acceptation contractuelle** (CGV / conditions
+   particulières) et le **consentement RGPD** à la collecte de données. Ils ont des règles de
+   preuve différentes.
+3. **L'index suffit-il à facturer → pas de consentement** (exécution du contrat). Dès qu'on collecte
+   **plus fin** (conso quotidienne transmise au fournisseur, courbe de charge) → **consentement RGPD
+   obligatoire**, démontrable, versionné, révocable.
+4. **EDN déclare à Enedis** détenir le consentement → **EDN porte la charge de la preuve**. D'où le
+   choix d'un **journal append-only** co-localisé avec la *Souscription*, et d'un **formulaire de
+   capture interne** (module raccordement) plutôt qu'externe.
+
+---
+
+## 1. La formation du contrat en ligne — sans signature
+
+- **Consensualisme** (Code civil, art. 1172) : un contrat se forme par le seul échange des
+  consentements ; la signature n'est **pas** une condition de validité (sauf contrats solennels).
+  Souscrire par un clic forme donc un contrat valide.
+- **Validité ≠ preuve.** Le clic forme le contrat ; le prouver ensuite relève d'un autre mécanisme.
+- **Contrat électronique B2C** : le **« double clic »** (Code civil, art. 1127-2) — le·la
+  consommateur·rice doit pouvoir **vérifier et corriger** sa commande puis la **confirmer** ; le
+  professionnel en **accuse réception** par voie électronique.
+- **Confirmation sur support durable** (Code de la conso., art. L221-13) : le fournisseur doit
+  remettre la confirmation du contrat sur support durable, **avant le début d'exécution**, avec
+  toutes les informations de l'art. L221-5.
+- **Conséquence pour nous** : le **PDF des conditions particulières** est la **confirmation sur
+  support durable**, pas un contrat signé. Sa valeur probante vient d'être cette confirmation **+**
+  les **journaux** de la souscription (horodatage, version des CGV acceptée, double-clic), pas d'une
+  signature.
+
+## 2. Le consentement RGPD aux données de consommation
+
+> **Repère** : « art. 6-1-a/b » renvoie au **RGPD** (Règlement (UE) 2016/679), **Article 6
+> « Licéité du traitement », paragraphe 1**, qui liste les 6 bases légales (a→f) : a) consentement,
+> b) exécution du contrat, c) obligation légale, d) intérêts vitaux, e) mission d'intérêt public,
+> f) intérêts légitimes.
+
+### Gradation Enedis (le cœur du sujet)
+
+| Donnée | Base légale | Consentement ? |
+|---|---|---|
+| **Index** (relevé périodique) servant à **facturer** | Exécution du contrat (RGPD art. 6-1-b) | **Non** |
+| **Consommations quotidiennes** transmises au **fournisseur** (au-delà du besoin de facturation) | Consentement (art. 6-1-a) | **Oui** |
+| **Courbe de charge** (horaire / demi-horaire) | Consentement explicite | **Oui** |
+
+Enedis : *« au-delà de ce qui est nécessaire à la facturation, aucune information n'est transmise à
+un tiers sans le consentement libre, éclairé, spécifique et univoque du client »*. Pour la courbe de
+charge, Enedis recueille soit le consentement du client (personne physique), soit une
+**déclaration du fournisseur attestant qu'il détient ce consentement**. La transmission récurrente
+peut être **interrompue à tout moment** sur simple demande (retrait).
+
+### Conditions d'un consentement valable (RGPD art. 4-11 et 7)
+
+- **Libre, spécifique, éclairé, univoque** — un **acte positif** (case **non** pré-cochée ; le
+  silence ou une case déjà cochée ne valent pas consentement).
+- **Spécifique = granulaire** : une finalité = un consentement (ne pas grouper « conso quotidienne »
+  et « courbe de charge » en une seule case).
+- **Démontrable** (*accountability*, art. 7-1) : le responsable doit pouvoir **prouver** que la
+  personne a consenti.
+- **Révocable** (art. 7-3) : le retrait doit être **aussi simple** que le consentement.
+
+### Éléments à journaliser pour la preuve
+
+Qui (identifiant unique) · Quelle **finalité** précise · **Quand** (horodatage) · **Comment**
+(case à cocher / formulaire) · **Quelle version du texte** affichée (capture ou empreinte datée) ·
+**Retrait** (possibilité + date effective). Un **booléen** ne suffit pas : il perd le quand, la
+version et l'historique de retrait.
+
+## 3. La chaîne de responsabilité (rôles RGPD)
+
+- **Souscripteur·rice** — *personne concernée*.
+- **EDN** — *responsable de traitement* (controller) : c'est son contrat, ses finalités.
+- **Formulaire public** (module *raccordement*, Odoo) — **point de capture de l'acte positif**, sous
+  le contrôle d'EDN (pas de sous-traitant externe).
+- **`souscription.souscription` + journal `souscription.consentement`** — système de référence et
+  **lieu de la preuve**.
+- **electricore** — service d'EDN qui **exécute** la collecte consentie (pull Enedis).
+- **Enedis (GRD)** — *tiers*, responsable de traitement **distinct** ; **source** des données et
+  **destinataire de la déclaration de consentement** d'EDN.
+- **CNIL** — autorité de contrôle (cible de l'*accountability*), **hors** flux de données.
+
+### Les deux fils, de bout en bout
+
+**A. Formation du contrat** : formulaire (offre : CGV + CP + tarifs) → double-clic (vérifier /
+corriger / confirmer) → accusé de réception → `date_validation` enregistrée → **confirmation sur
+support durable** (PDF CP) avant le début de fourniture. *Preuve = journaux du formulaire +
+confirmation. Pas de signature.*
+
+**B. Consentement données de consommation** : acte positif granulaire sur le formulaire (cases non
+pré-cochées, texte versionné) → **ligne dans `souscription.consentement`** (finalité, horodatage,
+version, source, état=donné) → EDN **déclare le consentement à Enedis** et demande l'activation
+(via electricore / SGE) → Enedis collecte / transmet, electricore pull → **retrait** : nouvelle
+ligne (état=retiré, date_retrait) → EDN demande la **désactivation** à Enedis. *Preuve = le journal
+append-only + la version du texte.*
+
+## 4. Pourquoi internaliser le formulaire (vs prod : externe → LSD)
+
+LSD = *Liste des Souscriptions Différées*, un **module Odoo** (équivalent prod du *raccordement*). Le
+seul maillon **externe** de la prod est donc le **formulaire**. Internaliser ce formulaire dans le
+*raccordement* :
+
+| Dimension | Externe → LSD (prod) | Formulaire Odoo interne (cible) |
+|---|---|---|
+| Point de capture de l'acte | Hors Odoo | Odoo, possédé par EDN |
+| Où vit la preuve | Système du formulaire ; Odoo ne reçoit qu'un digest | **Avec le système de référence** |
+| Intégrité texte ↔ preuve | PDF = texte statique rendu par un **autre** système → divergence | Texte affiché = consentement stocké = PDF, **source versionnée unique** |
+| Rôles | Maillon externe (sous-traitant si tiers) | **Un seul responsable**, pas de sous-traitant |
+| Retrait & droits | Éclatés | Un seul système |
+
+**Condition impérative** : le formulaire doit être **public** (l'acte est celui du·de la
+souscripteur·rice). Un formulaire back-office rempli par un·e facturiste **ne produit pas** de
+consentement valable.
+
+## 5. Modèle de données — journal de consentement append-only
+
+`souscription.consentement` (immuable, une ligne par événement) :
+
+| Champ | Rôle |
+|---|---|
+| `souscription_id` | rattachement (identifiant unique de la personne via le contrat) |
+| `finalite` | ex. `donnees_quotidiennes`, `courbe_de_charge` (granulaire) |
+| `date` | horodatage de l'acte |
+| `version_texte` | référence/empreinte du libellé affiché |
+| `source`, `ip` | preuve du canal (formulaire public) |
+| `etat` | `donne` \| `retire` |
+| `date_retrait` | effectivité du retrait (art. 7-3) |
+
+État courant d'une finalité = **dernière ligne**. Le retrait **ajoute** une ligne ; rien n'est écrasé.
+
+## 6. Conservation
+
+Conserver la **preuve du consentement** le temps nécessaire pour la démontrer : durée du contrat +
+délai de prescription des actions (en pratique ~5 ans pour les actions contractuelles ;
+recommandation CNIL de conserver la preuve du consentement quelques années après son retrait / la
+fin de la relation). À fixer avec le·la DPO.
+
+## 7. Hors périmètre de ce module (chantiers distincts)
+
+- Le **formulaire public** de souscription (website/portal Odoo) qui écrit le journal.
+- L'**activation / désactivation** de la collecte chez Enedis (via electricore / SGE).
+- L'**UI de retrait** au portail (art. 7-3 : aussi simple que donner).
+
+## Sources
+
+- [Consensualisme en droit français — Wikipédia](https://fr.wikipedia.org/wiki/Consensualisme_en_droit_fran%C3%A7ais)
+- [Code civil, art. 1127-2 (contrat électronique, « double clic ») — Légifrance](https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000032007506)
+- [Preuve du contrat électronique B2C (double-clic, support durable L221-13) — Saint-Louis Recouvrement](https://www.saint-louis-recouvrement.com/preuve-contrat-electronique/)
+- [« Le clic équivaut à une signature » — CGV-Expert](https://www.cgv-expert.fr/prestation-redaction-conditions-generales/validation-cgv-clic-signature-manuscrite)
+- [Prouver le consentement : traçabilité RGPD — Deshoulières Avocats](https://www.deshoulieres-avocats.com/prouver-le-consentement-comment-batir-une-tracabilite-rgpd/)
+- [Lignes directrices sur le consentement (WP259) — CNIL](https://www.cnil.fr/sites/cnil/files/atoms/files/ldconsentement_wp259_rev_0.1_fr.pdf)
+- [Données personnelles — Enedis](https://www.enedis.fr/donnees-personnelles)
+- [J'accède à mes données de mesure (index / quotidien / courbe de charge) — Enedis](https://www.enedis.fr/jaccede-mes-donnees-de-mesure)
+- [Compteurs Linky : EDF et Engie mis en demeure par la CNIL — Vie-publique](https://www.vie-publique.fr/en-bref/273429-compteurs-linky-edf-et-engie-mis-en-demeure-par-la-cnil)
+- [Sanction de 600 000 € à l'encontre d'EDF (prospection, sécurité — *pas* la courbe de charge) — CNIL](https://www.cnil.fr/fr/prospection-commerciale-et-droits-des-personnes-sanction-de-600-000-euros-lencontre-dedf)
+- [Protection des données personnelles et énergie — Seban Avocats](https://www.seban-associes.avocat.fr/protection-des-donnees-personnelles-et-energie/)


### PR DESCRIPTION
## Contexte

Documentation issue d'une session de cadrage (`grill-with-docs`) sur **deux sujets liés** : les documents contractuels modernes et la **traçabilité du consentement** (RGPD/CNIL). **Aucun code** — uniquement glossaire, ADR, note de référence et diagramme.

## Contenu

**Documents contractuels**
- `CONTEXT.md` — nouveaux termes : *Conditions particulières*, *Attestation de fourniture*, *Raccordement*.
- **ADR 0016** — la CP et l'attestation sont des **projections de la *Souscription*** (pas un modèle distinct) ; les consentements sont **captés au raccordement** puis **possédés par la Souscription** (rejet du read-through).

**Chaîne de consentement (RGPD/CNIL)**
- `CONTEXT.md` — terme *Consentement (données de consommation)*.
- **ADR 0017** — consentement capté par **formulaire Odoo public** + **journal append-only** (`souscription.consentement`), **EDN seul responsable** (vs prod : formulaire externe → LSD).
- `docs/consentement-donnees-conso.md` — note de référence **avec sources** : consensualisme (pas de signature), double-clic (art. 1127-2), confirmation sur support durable (L221-13 / L221-5), gradation Enedis (index = exécution du contrat ; conso quotidienne + courbe de charge = consentement).
- `docs/consentement-chaine-responsabilite.excalidraw` — diagramme de la chaîne de responsabilité (PNG rendu localement, **non versionné** : dépasse la limite 500 Ko du hook, régénérable depuis la source).

## Points marquants

- **Pas de signature** en souscription en ligne : la preuve = journaux + confirmation sur support durable, pas une signature ; le PDF des CP *est* cette confirmation (L221-13).
- **L'index facture sans consentement** (art. 6-1-b RGPD) ; toute donnée plus fine l'exige (art. 6-1-a) — et comme EDN **déclare à Enedis** détenir le consentement, la **preuve** doit vivre dans le système de référence (journal append-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
