### PR TITLE
Démo locale : entrypoint docker réparé + grilles de démo affines

### DIFF
--- a/demo/grille_prix_demo.xml
+++ b/demo/grille_prix_demo.xml
@@ -62,5 +62,73 @@
             <field name="type_produit">energie</field>
             <field name="prix_unitaire">0.1520</field>
         </record>
+
+        <!-- ============================================================== -->
+        <!-- Grille historique 2024 : explicitement fermée (date_fin) pour  -->
+        <!-- ne pas chevaucher la grille 2025 ouverte. Démontre la sélection -->
+        <!-- par date (get_grille_active) et la régularisation aux prix      -->
+        <!-- historiques : facturer un mois 2024 utilise ces tarifs.        -->
+        <!-- ============================================================== -->
+        <record id="grille_prix_2024" model="grille.prix">
+            <field name="name">Grille tarifaire 2024</field>
+            <field name="date_debut">2024-01-01</field>
+            <field name="date_fin">2024-12-31</field>
+        </record>
+
+        <!-- Abonnement affine 2024 (tarifs plus bas qu'en 2025) -->
+        <record id="prix_abo_std_2024" model="grille.prix.ligne">
+            <field name="grille_id" ref="grille_prix_2024"/>
+            <field name="product_id" ref="souscriptions_product_abonnement_standard"/>
+            <field name="type_produit">abonnement</field>
+            <field name="prix_base_3kva">140.00</field>
+            <field name="coef_kva">11.00</field>
+        </record>
+        <record id="prix_abo_sol_2024" model="grille.prix.ligne">
+            <field name="grille_id" ref="grille_prix_2024"/>
+            <field name="product_id" ref="souscriptions_product_abonnement_solidaire"/>
+            <field name="type_produit">abonnement</field>
+            <field name="prix_base_3kva">112.00</field>
+            <field name="coef_kva">9.00</field>
+        </record>
+
+        <!-- Énergies standard 2024 (€/kWh) -->
+        <record id="prix_energie_base_2024" model="grille.prix.ligne">
+            <field name="grille_id" ref="grille_prix_2024"/>
+            <field name="product_id" ref="souscriptions_product_energie_base"/>
+            <field name="type_produit">energie</field>
+            <field name="prix_unitaire">0.1700</field>
+        </record>
+        <record id="prix_energie_hp_2024" model="grille.prix.ligne">
+            <field name="grille_id" ref="grille_prix_2024"/>
+            <field name="product_id" ref="souscriptions_product_energie_hp"/>
+            <field name="type_produit">energie</field>
+            <field name="prix_unitaire">0.1850</field>
+        </record>
+        <record id="prix_energie_hc_2024" model="grille.prix.ligne">
+            <field name="grille_id" ref="grille_prix_2024"/>
+            <field name="product_id" ref="souscriptions_product_energie_hc"/>
+            <field name="type_produit">energie</field>
+            <field name="prix_unitaire">0.1400</field>
+        </record>
+
+        <!-- Énergies solidaires 2024 (€/kWh) — produits isolés (ADR 0013) -->
+        <record id="prix_energie_base_sol_2024" model="grille.prix.ligne">
+            <field name="grille_id" ref="grille_prix_2024"/>
+            <field name="product_id" ref="souscriptions_product_energie_base_solidaire"/>
+            <field name="type_produit">energie</field>
+            <field name="prix_unitaire">0.1700</field>
+        </record>
+        <record id="prix_energie_hp_sol_2024" model="grille.prix.ligne">
+            <field name="grille_id" ref="grille_prix_2024"/>
+            <field name="product_id" ref="souscriptions_product_energie_hp_solidaire"/>
+            <field name="type_produit">energie</field>
+            <field name="prix_unitaire">0.1850</field>
+        </record>
+        <record id="prix_energie_hc_sol_2024" model="grille.prix.ligne">
+            <field name="grille_id" ref="grille_prix_2024"/>
+            <field name="product_id" ref="souscriptions_product_energie_hc_solidaire"/>
+            <field name="type_produit">energie</field>
+            <field name="prix_unitaire">0.1400</field>
+        </record>
     </data>
 </odoo>

--- a/demo/souscriptions_demo.xml
+++ b/demo/souscriptions_demo.xml
@@ -369,36 +369,9 @@
             <field name="index_hcb">1100</field>
         </record>
 
-        <!-- ================================ -->
-        <!-- GRILLE DE PRIX COMPLÈTE         -->
-        <!-- ================================ -->
-
-        <!-- Grille de prix réaliste 2024 -->
-        <record id="demo_grille_prix_complete_2024" model="grille.prix">
-            <field name="name">Tarifs électricité 2024 - Complets</field>
-            <field name="date_debut">2024-01-01</field>
-            <field name="date_fin">2024-12-31</field>
-            <field name="active">True</field>
-        </record>
-
-        <!-- Prix énergies réalistes -->
-        <record id="demo_prix_energie_base_2024" model="grille.prix.ligne">
-            <field name="grille_id" ref="demo_grille_prix_complete_2024"/>
-            <field name="product_id" ref="souscriptions_product_energie_base"/>
-            <field name="prix_interne">0.2276</field>
-        </record>
-
-        <record id="demo_prix_energie_hp_2024" model="grille.prix.ligne">
-            <field name="grille_id" ref="demo_grille_prix_complete_2024"/>
-            <field name="product_id" ref="souscriptions_product_energie_hp"/>
-            <field name="prix_interne">0.2516</field>
-        </record>
-
-        <record id="demo_prix_energie_hc_2024" model="grille.prix.ligne">
-            <field name="grille_id" ref="demo_grille_prix_complete_2024"/>
-            <field name="product_id" ref="souscriptions_product_energie_hc"/>
-            <field name="prix_interne">0.2032</field>
-        </record>
+        <!-- Les grilles de prix de démo (2024 historique + 2025 courante) sont
+             définies dans grille_prix_demo.xml, au schéma affine (ADR 0018) :
+             une seule source, pas de doublon ni de chevauchement. -->
 
         <!-- ================================ -->
         <!-- FACTURES ADMIN (PORTAL TESTING) -->

--- a/docker/docker-entrypoint-init.sh
+++ b/docker/docker-entrypoint-init.sh
@@ -1,9 +1,18 @@
 #!/bin/bash
 set -e
 
-# Script d'entrée qui initialise automatiquement la démo au premier lancement
+# Entrypoint de développement : au premier lancement, crée la base, installe
+# souscriptions_odoo et charge les données de démo du *manifeste* (source unique),
+# puis lance le serveur Odoo. Aux lancements suivants, démarre directement.
+#
+# Notes :
+# - Le module s'appelle `souscriptions_odoo` (pas `souscriptions`).
+# - Dans ce harnais, `-i` ne charge PAS les fichiers `demo:` du manifeste ; on les
+#   charge explicitement via `force_demo` dans un `odoo shell`. On ne ré-écrit donc
+#   plus de données de démo à la main : tout vient de `demo/*.xml`.
 
-# Fonction pour attendre PostgreSQL
+DB=souscriptions_demo
+
 wait_for_postgres() {
     echo "Attente de PostgreSQL..."
     export PGPASSWORD=$PASSWORD
@@ -14,103 +23,32 @@ wait_for_postgres() {
     echo " PostgreSQL prêt!"
 }
 
-# Attendre que PostgreSQL soit prêt
 wait_for_postgres
 
-# Vérifier si la base de données existe déjà
 export PGPASSWORD=$PASSWORD
-if psql -h "$HOST" -U "$USER" -d postgres -lqt | cut -d \| -f 1 | grep -qw souscriptions_demo; then
-    echo "✅ Base de données déjà initialisée"
+if psql -h "$HOST" -U "$USER" -d postgres -lqt | cut -d \| -f 1 | grep -qw "$DB"; then
+    echo "✅ Base '$DB' déjà initialisée"
 else
-    echo "🗄️ Initialisation de la base de données..."
-    
-    # Créer la base
-    createdb -h "$HOST" -U "$USER" souscriptions_demo
-    
-    # Initialiser Odoo avec le module
+    echo "🗄️  Création de la base + installation de souscriptions_odoo..."
+    createdb -h "$HOST" -U "$USER" "$DB"
     odoo --db_host="$HOST" --db_user="$USER" --db_password="$PASSWORD" \
-         --database=souscriptions_demo --init=souscriptions \
-         --load-language=fr_FR --stop-after-init
-    
-    # Créer les données de démo
-    echo "📊 Création des données de démo..."
-    odoo shell --db_host="$HOST" --db_user="$USER" --db_password="$PASSWORD" -d souscriptions_demo <<'EOF'
-# Créer des partenaires de test
-partners = []
-for i, (name, is_pro) in enumerate([
-    ("Jean Dupont", False),
-    ("Marie Martin", False),
-    ("Boulangerie Artisanale SARL", True),
-    ("Restaurant Le Gourmet", True)
-]):
-    partner = env["res.partner"].create({
-        "name": name,
-        "is_company": is_pro,
-        "street": f"{i+1} rue de la Demo",
-        "city": "Paris",
-        "zip": f"7500{i+1}",
-        "country_id": env.ref("base.fr").id,
-        "phone": f"01 23 45 67 8{i}",
-        "email": f"{name.lower().replace(' ', '.')}@demo.fr"
-    })
-    partners.append(partner)
+         -d "$DB" -i souscriptions_odoo --load-language=fr_FR --stop-after-init
 
-# Créer une grille de prix
-grille = env["grille.prix"].create({
-    "name": "Grille démo 2025",
-    "date_debut": "2025-01-01",
-    "active": True
-})
-
-# Prix des produits
-for xml_id, prix in [
-    ("souscriptions_product_energie_base", 0.25),
-    ("souscriptions_product_energie_hp", 0.30),
-    ("souscriptions_product_energie_hc", 0.20)
-]:
-    product = env.ref(f"souscriptions.{xml_id}")
-    env["grille.prix.ligne"].create({
-        "grille_id": grille.id,
-        "product_id": product.id,
-        "prix_interne": prix
-    })
-
-# Créer des souscriptions
-souscriptions_data = [
-    (partners[0], "6", "base", False, 100, 0, 0),
-    (partners[1], "9", "hphc", True, 0, 120, 80),
-    (partners[2], "12", "base", True, 300, 0, 0),
-    (partners[3], "18", "hphc", False, 0, 250, 150)
-]
-
-# Récupérer l'état de facturation par défaut
-etat_a_facturer = env.ref("souscriptions.etat_a_facturer")
-
-for i, (partner, puissance, tarif, lisse, base_kwh, hp_kwh, hc_kwh) in enumerate(souscriptions_data):
-    env["souscription.souscription"].create({
-        "partner_id": partner.id,
-        "date_debut": "2025-01-01",
-        "puissance_souscrite": puissance,
-        "type_tarif": tarif,
-        "lisse": lisse,
-        "provision_mensuelle_kwh": base_kwh,
-        "provision_hp_kwh": hp_kwh,
-        "provision_hc_kwh": hc_kwh,
-        "pdl": f"0000000000{i+1}",
-        "mode_paiement": "prelevement" if i % 2 == 0 else "virement",
-        "coeff_pro": 10.0 if partner.is_company else 0.0,
-        "ref_compteur": f"COMP{i+1:04d}",
-        "numero_depannage": "09 726 750 01",
-        "etat_facturation_id": etat_a_facturer.id
-    })
-
+    echo "📊 Chargement des données de démo du manifeste (force_demo)..."
+    odoo shell --db_host="$HOST" --db_user="$USER" --db_password="$PASSWORD" -d "$DB" <<'PY'
+import odoo.modules.loading as loading
+loading.force_demo(env)
 env.cr.commit()
-print("✅ Données de démo créées avec succès!")
-EOF
-    
-    echo "✅ Base de données initialisée!"
+print("✅ Données de démo chargées (grilles, souscriptions, périodes…)")
+PY
+    echo "✅ Base '$DB' prête"
 fi
 
-# Lancer Odoo normalement avec la base de données par défaut
+# La commande compose commence historiquement par « odoo » ; on le retire car on
+# relance odoo nous-mêmes ci-dessous (sinon : « unrecognized parameters: odoo »).
+if [ "$1" = "odoo" ]; then
+    shift
+fi
+
 exec odoo --db_host="$HOST" --db_user="$USER" --db_password="$PASSWORD" \
-          --database=souscriptions_demo --db-filter=souscriptions_demo "$@"
+          -d "$DB" --db-filter="^${DB}$" "$@"


### PR DESCRIPTION
Empilée sur #68 (à fusionner après). Rend `docker compose up` fonctionnel pour la démo locale.

## Contenu
- **fix(docker)** : l'entrypoint charge la démo du **manifeste** via `force_demo` (au lieu d'un seed manuel cassé). Corrige le nom du module (`souscriptions` → `souscriptions_odoo`), les préfixes `env.ref`, et le démarrage (`unrecognized parameters: odoo`).
- **demo(grille)** : grilles de démo **affines consolidées** dans `grille_prix_demo.xml` (2024 historique fermée + 2025 ouverte). Supprime la grille 2024 obsolète de `souscriptions_demo.xml` (schéma pré-affine `prix_interne`, sans abonnement) qui faisait planter `force_demo` — bug latent de #68 non couvert par les tests (la démo n'est pas chargée en test).

## Vérifié (docker)
`force_demo` charge les 2 grilles (8 lignes chacune, 2 abo affines) sans erreur ; le serveur démarre, `db-filter` correct.

## Tester
```
docker compose -f docker/docker-compose.yml up --build
```
→ http://localhost:8069 (admin/admin), base `souscriptions_demo` avec démo complète.

🤖 Generated with [Claude Code](https://claude.com/claude-code)