### PR TITLE
fix(souscription): unifier la provision par cadran (raccordement HP/HC lissé facturait 0 kWh)

### DIFF
--- a/models/core/souscription.py
+++ b/models/core/souscription.py
@@ -166,6 +166,25 @@ class Souscription(models.Model):
         'hphc': [('hp', 'Heures pleines'), ('hc', 'Heures creuses')],
     }
 
+    def _provisions_cadrans(self):
+        """Provision mensuelle par cadran facturé ('base'/'hp'/'hc') — source
+        unique (#73). HP/HC explicites (`provision_hp_kwh`/`provision_hc_kwh`)
+        si renseignées, tel que peuplé par le raccordement ; sinon répartition
+        70% HP / 30% HC de `provision_mensuelle_kwh`. Consommée par la création
+        de Période (snapshot figé, ADR 0006) et par la projection documents
+        (ADR 0016) : la règle de répartition ne vit qu'ici.
+        """
+        self.ensure_one()
+        if self.provision_hp_kwh or self.provision_hc_kwh:
+            hp, hc = self.provision_hp_kwh, self.provision_hc_kwh
+        else:
+            hp, hc = self.provision_mensuelle_kwh * 0.7, self.provision_mensuelle_kwh * 0.3
+        return {
+            'base': self.provision_mensuelle_kwh,
+            'hp': hp,
+            'hc': hc,
+        }
+
     def _prix_documents(self, a_date=None):
         """Prix engagés à projeter sur les *Conditions particulières* (ADR 0016).
 
@@ -209,12 +228,9 @@ class Souscription(models.Model):
         abo_an = affiche(abo_product, abo_jour_ht * 365.0)
         abo_mois = affiche(abo_product, abo_jour_ht * 365.0 / 12.0)
 
-        # Provision mensuelle par cadran facturé (utilisée pour la mensualité).
-        provisions = {
-            'base': self.provision_mensuelle_kwh,
-            'hp': self.provision_hp_kwh,
-            'hc': self.provision_hc_kwh,
-        }
+        # Provision mensuelle par cadran facturé (utilisée pour la mensualité) —
+        # source unique _provisions_cadrans() (#73).
+        provisions = self._provisions_cadrans()
 
         energies = []
         mensualite = abo_mois

--- a/models/core/souscription_periode.py
+++ b/models/core/souscription_periode.py
@@ -165,13 +165,19 @@ class SouscriptionPeriode(models.Model):
                 }
             )
 
-            # Gestion des provisions selon type de tarif
-            if sous.lisse and sous.provision_mensuelle_kwh:
+            # Provisions par cadran selon type de tarif — source unique
+            # souscription._provisions_cadrans() (#73) : hp/hc explicites
+            # (peuplées par le raccordement) priment, sinon répartition 70/30
+            # de la mensuelle. La répartition ne vit qu'à cet unique endroit.
+            # N'écrase jamais une provision déjà fournie explicitement à create()
+            # (saisie manuelle d'une période, tests).
+            if sous.lisse:
+                provisions = sous._provisions_cadrans()
                 if sous.type_tarif == 'base':
-                    vals['provision_base_kwh'] = sous.provision_mensuelle_kwh
-                else:  # HP/HC - répartition temporaire 70% HP / 30% HC
-                    vals['provision_hp_kwh'] = sous.provision_mensuelle_kwh * 0.7
-                    vals['provision_hc_kwh'] = sous.provision_mensuelle_kwh * 0.3
+                    vals.setdefault('provision_base_kwh', provisions['base'])
+                else:  # HP/HC
+                    vals.setdefault('provision_hp_kwh', provisions['hp'])
+                    vals.setdefault('provision_hc_kwh', provisions['hc'])
 
         return super().create(vals_list)
 

--- a/tests/test_raccordement.py
+++ b/tests/test_raccordement.py
@@ -595,6 +595,53 @@ class TestRaccordementWorkflow(SouscriptionsTestMixin, TransactionCase):
         self.assertEqual(souscription.provision_hp_kwh, 150.0)
         self.assertEqual(souscription.provision_hc_kwh, 100.0)
 
+    def test_raccordement_hphc_lisse_facture_energie_non_nulle(self):
+        """Régression #73 : une souscription HP/HC lissée née du raccordement
+        (provision_hp_kwh/provision_hc_kwh peuplées, provision_mensuelle_kwh à 0)
+        produit une Période dont les provisions par cadran sont non nulles, et
+        dont la facture porte une quantité d'énergie non nulle — cohérente avec
+        la mensualité affichée sur les conditions particulières."""
+        demande = self.create_complete_demande(
+            type_tarif='hphc',
+            provision_hp_kwh=150.0,
+            provision_hc_kwh=100.0,
+            provision_mensuelle_kwh=0.0,
+        )
+
+        demande.stage_id = self.stage_final
+        souscription = demande.souscription_id
+        self.assertTrue(souscription.lisse, 'Le raccordement active le lissage par défaut')
+
+        # La CP affiche une mensualité non nulle pour cette souscription (grille
+        # de test active sur 2024, indépendante de la date de début souhaitée).
+        mensualite_cp = souscription._prix_documents(a_date=date(2024, 1, 1))['mensualite']
+        self.assertGreater(mensualite_cp, 0.0, 'La CP doit afficher une mensualité non nulle')
+
+        periode = self.env['souscription.periode'].create(
+            {
+                'souscription_id': souscription.id,
+                'date_debut': date(2024, 1, 1),
+                'date_fin': date(2024, 1, 31),
+                'type_periode': 'mensuelle',
+            }
+        )
+
+        # La Période doit porter des provisions par cadran non nulles, cohérentes
+        # avec ce qui a été saisi au raccordement.
+        self.assertEqual(periode.provision_hp_kwh, 150.0)
+        self.assertEqual(periode.provision_hc_kwh, 100.0)
+
+        produits = [vals for (_cmd, _id, vals) in periode._composer_lignes(self.grille_prix) if vals.get('product_id')]
+        hp = next(d for d in produits if d['name'] == 'Énergie HP')
+        hc = next(d for d in produits if d['name'] == 'Énergie HC')
+        self.assertEqual(hp['quantity'], 150.0)
+        self.assertEqual(hc['quantity'], 100.0)
+        self.assertGreater(
+            hp['quantity'] + hc['quantity'],
+            0.0,
+            "La facture doit porter une quantité d'énergie non nulle (provision HP+HC)",
+        )
+
     def test_create_odoo_entries_no_bank_for_other_payment(self):
         """Test de création sans compte bancaire pour autre mode de paiement"""
         demande = self.create_complete_demande(

--- a/tests/test_souscription.py
+++ b/tests/test_souscription.py
@@ -55,6 +55,47 @@ class TestSouscription(TransactionCase):
         self.assertEqual(souscription.type_tarif, 'hphc')
         self.assertEqual(souscription.provision_mensuelle_kwh, 500.0)
 
+    def test_provisions_cadrans_repartition_70_30(self):
+        """_provisions_cadrans() répartit la provision mensuelle 70% HP / 30% HC
+        quand hp/hc ne sont pas renseignées explicitement (issue #73)."""
+        souscription = self.env['souscription.souscription'].create(
+            {
+                'partner_id': self.partner.id,
+                'pdl': 'PDL_REPARTITION',
+                'puissance_souscrite': '9',
+                'type_tarif': 'hphc',
+                'etat_facturation_id': self.etat_actif.id,
+                'provision_mensuelle_kwh': 500.0,
+            }
+        )
+
+        provisions = souscription._provisions_cadrans()
+
+        self.assertEqual(provisions['hp'], 350.0)
+        self.assertEqual(provisions['hc'], 150.0)
+        self.assertEqual(provisions['base'], 500.0)
+
+    def test_provisions_cadrans_explicites_priment(self):
+        """_provisions_cadrans() renvoie les provisions HP/HC explicites telles
+        quelles (cas raccordement) sans passer par la répartition 70/30, même si
+        provision_mensuelle_kwh vaut 0 (issue #73)."""
+        souscription = self.env['souscription.souscription'].create(
+            {
+                'partner_id': self.partner.id,
+                'pdl': 'PDL_EXPLICITE',
+                'puissance_souscrite': '9',
+                'type_tarif': 'hphc',
+                'etat_facturation_id': self.etat_actif.id,
+                'provision_hp_kwh': 200.0,
+                'provision_hc_kwh': 120.0,
+            }
+        )
+
+        provisions = souscription._provisions_cadrans()
+
+        self.assertEqual(provisions['hp'], 200.0)
+        self.assertEqual(provisions['hc'], 120.0)
+
     def test_coefficient_pro(self):
         """Test majoration PRO"""
         souscription = self.env['souscription.souscription'].create(


### PR DESCRIPTION
Closes #73

## Résumé
- Bug racine : `souscription_periode.create()` ne dérivait les provisions HP/HC
  que depuis `provision_mensuelle_kwh` (règle 70/30), alors que le workflow
  raccordement peuple `provision_hp_kwh`/`provision_hc_kwh` directement et
  laisse `provision_mensuelle_kwh` à 0 — une souscription HP/HC lissée née du
  raccordement facturait donc 0 kWh d'énergie malgré une CP à mensualité non nulle.
- Introduit `souscription._provisions_cadrans()` comme source unique (hp/hc
  explicites si renseignées, sinon répartition 70/30 de la mensuelle) ;
  consommée à la fois par la création de Période (snapshot figé, ADR 0006,
  via `setdefault` pour ne jamais écraser une provision de période saisie
  explicitement) et par la projection documents (`_prix_documents`, ADR 0016).
- La règle 70/30 ne vit plus qu'à un seul endroit (`souscription.py`).
- Ajoute un test de régression bout-en-bout (raccordement → souscription →
  période → composition de facture) et deux tests unitaires sur
  `_provisions_cadrans()`.

Suite complète : **0 failed, 0 error(s) of 183 tests** (docker, DB fraîche).

🤖 Generated with [Claude Code](https://claude.com/claude-code)