### PR TITLE
fix(raccordement): garde is_company + non-écrasement d'identité sur réutilisation partner

### DIFF
--- a/models/raccordement/raccordement_demande.py
+++ b/models/raccordement/raccordement_demande.py
@@ -376,12 +376,23 @@ class RaccordementDemande(models.Model):
                 'is_company': False,  # C'est un particulier
             }
 
-        # Vérifier si un contact existe déjà avec cet email
-        existing_partner = self.env['res.partner'].search([('email', '=', self.contact_email)], limit=1)
+        # Vérifier si un contact existe déjà avec cet email : recherche
+        # insensible à la casse (=ilike), restreinte aux partners actifs et de
+        # même nature (société/particulier) que la demande. Sans ce filtre sur
+        # is_company, une demande PRO pourrait retomber sur un particulier
+        # existant et écraser son identité (et inversement).
+        existing_partner = self.env['res.partner'].search(
+            [('email', '=ilike', self.contact_email), ('is_company', '=', self.pro)], limit=1
+        )
 
         if existing_partner:
-            # Mettre à jour le contact existant
-            existing_partner.write(partner_vals)
+            # Réutiliser le contact existant sans écraser son identité (nom,
+            # adresse, is_company...) : seule la demande est tracée, le
+            # contact n'est pas modifié.
+            self.message_post(
+                body=f'Contact existant réutilisé : {existing_partner.name} (ID: {existing_partner.id}), '
+                'identité non modifiée.'
+            )
             return existing_partner
         else:
             # Créer un nouveau contact

--- a/tests/test_raccordement.py
+++ b/tests/test_raccordement.py
@@ -609,24 +609,125 @@ class TestRaccordementWorkflow(SouscriptionsTestMixin, TransactionCase):
         self.assertFalse(demande.partner_bank_id, 'Compte bancaire ne devrait pas être créé')
         self.assertTrue(demande.souscription_id, 'Souscription devrait être créée')
 
-    def test_existing_partner_update(self):
-        """Test de mise à jour d'un contact existant"""
+    def test_existing_partner_reused_without_identity_overwrite(self):
+        """Un partner existant (même nature pro/particulier) est réutilisé,
+        mais ses champs d'identité (nom, adresse) ne sont pas écrasés."""
         # Créer un contact existant avec le même email
         existing_partner = self.env['res.partner'].create(
             {
                 'name': 'Ancien Nom',
                 'email': 'test@example.com',
                 'city': 'Ancienne Ville',
+                'is_company': False,
             }
         )
 
         demande = self.create_complete_demande()
         demande.stage_id = self.stage_final
 
-        # Le contact existant devrait être mis à jour
+        # Le contact existant est réutilisé (même ID), mais son identité
+        # n'est pas écrasée par les données de la demande.
         self.assertEqual(demande.partner_id.id, existing_partner.id)
-        self.assertEqual(existing_partner.name, 'Test User')  # prénom + nom
-        self.assertEqual(existing_partner.city, 'Test City')
+        self.assertEqual(existing_partner.name, 'Ancien Nom')
+        self.assertEqual(existing_partner.city, 'Ancienne Ville')
+
+        # La réutilisation est tracée au chatter de la demande.
+        messages = demande.message_ids.mapped('body')
+        self.assertTrue(
+            any('Ancien Nom' in body or 'existant' in body for body in messages),
+            'La réutilisation du partner existant devrait être tracée au chatter',
+        )
+
+    def test_pro_demande_does_not_match_particulier_partner(self):
+        """Une demande PRO avec l'email d'un particulier existant crée une
+        société, sans modifier le particulier existant."""
+        existing_particulier = self.env['res.partner'].create(
+            {
+                'name': 'Jean Dupont',
+                'email': 'test@example.com',
+                'city': 'Ancienne Ville',
+                'is_company': False,
+            }
+        )
+
+        demande = self.create_complete_demande(
+            pro=True,
+            contact_nom='SARL Test Énergie',
+            contact_prenom='',
+            siret='12345678901234',
+        )
+        demande.stage_id = self.stage_final
+
+        # Une nouvelle société est créée, distincte du particulier existant.
+        self.assertTrue(demande.partner_id)
+        self.assertNotEqual(demande.partner_id.id, existing_particulier.id)
+        self.assertTrue(demande.partner_id.is_company)
+        self.assertEqual(demande.partner_id.name, 'SARL Test Énergie')
+
+        # Le particulier existant reste intact.
+        self.assertEqual(existing_particulier.name, 'Jean Dupont')
+        self.assertFalse(existing_particulier.is_company)
+        self.assertEqual(existing_particulier.city, 'Ancienne Ville')
+
+    def test_particulier_demande_does_not_match_pro_partner(self):
+        """Une demande particulier avec l'email d'une société existante crée
+        un nouveau contact, sans modifier la société existante."""
+        existing_company = self.env['res.partner'].create(
+            {
+                'name': 'Ancienne SARL',
+                'email': 'test@example.com',
+                'city': 'Ancienne Ville',
+                'is_company': True,
+            }
+        )
+
+        demande = self.create_complete_demande(pro=False)
+        demande.stage_id = self.stage_final
+
+        self.assertTrue(demande.partner_id)
+        self.assertNotEqual(demande.partner_id.id, existing_company.id)
+        self.assertFalse(demande.partner_id.is_company)
+
+        self.assertEqual(existing_company.name, 'Ancienne SARL')
+        self.assertTrue(existing_company.is_company)
+        self.assertEqual(existing_company.city, 'Ancienne Ville')
+
+    def test_existing_partner_match_is_case_insensitive_on_email(self):
+        """La recherche par email doit ignorer la casse."""
+        existing_partner = self.env['res.partner'].create(
+            {
+                'name': 'Ancien Nom',
+                'email': 'Test@Example.com',
+                'is_company': False,
+            }
+        )
+
+        demande = self.create_complete_demande(contact_email='TEST@EXAMPLE.COM')
+        demande.stage_id = self.stage_final
+
+        self.assertEqual(demande.partner_id.id, existing_partner.id)
+        self.assertEqual(existing_partner.name, 'Ancien Nom')
+
+    def test_archived_partner_not_reused(self):
+        """Un partner archivé partageant l'email n'est pas réutilisé : une
+        demande crée un nouveau contact plutôt que de toucher un contact
+        désactivé."""
+        archived_partner = self.env['res.partner'].create(
+            {
+                'name': 'Ancien Contact Archivé',
+                'email': 'test@example.com',
+                'is_company': False,
+                'active': False,
+            }
+        )
+
+        demande = self.create_complete_demande()
+        demande.stage_id = self.stage_final
+
+        self.assertTrue(demande.partner_id)
+        self.assertNotEqual(demande.partner_id.id, archived_partner.id)
+        self.assertFalse(archived_partner.active)
+        self.assertEqual(archived_partner.name, 'Ancien Contact Archivé')
 
     def test_stage_change_no_duplicate_creation(self):
         """Test qu'on ne crée pas de doublons en changeant d'étape plusieurs fois"""

--- a/tests/test_raccordement.py
+++ b/tests/test_raccordement.py
@@ -518,7 +518,10 @@ class TestRaccordementWorkflow(SouscriptionsTestMixin, TransactionCase):
 
     def test_create_odoo_entries_complete(self):
         """Test de création des entrées Odoo avec données complètes (particulier)"""
-        demande = self.create_complete_demande()
+        # Email sans collision avec le partner fixture du setUp
+        # (test@example.com) : on teste ici la création pure d'un contact,
+        # la réutilisation d'un partner existant a ses propres tests.
+        demande = self.create_complete_demande(contact_email='creation@example.com')
 
         # Passer à l'étape finale
         demande.stage_id = self.stage_final
@@ -531,7 +534,7 @@ class TestRaccordementWorkflow(SouscriptionsTestMixin, TransactionCase):
         # Vérifier les données du contact (particulier)
         partner = demande.partner_id
         self.assertEqual(partner.name, 'Test User')  # prénom + nom
-        self.assertEqual(partner.email, 'test@example.com')
+        self.assertEqual(partner.email, 'creation@example.com')
         self.assertEqual(partner.street, 'Test Street')
         self.assertEqual(partner.city, 'Test City')
         self.assertFalse(partner.is_company)  # C'est un particulier


### PR DESCRIPTION
Closes #75

À la clôture d'une demande de raccordement, la recherche d'un partner par
email seul, suivie d'une écriture aveugle, écrasait nom/adresse/is_company
de n'importe quel contact partageant l'email — une demande PRO pouvait
renommer un particulier existant en société.

La recherche du partner filtre désormais par is_company (selon la nature
pro/particulier de la demande) et compare l'email sans tenir compte de la
casse (=ilike). Sur correspondance, le contact existant est réutilisé sans
écraser ses champs d'identité, et la réutilisation est tracée au chatter
de la demande. Les partners archivés ne sont jamais réutilisés (filtre
actif par défaut d'Odoo).

5 tests ajoutés/mis à jour dans tests/test_raccordement.py couvrant : la
non-réutilisation croisée PRO/particulier, le non-écrasement d'identité +
traçabilité chatter, l'insensibilité à la casse de l'email, et le
non-matching des partners archivés. `test_create_odoo_entries_complete`
reçoit un email sans collision avec la fixture : il redevient un test de
création pure, la réutilisation ayant ses tests dédiés.

Suite complète : **0 failed, 0 error(s) of 184 tests** (docker, DB fraîche).

🤖 Generated with [Claude Code](https://claude.com/claude-code)