### PR TITLE
feat(contrat-v3): identité et atterrissage PeriodeMeta v3 (RSC, mois canonique, champs de facturation, provenance des relevés)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,24 @@
+# AGENTS.md — constitution agent (module Odoo)
+
+Court, factuel, vivant. Module Odoo **19** en Docker. Si je te corrige sur une
+convention, mets à jour ce fichier dans la foulée.
+
+## Lancer / tester (FAITS)
+- Stack dev : `docker compose -f docker/docker-compose.yml up odoo-dev` (port 8070)
+- Suite de tests COMPLÈTE (lourde, délibérée) : `./test.sh`
+  → `odoo -d <db> -i <module> --test-enable --test-tags /<module> --stop-after-init`
+- Le hook `Stop` ne lance QUE le gate rapide (syntaxe Python + XML bien formé). Les vrais tests = `./test.sh` + la CI.
+- Lint/format : `ruff` (config dans `.pre-commit-config.yaml`).
+
+## Structure (conventions Odoo)
+- `__manifest__.py` : tenir `data` à jour pour CHAQUE nouveau fichier XML/CSV ; version `19.0.x.y.z`.
+- `models/` (Python) · `views/` (XML) · `security/ir.model.access.csv` (OBLIGATOIRE pour tout nouveau modèle) · `data/` · `demo/` · `migrations/`.
+- Pas de logique métier dans les vues. Étendre via `_inherit`, pas réécrire.
+- Nouveau champ stocké → prévoir une migration dans `migrations/`.
+
+## Skills vs MCP (le seuil — cf. recherche)
+- Ce module est **greenfield (tu en possèdes la structure)** → les **skills statiques + ce fichier suffisent**. Pas de MCP.
+- N'ajoute un **MCP live** (`tuanle96/mcp-odoo`, `uvx odoo-mcp --setup`, zéro Docker) QUE si tu dois raisonner sur une **instance / un schéma que tu n'as pas écrits** (modules OCA, Studio, debug d'une prod). Pas avant.
+
+## Sécurité
+- Jamais committer un `.env` (déjà en deny global). `gitleaks` tourne en pre-commit.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -73,9 +73,11 @@ est un brouillon facturable, pas une copie figée d'electricore).
 
 **Relevé (d'index)** :
 Événement de lecture **daté** du compteur, enfant d'une *Période* (`souscription.releve`,
-`periode_id`). Porte un **index** (compteur cumulé) **par cadran réseau** — même axe *mesuré* que
-les `energie_*` (registres physiques : HPH/HPB/HCH/HCB, ou HP/HC, ou Base selon le *calendrier de
-comptage*), jamais par cadran **facturé**. Consigne **tous les index qu'electricore a utilisés**
+`periode_id`). Porte un **index** (compteur cumulé) **par registre réel** du compteur
+(HPH/HPB/HCH/HCB, ou HP/HC, ou Base selon le *calendrier de comptage*), jamais par cadran
+**facturé** — c'est le seul endroit où ce détail survit, les énergies de la *Période* arrivant
+déjà regroupées (contrat v3, ADR 0020). Porte sa **provenance** (`releve_externe_id`,
+`origine`) : l'identifiant du justificatif côté electricore, support de la dédup au re-pull. Consigne **tous les index qu'electricore a utilisés**
 pour le calcul d'énergie de la Période — **obligation légale** sur la *Facture* et support de
 **vérification** par le·la *souscripteur·rice*. Chaque relevé déclare sa **nature** : *réel*
 (mesure Enedis) ou *estimé* (estimation electricore ou *facturiste*), étiquetée sur la facture.
@@ -139,8 +141,10 @@ calendrier de comptage distingue.
 La configuration *commerciale* portée par la *Souscription* : formule tarifaire fournisseur
 (cadrans **facturés** : Base, ou HP/HC), lissage, provisions, mode de paiement. **Orthogonale
 à la _Configuration Enedis_** : un PDL peut avoir une FTA 4 cadrans (pour minorer le TURPE) et
-être facturé en Base. electricore renvoie le détail par cadran réseau ; Odoo le **regroupe**
-selon la formule fournisseur.
+être facturé en Base. electricore sert l'énergie **déjà regroupée** depuis les 4 cadrans
+saisonniers (HP = HPH+HPB, HC = HCH+HCB — contrat v3, ADR 0020) ; ne reste côté Odoo que le
+regroupement final vers le cadran **facturé** (HP/HC → Base si la formule fournisseur est
+Base), le détail par registre réel ne survivant que dans les index des *Relevés*.
 _Éviter_ : FTA (c'est l'acheminement réseau, côté Enedis), option tarifaire.
 
 **Tarif solidaire** :

--- a/__manifest__.py
+++ b/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Souscriptions Électricité',
-    'version': '19.0.1.4.0',
+    'version': '19.0.1.5.0',
     'depends': ['base', 'mail', 'contacts', 'account', 'portal'],
     'author': 'Virgile Daugé',
     'category': 'Energy',

--- a/docs/adr/0010-identite-souscription-rsc-cle-id-affaire-amorce.md
+++ b/docs/adr/0010-identite-souscription-rsc-cle-id-affaire-amorce.md
@@ -1,5 +1,10 @@
 # Identité de la *Souscription* : la RSC comme clé, l'`id_Affaire` comme amorce de réconciliation
 
+*Note (juillet 2026) : décision inchangée. Les champs atterrissent via #76
+([ADR-0020](0020-alignement-contrat-meta-periodes-v3.md)) — saisissables à la main tant que
+le raccordement ne les peuple pas ; l'acquisition automatique (`id_Affaire → RSC`, §3) est
+portée par #79.*
+
 La *Souscription* était entièrement clée sur le **PDL**, qui n'est pas un identifiant de
 contrat : un même PDL est attribué à plusieurs *souscripteur·rice·s* successif·ves (issue #5).
 electricore travaille en **`ref_situation_contractuelle`** (RSC), unique par couple

--- a/docs/adr/0011-contrat-pull-facturation-electricore-cle-rsc-mois.md
+++ b/docs/adr/0011-contrat-pull-facturation-electricore-cle-rsc-mois.md
@@ -1,5 +1,16 @@
 # Contrat de facturation electricore → Odoo : *pull* facturiste, clé `(RSC, mois)`, payload physique
 
+*Note (juillet 2026) : le payload décrit en §4/§5 a été rattrapé par le contrat **réel**
+d'electricore — `PeriodeMeta` **v3**, qui fait foi
+([ADR-0020](0020-alignement-contrat-meta-periodes-v3.md)). Écarts : l'accise arrive en
+**taux** (`taux_accise_eur_mwh`, l'assiette restant côté Odoo) et non en montant + assiette ;
+`data_complete` n'existe plus (verdicts jumeaux `qualite`/`statut_communication`) ;
+`puissance_moyenne_kva` — grandeur **physique** C15, pas le paramètre contractuel — traverse
+le fil pour prixer l'abonnement (#78) ; les énergies arrivent **déjà regroupées** base/HP/HC
+(plus de grain `config_cadrans` sur le fil), le détail par registre survivant dans la trace
+d'index `releves_utilises`. La direction, la clé `(RSC, mois)`, le déclencheur facturiste et
+create-missing-only sont inchangés.*
+
 [ADR-0001](0001-odoo-systeme-ecriture-electricore-api-read-only.md) a tranché la **direction**
 (Odoo *tire*, electricore *calcule-et-renvoie*, n'écrit jamais le nouveau module). Cet ADR fixe
 le **contrat concret** : endpoints, clé d'idempotence, format du payload, déclencheur,

--- a/docs/adr/0019-consommation-electricore-client-fin-contrat-type-versionne.md
+++ b/docs/adr/0019-consommation-electricore-client-fin-contrat-type-versionne.md
@@ -1,0 +1,32 @@
+# Consommation d'electricore : client fin distribué à part (httpx+pydantic), contrat typé versionné, AGPL de bout en bout
+
+*Statut : accepté. Le spike de packaging côté electricore (agent dédié) a retiré l'inconnue porteuse : un paquet fin polars-free est faisable, et même additif pour le moteur (les routers facturiste n'ayant aujourd'hui aucun `response_model`). Précision imposée par la structure réelle — `electricore/__init__.py` n'étant pas vide, deux distributions ne peuvent pas partager le nom de package `electricore` ; le client fin est donc un **top-level distinct `electricore_client`** (dist `electricore-client`, sous-projet `packages/` du monorepo). La conception complète (layout hatchling, modèles, plan de migration) fait l'objet d'un ADR propre côté electricore.*
+
+Odoo consomme electricore **en lecture** ([ADR-0001](0001-odoo-systeme-ecriture-electricore-api-read-only.md), [ADR-0011](0011-contrat-pull-facturation-electricore-cle-rsc-mois.md)). Reste à fixer le **comment** côté code : par quoi l'addon parle au service. Premier endpoint visé : la *vue facturiste* `/facturation/chronologie` — frise diagnostique **affichée non stockée** ([ADR-0002](0002-deux-sources-de-verite-marge-en-analytique.md)) — puis plus tard `/facturation/meta-periodes` (pull facturation, [ADR-0011](0011-contrat-pull-facturation-electricore-cle-rsc-mois.md)). Les deux rendent la **même enveloppe JSON** (`grain`/`contract_version`/`filters`/`pagination`/`data`), lignes en `dict` non typées sur le fil. Le client Python *existant* d'electricore est polars/Arrow (pour notebooks distants) : inimportable ici, où polars/pandas sont proscrits (CLAUDE.md).
+
+## Décision
+
+1. **Client fin distribué à part.** Odoo dépend d'un paquet **`electricore-client`** léger (**httpx + pydantic**, zéro polars ; import `electricore_client`, top-level distinct — cf. statut), publié depuis le monorepo electricore et **épinglé** (tag git d'abord, cible PyPI pour un build odoo.sh sans clone). Ni l'import du paquet `electricore` (moteur lourd), ni un *extra* (les extras s'**ajoutent** aux deps de base lourdes — pas d'install léger possible ainsi).
+2. **Contrat typé single-source.** Les types du contrat sont définis dans electricore et **réutilisés comme `response_model` FastAPI** : une **union discriminée sur `type_ligne`** (`Evenement | Releve | PeriodeEnergie`) pour la chronologie, un modèle méta-période pour l'autre. Le serveur *valide* contre exactement ce que le client *parse* ; Odoo reçoit des **modèles typés**, pas des dicts.
+3. **Garde de version runtime, par endpoint.** `contract_version` est **indépendant par endpoint** (chronologie=1, méta-périodes=3), pas un numéro global. Le client compare au numéro attendu : `reçu > attendu` → *avertissement* (tolérance additive, `extra="ignore"`), `reçu < attendu` → *erreur dure*. Champ déjà présent sur le fil. Le pin (1) couvre le compile-time, la garde couvre la dérive *service déployé ↔ client*.
+4. **Grain de la chronologie.** `pdl` d'abord — le champ existe déjà sur la souscription, et la vue « toute l'histoire du point » est légitime pour un diagnostic ; `rsc` (une tenure) quand la souscription portera la RSC ([ADR-0010](0010-identite-souscription-rsc-cle-id-affaire-amorce.md)). La pull méta-périodes, elle, est clé `(RSC, mois)` et **requiert** donc le champ RSC.
+5. **Licence.** `electricore-client` reste **AGPL-3** ; l'addon est déjà AGPL-3 → import cohérent, aucune contamination à arbitrer.
+
+## Conséquences
+
+- L'addon ne dépend que du **contrat HTTP** + d'un paquet httpx/pydantic léger ; pas de polars/duckdb/fastapi dans le runtime Odoo (CLAUDE.md respecté). Runtime `odoo:19` = **Python 3.12.3**, dans le plancher electricore (`>=3.12,<3.14`) — l'extra aurait suffi côté Python, c'est la *réalité des deps* qui impose la distribution séparée.
+- **Contrat single-source** : un changement de forme se fait dans electricore, le serveur le valide via ses `response_model`, le client (donc Odoo) suit par bump de version pinné. Pas d'édition parallèle de code de transport entre les deux repos.
+- **Tests partagés proprement** : electricore teste client + sérialisation (union discriminée incluse) ; Odoo ne teste plus que son mapping modèles → `souscription.*`, en mockant le client.
+- **Déploiement** : l'addon doit `pip install electricore-client` (git+tag ou PyPI) — nouvelle étape de build (odoo.sh).
+- Le **packaging réel côté electricore** (sous-projet `packages/electricore-client`, top-level distinct, modèles servis aussi en `response_model`, client Arrow existant inchangé) est délégué à electricore et à son propre ADR ; le spike dédié l'a **confirmé faisable** et additif pour le moteur. Pièges à traiter là-bas : `int` vs `float` sur le fil JSON, et `releves_utilises` (colonne `pl.Object`) sous `response_model`.
+
+## Options écartées
+
+- **Importer le paquet `electricore`** : tire polars/duckdb/fastapi dans l'addon (interdit CLAUDE.md) ; et son client est Arrow→DataFrame, sans même de méthode chronologie JSON.
+- **Extra `electricore[client]`** : les extras s'ajoutent aux deps de base lourdes du moteur ; install non léger. Et « vider » les deps de base d'un moteur polars/duckdb pour les passer en extras casse `import electricore` pour ses vrais usagers.
+- **Codegen depuis l'OpenAPI** (FastAPI le sert gratuitement) : sans types de ligne sur le fil, le client généré rend des dicts ; une fois l'union discriminée posée à la source (point 2), le bénéfice typage est déjà capté par le paquet fin — la codegen en plus n'apporte pas assez.
+- **Client JSON local dans l'addon (« Option B »)** : zéro dépendance, couche anti-corruption — c'est le **repli** si le paquet fin electricore ne se matérialise pas proprement. Écarté comme *cible* car il duplique à la main la connaissance du contrat, ce qu'on veut justement déléguer à electricore via ses releases.
+
+## Raison
+
+electricore possède le calcul **et** le contrat ; Odoo possède la facturation. Mettre le client *et* les types là où vit l'API rend le contrat single-source et versionné par les releases — exactement la frontière voulue ([ADR-0001](0001-odoo-systeme-ecriture-electricore-api-read-only.md), [ADR-0002](0002-deux-sources-de-verite-marge-en-analytique.md)). Le repli local garde la décision **réversible** : on s'engage sur la cible sans se verrouiller, ce qui autorise à acter maintenant sans attendre le spike de packaging.

--- a/docs/adr/0020-alignement-contrat-meta-periodes-v3.md
+++ b/docs/adr/0020-alignement-contrat-meta-periodes-v3.md
@@ -1,0 +1,103 @@
+# Alignement sur le contrat méta-périodes v3 : noms du contrat, `mois` canonique, atterrissage des verdicts et montants, provenance des relevés
+
+[ADR-0011](0011-contrat-pull-facturation-electricore-cle-rsc-mois.md) a fixé le pull
+facturiste sur un payload *supposé* ; depuis, electricore a versionné son contrat **réel** :
+`PeriodeMeta` **v3** (`electricore_client.models.meta_periodes`, servi en `response_model`,
+[ADR-0019](0019-consommation-electricore-client-fin-contrat-type-versionne.md)), qui **fait
+foi**. Cet ADR fixe comment `souscription.*` s'y aligne — quels noms, quels sens, où
+atterrissent les champs — pour que #76 (champs), #77 (pull) et #78 (abonnement sur puissance
+moyenne) construisent sur un vocabulaire arrêté. Les écarts avec l'ADR-0011 sont notés
+là-bas ; ici on acte la cible.
+
+## Décision
+
+1. **Les noms du contrat, sauf collision.** Les champs v3 atterrissent sur la *Période*
+   **sous le nom du contrat** : `qualite`, `statut_communication`, `has_changement`,
+   `source_hash`, `cta_eur`, `taux_accise_eur_mwh`, `puissance_moyenne_kva`. Le contrat typé
+   étant single-source ([ADR-0019](0019-consommation-electricore-client-fin-contrat-type-versionne.md)),
+   partager les noms supprime toute couche de traduction au mapping. **Une** collision,
+   tranchée en faveur de l'existant Odoo : le contrat nomme `mois_annee` sa clé « YYYY-MM » ;
+   côté Odoo, `mois_annee` est déjà le **libellé d'affichage** français (« juillet 2025 »)
+   et le reste — la clé canonique est un champ **`mois`** distinct.
+
+2. **`mois` canonique.** `Date` au **1er du mois**, **dérivé stocké** de `date_debut` —
+   support local de la clé d'idempotence `(RSC, mois)` du pull
+   ([ADR-0011](0011-contrat-pull-facturation-electricore-cle-rsc-mois.md)). Unicité
+   **`(souscription, mois)` scopée aux périodes mensuelles** : les
+   régularisations/ajustements restent libres (plusieurs par mois possibles).
+
+3. **Identité : la *Période* snapshotte la RSC.** `ref_situation_contractuelle` est recopiée
+   de la *Souscription* à la création — même logique que le snapshot des paramètres
+   contractuels ([ADR-0006](0006-snapshot-periode-fait-autorite-facturation.md)). La
+   *Souscription* porte RSC + `id_affaire`
+   ([ADR-0010](0010-identite-souscription-rsc-cle-id-affaire-amorce.md)), saisissables à la
+   main tant que le raccordement ne les peuple pas (acquisition RSC : #79).
+
+4. **Sens des champs d'atterrissage.**
+   - `qualite` (réelle / estimée / incalculable) et `statut_communication` (communicante /
+     non communicante) : les **verdicts jumeaux** d'electricore — ils remplacent le drapeau
+     `data_complete` d'ADR-0011. Une période `incalculable` est créée quand même : le
+     brouillon facturable reste la règle (`CONTEXT.md`, *Période*).
+   - `taux_accise_eur_mwh` est un **taux** : l'assiette est l'énergie **facturée** par Odoo
+     (la provision si le contrat est lissé,
+     [ADR-0008](0008-quantite-facturee-mesure-ou-provision-selon-lissage.md)) ; le montant
+     se calcule côté Odoo. `cta_eur` est un **montant**, servi tel quel.
+   - `puissance_moyenne_kva` : moyenne pondérée **physique** (C15) sur la période — une
+     grandeur réseau, pas le paramètre contractuel. C'est **elle** qui prixe l'abonnement
+     affine quand elle est présente (#78,
+     [ADR-0018](0018-abonnement-affine-base-3kva-plus-coefficient-kva.md)) ; la puissance
+     **souscrite** reste le paramètre contractuel snapshotté, affiché aux *conditions
+     particulières*.
+
+5. **Énergies pré-pliées, cascade préservée.** electricore sert `energie_base/hp/hc_kwh`
+   **déjà regroupées** depuis les 4 cadrans saisonniers (HP = HPH+HPB, HC = HCH+HCB) — ce
+   pliage lui appartient. La cascade locale (4 cadrans → HP/HC → Base) ne sert plus qu'à la
+   **saisie manuelle** et ne doit **jamais écraser** des valeurs fournies à la création
+   (test verrouillant, #76). Seul le regroupement final vers le cadran **facturé**
+   (HP/HC → Base si la formule fournisseur est Base) reste côté Odoo. Le détail par
+   **registre réel** ne survit que dans la trace d'index `releves_utilises`.
+
+6. **Provenance des relevés.** Le *Relevé* porte `releve_externe_id` (← `releve_id` du
+   contrat) et `origine` (← `origine_releve`, précisé par `evenement` pour les relevés
+   d'événement C15) : identifiant du justificatif côté electricore, support de la **dédup au
+   re-pull**. La nature réel/estimé se mappe depuis `nature_index`.
+
+7. **Verrouillage et exposition.** Tous ces champs sont **figés après facturation**
+   ([ADR-0007](0007-snapshot-periode-type-verrou-facturation.md)) et visibles du·de la
+   *facturiste* sur le formulaire Période.
+
+## Conséquences
+
+- Nouveaux champs sur *Souscription*, *Période* et *Relevé* (#76) ; le wizard de pull (#77)
+  mappe `PeriodeMeta → create()` sans table de traduction (hors `mois`, dérivé).
+- La garde de version du client
+  ([ADR-0019](0019-consommation-electricore-client-fin-contrat-type-versionne.md)) attend
+  `contract_version = 3` sur l'endpoint méta-périodes.
+- `CONTEXT.md` corrigé : le regroupement en HP/HC appartient à electricore, l'axe des
+  *Relevés* (registres réels) diverge de celui des énergies servies (cadrans regroupés).
+- Notes de dérive apposées sur
+  [ADR-0010](0010-identite-souscription-rsc-cle-id-affaire-amorce.md) et
+  [ADR-0011](0011-contrat-pull-facturation-electricore-cle-rsc-mois.md).
+
+## Options écartées
+
+- **Renommer le libellé Odoo pour suivre le contrat (`mois_annee` = clé)** : casse vues,
+  rapports et habitudes pour un bénéfice nul — la collision porte sur un *nom*, pas un sens.
+- **Clé `mois` en `Char` « YYYY-MM » (copie du fil)** : une `Date` au 1er trie, groupe et se
+  contraint nativement (ORM + SQL) ; la forme fil se dérive trivialement.
+- **Table de correspondance nom-fil → nom-Odoo** : une couche de traduction à maintenir,
+  que l'alignement des noms rend inutile.
+- **Unicité `(souscription, mois)` globale** : bloquerait régularisations et ajustements —
+  d'où le scope aux seules périodes mensuelles.
+- **Renvoyer la puissance souscrite dans le payload** : reste exclu — la frontière
+  d'[ADR-0002](0002-deux-sources-de-verite-marge-en-analytique.md)/0011 sur les paramètres
+  contractuels tient ; seule la grandeur *physique* (moyenne C15) traverse le fil.
+
+## Raison
+
+Le contrat typé est single-source et versionné
+([ADR-0019](0019-consommation-electricore-client-fin-contrat-type-versionne.md)) : s'aligner
+sur ses noms et son sens supprime la classe entière des bugs de traduction, et la seule
+collision (`mois_annee`) se résout en préservant l'existant. Fixer ces décisions *avant*
+#76/#77/#78 donne aux trois tranches un vocabulaire commun au lieu de trois interprétations
+du même fil.

--- a/migrations/19.0.1.5.0/post-migrate.py
+++ b/migrations/19.0.1.5.0/post-migrate.py
@@ -1,0 +1,34 @@
+"""Amorce l'identité/atterrissage v3 sur les Périodes existantes (#76, ADR 0020).
+
+`souscription.periode.mois` est un nouveau champ calculé/stocké (dérivé de
+`date_debut`) : on force son recalcul sur une base existante, comme pour
+`facture_id` (migration 19.0.1.1.0).
+
+`ref_situation_contractuelle` n'est snapshotté qu'à la *création* d'une
+Période (#76) : sur une base existante, les périodes déjà créées n'ont jamais
+eu cette occasion. Best-effort : on recopie la RSC courante de la Souscription
+quand elle en porte une — mieux qu'un champ vide, sans prétendre reconstituer
+un historique qui n'existait pas avant cette version. Les périodes déjà
+**facturées** sont figées (#14) : on les laisse telles quelles plutôt que de
+contourner le verrou pour une donnée qui n'existait pas au moment de la
+facturation.
+"""
+
+from odoo import SUPERUSER_ID, api
+
+
+def migrate(cr, version):
+    env = api.Environment(cr, SUPERUSER_ID, {})
+
+    Periode = env['souscription.periode']
+    periodes = Periode.search([])
+    if periodes:
+        periodes.invalidate_recordset(['mois'])
+        periodes._compute_mois()
+        periodes.flush_recordset(['mois'])
+
+        a_completer = periodes.filtered(lambda p: not p.ref_situation_contractuelle and not p.facture_id)
+        for periode in a_completer:
+            rsc = periode.souscription_id.ref_situation_contractuelle
+            if rsc:
+                periode.ref_situation_contractuelle = rsc

--- a/models/core/souscription.py
+++ b/models/core/souscription.py
@@ -144,6 +144,27 @@ class Souscription(models.Model):
     ref_compteur = fields.Char(string='Référence compteur')
     numero_depannage = fields.Char(string='Numéro de dépannage')
 
+    # Identité électricore (ADR 0010, ADR 0020 §3). `ref_situation_contractuelle`
+    # est la clé d'articulation du pull de méta-périodes (RSC, unique par couple
+    # PDL/usager·ère) ; `id_affaire` est l'amorce de réconciliation (référence
+    # d'affaire Enedis, connue tôt et non ambiguë). Peuplés à terme par le
+    # raccordement (id_Affaire capturé au raccordement, RSC résolue à la bascule
+    # « raccordement effectué » — issue dédiée) ; saisissables à la main d'ici là.
+    ref_situation_contractuelle = fields.Char(
+        string='RSC (référence situation contractuelle)',
+        tracking=True,
+        help="Clé d'articulation du pull de méta-périodes electricore, unique par "
+        'couple PDL/usager·ère. Non affichée dans SGE : peuplée par le raccordement '
+        "à terme (résolution id_Affaire → RSC), saisissable à la main d'ici là.",
+    )
+    id_affaire = fields.Char(
+        string="N° d'affaire Enedis",
+        tracking=True,
+        help="Référence d'affaire Enedis, renvoyée dès la demande de raccordement. "
+        'Amorce de réconciliation (audit + ré-résolution de la RSC) — recopiée '
+        "depuis raccordement.demande à terme, saisissable à la main d'ici là.",
+    )
+
     @api.model_create_multi
     def create(self, vals_list):
         for vals in vals_list:

--- a/models/core/souscription_periode.py
+++ b/models/core/souscription_periode.py
@@ -16,8 +16,25 @@ class SouscriptionPeriode(models.Model):
     date_fin = fields.Date(required=True, readonly=True)
     mois_annee = fields.Char(string='Mois', compute='_compute_mois_annee', store=True, readonly=True)
 
+    # Mois canonique (ADR 0020 §2) : Date au 1er du mois, dérivé stocké de
+    # `date_debut` — support local de la clé d'idempotence `(RSC, mois)` du pull
+    # electricore (ADR 0011). Distinct de `mois_annee` (libellé d'affichage
+    # français, inchangé) : la collision de nom avec le contrat v3 (qui nomme
+    # `mois_annee` sa clé « YYYY-MM ») se résout en gardant l'existant Odoo.
+    mois = fields.Date(string='Mois (canonique)', compute='_compute_mois', store=True, readonly=True)
+
     pdl = fields.Char(string='pdl', readonly=True)
     lisse = fields.Boolean(string='Lissé', readonly=True)  # related='souscription_id.lisse',  store=True)
+
+    # Identité electricore (ADR 0010, ADR 0020 §3) : la Période snapshotte la RSC
+    # de la Souscription à sa création — même logique que le snapshot des
+    # paramètres contractuels (ADR 0006).
+    ref_situation_contractuelle = fields.Char(
+        string='RSC (référence situation contractuelle)',
+        readonly=True,
+        help='RSC de la Souscription au moment de la création de cette période '
+        "(snapshot) — support de la clé d'idempotence (RSC, mois) du pull electricore.",
+    )
 
     # Calendrier de comptage figé à la création (copie de la souscription, ADR 0005).
     # Pilote le niveau de saisie de l'énergie (voir la cascade plus bas).
@@ -63,6 +80,51 @@ class SouscriptionPeriode(models.Model):
     # TURPE (calculé sur tous les cadrans)
     turpe_fixe = fields.Float(string='TURPE Fixe (€)')
     turpe_variable = fields.Float(string='TURPE Variable (€)', help='Utilise HPH+HPB+HCH+HCB')
+
+    # Atterrissage du contrat PeriodeMeta v3 electricore (ADR 0020 §4) : noms du
+    # contrat repris tels quels (single-source, ADR 0019), sauf collision. Les
+    # verdicts jumeaux qualite/statut_communication remplacent le drapeau
+    # data_complete d'ADR 0011 ; une période incalculable est créée quand même
+    # (le brouillon facturable reste la règle, CONTEXT.md).
+    qualite = fields.Selection(
+        [('reelle', 'Réelle'), ('estimee', 'Estimée'), ('incalculable', 'Incalculable')],
+        string='Qualité',
+        readonly=True,
+        help="Verdict electricore sur la qualité de l'énergie de cette période.",
+    )
+    statut_communication = fields.Selection(
+        [('communicante', 'Communicante'), ('non_communicante', 'Non communicante')],
+        string='Statut de communication',
+        readonly=True,
+        help='Verdict electricore sur la communication du compteur (Linky) sur cette période.',
+    )
+    has_changement = fields.Boolean(
+        string='Changement pendant la période',
+        readonly=True,
+        help='Un événement C15 (changement de compteur, de puissance…) a eu lieu pendant cette période.',
+    )
+    source_hash = fields.Char(
+        string='Hash source',
+        readonly=True,
+        help='Empreinte electricore des données sources ayant produit cette période (traçabilité du pull).',
+    )
+    cta_eur = fields.Float(
+        string='CTA (€)',
+        readonly=True,
+        help="Contribution Tarifaire d'Acheminement, montant servi tel quel par electricore.",
+    )
+    taux_accise_eur_mwh = fields.Float(
+        string='Taux accise (€/MWh)',
+        readonly=True,
+        help="Taux d'accise servi par electricore ; l'assiette est l'énergie facturée par Odoo "
+        '(la provision si le contrat est lissé) — le montant se calcule côté Odoo.',
+    )
+    puissance_moyenne_kva = fields.Float(
+        string='Puissance moyenne (kVA)',
+        readonly=True,
+        help='Moyenne pondérée physique (C15) de la puissance sur la période — grandeur réseau, '
+        'distincte de la puissance souscrite (paramètre contractuel snapshotté).',
+    )
 
     # Métadonnées période
     type_periode = fields.Selection(
@@ -143,6 +205,22 @@ class SouscriptionPeriode(models.Model):
         'Une seule période par souscription et par dates début/fin.',
     )
 
+    def init(self):
+        """Unicité `(souscription, mois)` scopée aux périodes **mensuelles**
+        (ADR 0020 §2) : support de la clé d'idempotence `(RSC, mois)` du pull
+        electricore, sans bloquer régularisations/ajustements (libres, plusieurs
+        par mois possibles). Un index unique partiel — hors du vocabulaire de
+        `models.Constraint`, qui ne sait pas exprimer de clause `WHERE` — est la
+        façon idiomatique Odoo d'imposer une contrainte SQL conditionnelle."""
+        self.env.cr.execute(
+            """
+            CREATE UNIQUE INDEX IF NOT EXISTS souscription_periode_mois_mensuelle_unique
+            ON souscription_periode (souscription_id, mois)
+            WHERE type_periode = 'mensuelle'
+            """
+        )
+        super().init()
+
     @api.model_create_multi
     def create(self, vals_list):
         for vals in vals_list:
@@ -162,6 +240,9 @@ class SouscriptionPeriode(models.Model):
                     'pdl': sous.pdl,  # Copie du PDL aussi
                     'lisse': sous.lisse,  # Compatibilité ancien champ
                     'config_cadrans': sous.config_cadrans or ('4_cadrans' if sous.type_tarif == 'hphc' else 'base'),
+                    # Snapshot de la RSC (ADR 0010, ADR 0020 §3) : même logique que
+                    # le snapshot des paramètres contractuels (ADR 0006).
+                    'ref_situation_contractuelle': sous.ref_situation_contractuelle,
                 }
             )
 
@@ -206,6 +287,16 @@ class SouscriptionPeriode(models.Model):
             'puissance_souscrite_periode',
             'provision_mensuelle_kwh_periode',
             'coeff_pro_periode',
+            # Identité et atterrissage v3 (#76, ADR 0020 §7) : figés au même titre
+            # que le reste du snapshot dès qu'une facture référence la période.
+            'ref_situation_contractuelle',
+            'qualite',
+            'statut_communication',
+            'has_changement',
+            'source_hash',
+            'cta_eur',
+            'taux_accise_eur_mwh',
+            'puissance_moyenne_kva',
         }
     )
 
@@ -308,6 +399,13 @@ class SouscriptionPeriode(models.Model):
                 rec.mois_annee = format_date(rec.date_debut, format='MMMM yyyy', locale='fr_FR').capitalize()
             else:
                 rec.mois_annee = ''
+
+    @api.depends('date_debut')
+    def _compute_mois(self):
+        """Mois canonique (ADR 0020 §2) : `date_debut` tronquée au 1er du mois —
+        support de la clé d'idempotence `(RSC, mois)` du pull electricore."""
+        for rec in self:
+            rec.mois = rec.date_debut.replace(day=1) if rec.date_debut else False
 
     # === Composition de la facture (candidate A / ADR 0006) ===
     # La Période compose ses lignes de facture à partir de son snapshot figé

--- a/models/core/souscription_periode.py
+++ b/models/core/souscription_periode.py
@@ -258,9 +258,19 @@ class SouscriptionPeriode(models.Model):
     @api.depends('energie_hph_kwh', 'energie_hpb_kwh', 'energie_hch_kwh', 'energie_hcb_kwh', 'config_cadrans')
     def _compute_hp_hc(self):
         """HP/HC dérivés des 4 cadrans saisonniers en config 4_cadrans ; sinon
-        saisis directement (valeur conservée)."""
+        saisis directement (valeur conservée).
+
+        electricore (contrat v3, ADR 0020) sert HP/HC **déjà groupés** même en
+        config ``4_cadrans`` : à la création, si HP/HC sont fournis en vals sans
+        qu'aucun des 4 cadrans ne le soit, la cascade ne doit pas les remettre à
+        zéro. On ne dérive donc que si au moins un cadran source est non nul —
+        seule la saisie manuelle des 4 cadrans déclenche le regroupement.
+        """
         for periode in self:
-            if periode.config_cadrans == '4_cadrans':
+            cadrans_fournis = any(
+                (periode.energie_hph_kwh, periode.energie_hpb_kwh, periode.energie_hch_kwh, periode.energie_hcb_kwh)
+            )
+            if periode.config_cadrans == '4_cadrans' and cadrans_fournis:
                 periode.energie_hp_kwh = periode.energie_hph_kwh + periode.energie_hpb_kwh
                 periode.energie_hc_kwh = periode.energie_hch_kwh + periode.energie_hcb_kwh
             else:

--- a/models/core/souscription_releve.py
+++ b/models/core/souscription_releve.py
@@ -50,6 +50,21 @@ class SouscriptionReleve(models.Model):
     index_hc = fields.Float(string='Index HC')
     index_base = fields.Float(string='Index Base')
 
+    # Provenance du justificatif côté electricore (#76, ADR 0020 §6) :
+    # `releve_externe_id` (← `releve_id` du contrat v3) identifie le relevé
+    # source, support de la **dédup au re-pull** ; `origine` (← `origine_releve`,
+    # précisé par `evenement` pour les relevés d'événement C15) documente sa
+    # nature (flux, événement…).
+    releve_externe_id = fields.Char(
+        string='ID relevé externe',
+        help='Identifiant du relevé côté electricore (releve_id du contrat), support de la dédup au re-pull.',
+    )
+    origine = fields.Char(
+        string='Origine',
+        help='Provenance du relevé côté electricore (origine_releve, précisée par evenement '
+        "pour les relevés d'événement C15).",
+    )
+
     # Verrou de facturation étendu à l'enfant (#56 / ADR 0014-0015). Symétrique du
     # verrou _LOCKED_FIELDS de la Période : dès qu'une Période est facturée
     # (facture_id existe, brouillon de facture compris), ses relevés sont figés —

--- a/tests/test_periode_atterrissage.py
+++ b/tests/test_periode_atterrissage.py
@@ -1,0 +1,110 @@
+"""
+Tests des champs d'atterrissage du contrat PeriodeMeta v3 electricore
+(#76, ADR 0020 §4/§6/§7).
+
+`qualite`/`statut_communication` (verdicts jumeaux), `has_changement`,
+`source_hash`, `cta_eur`, `taux_accise_eur_mwh`, `puissance_moyenne_kva`
+atterrissent sur la Période sous le nom du contrat. `releve_externe_id` et
+`origine` portent la provenance du justificatif sur le Relevé. Tous figés dès
+la facturation (ADR 0007), symétrique du verrou existant (#14).
+"""
+
+from datetime import date
+
+from odoo.exceptions import UserError
+from odoo.tests.common import tagged
+
+from .common import SouscriptionsTestCase
+
+
+@tagged('souscriptions', 'souscriptions_atterrissage', 'post_install', '-at_install')
+class TestPeriodeAtterrissage(SouscriptionsTestCase):
+    def _periode(self, souscription, **vals):
+        base = {
+            'souscription_id': souscription.id,
+            'date_debut': date(2024, 1, 1),
+            'date_fin': date(2024, 2, 1),
+            'type_periode': 'mensuelle',
+        }
+        base.update(vals)
+        return self.env['souscription.periode'].create(base)
+
+    def test_champs_atterrissage_persistes(self):
+        """Les champs d'atterrissage v3 se créent et se lisent tels quels."""
+        periode = self._periode(
+            self.souscription_base,
+            qualite='estimee',
+            statut_communication='non_communicante',
+            has_changement=True,
+            source_hash='abc123',
+            cta_eur=4.2,
+            taux_accise_eur_mwh=21.0,
+            puissance_moyenne_kva=5.8,
+        )
+
+        self.assertEqual(periode.qualite, 'estimee')
+        self.assertEqual(periode.statut_communication, 'non_communicante')
+        self.assertTrue(periode.has_changement)
+        self.assertEqual(periode.source_hash, 'abc123')
+        self.assertEqual(periode.cta_eur, 4.2)
+        self.assertEqual(periode.taux_accise_eur_mwh, 21.0)
+        self.assertEqual(periode.puissance_moyenne_kva, 5.8)
+
+    def test_periode_incalculable_creee_quand_meme(self):
+        """Une période `incalculable` reste créable : le brouillon facturable
+        est la règle (CONTEXT.md, ADR 0020 §4)."""
+        periode = self._periode(self.souscription_base, qualite='incalculable')
+        self.assertEqual(periode.qualite, 'incalculable')
+
+    def test_champs_atterrissage_verrouilles_apres_facturation(self):
+        """Dès qu'une facture référence la période, les champs d'atterrissage
+        sont figés (extension du verrou #14, ADR 0020 §7)."""
+        periode = self._periode(self.souscription_base, provision_base_kwh=100.0, cta_eur=4.2)
+        periode._creer_facture()
+
+        with self.assertRaises(UserError):
+            periode.write({'cta_eur': 999.0})
+        with self.assertRaises(UserError):
+            periode.write({'qualite': 'reelle'})
+        with self.assertRaises(UserError):
+            periode.write({'puissance_moyenne_kva': 12.0})
+
+        self.assertEqual(periode.cta_eur, 4.2)
+
+
+@tagged('souscriptions', 'souscriptions_atterrissage', 'post_install', '-at_install')
+class TestReleveProvenance(SouscriptionsTestCase):
+    def test_releve_porte_sa_provenance(self):
+        """Le Relevé porte `releve_externe_id` et `origine` — identifiant du
+        justificatif côté electricore, support de la dédup au re-pull (#76,
+        ADR 0020 §6)."""
+        periode = self.create_test_periode(self.souscription_base)
+        releve = self.env['souscription.releve'].create(
+            {
+                'periode_id': periode.id,
+                'date': date(2024, 1, 1),
+                'nature': 'reel',
+                'index_base': 12345.0,
+                'releve_externe_id': 'ELC-RELEVE-001',
+                'origine': 'C15_releve_meter_reading',
+            }
+        )
+
+        self.assertEqual(releve.releve_externe_id, 'ELC-RELEVE-001')
+        self.assertEqual(releve.origine, 'C15_releve_meter_reading')
+
+    def test_releve_provenance_verrouillee_apres_facturation(self):
+        """La provenance suit le verrou existant du Relevé (#56, ADR 0020 §7)."""
+        periode = self.create_test_periode(self.souscription_base)
+        releve = self.env['souscription.releve'].create(
+            {
+                'periode_id': periode.id,
+                'date': date(2024, 1, 1),
+                'index_base': 100.0,
+                'releve_externe_id': 'ELC-RELEVE-002',
+            }
+        )
+        periode._creer_facture()
+
+        with self.assertRaises(UserError):
+            releve.write({'releve_externe_id': 'AUTRE'})

--- a/tests/test_periode_energie.py
+++ b/tests/test_periode_energie.py
@@ -57,6 +57,19 @@ class TestPeriodeEnergie(SouscriptionsTestCase):
         self.assertEqual(p.energie_hp_kwh, 0)
         self.assertEqual(p.energie_hc_kwh, 0)
 
+    def test_cascade_4_cadrans_ne_recrase_pas_hp_hc_fournis_a_la_creation(self):
+        """4_cadrans : HP/HC déjà groupés fournis à la création (contrat v3,
+        electricore plie HPH+HPB/HCH+HCB avant le pull) survivent — la cascade
+        locale ne sert qu'à la saisie manuelle des 4 cadrans et ne doit jamais
+        remettre HP/HC à zéro quand ils sont fournis en vals (#76, ADR 0020)."""
+        self.souscription_base.config_cadrans = '4_cadrans'
+        p = self._periode(self.souscription_base, energie_hp_kwh=215, energie_hc_kwh=95)
+        self.assertEqual(p.energie_hp_kwh, 215)
+        self.assertEqual(p.energie_hc_kwh, 95)
+        # Les 4 cadrans, non fournis, restent à 0 : aucun recalcul ne les invente.
+        self.assertEqual(p.energie_hph_kwh, 0)
+        self.assertEqual(p.energie_hpb_kwh, 0)
+
     def test_saisie_non_ecrasee_par_recompute(self):
         """Une valeur saisie n'est pas écrasée par un recalcul déclenché ailleurs."""
         self.souscription_base.config_cadrans = 'hp_hc'

--- a/tests/test_periode_form.py
+++ b/tests/test_periode_form.py
@@ -66,3 +66,21 @@ class TestPeriodeForm(SouscriptionsTestCase):
         """Le calendrier de comptage est réglable depuis la souscription."""
         with Form(self.souscription_base) as f:
             f.config_cadrans = 'hp_hc'
+
+    def test_champs_atterrissage_v3_visibles_sur_le_formulaire(self):
+        """Les champs d'identité et d'atterrissage v3 sont exposés au·à la
+        facturiste sur le formulaire Période (#76, ADR 0020 §7)."""
+        view = self.env['souscription.periode'].get_view(view_type='form')
+        arch = view['arch']
+        for champ in (
+            'mois',
+            'ref_situation_contractuelle',
+            'qualite',
+            'statut_communication',
+            'has_changement',
+            'source_hash',
+            'cta_eur',
+            'taux_accise_eur_mwh',
+            'puissance_moyenne_kva',
+        ):
+            self.assertIn(champ, arch, f'Champ {champ} absent du formulaire Période')

--- a/tests/test_periode_mois.py
+++ b/tests/test_periode_mois.py
@@ -1,0 +1,67 @@
+"""
+Tests du `mois` canonique de la Période (#76, ADR 0020 §2).
+
+`mois` est un `Date` au 1er du mois, dérivé stocké de `date_debut` — support
+local de la clé d'idempotence `(RSC, mois)` du pull electricore (ADR 0011).
+Unicité `(souscription, mois)` scopée aux périodes **mensuelles** :
+régularisations et ajustements restent libres.
+"""
+
+from datetime import date
+
+from odoo.tests.common import tagged
+from odoo.tools import mute_logger
+from psycopg2 import IntegrityError
+
+from .common import SouscriptionsTestCase
+
+
+@tagged('souscriptions', 'souscriptions_mois', 'post_install', '-at_install')
+class TestPeriodeMoisCanonique(SouscriptionsTestCase):
+    def _periode(self, souscription, **vals):
+        base = {
+            'souscription_id': souscription.id,
+            'date_debut': date(2024, 3, 1),
+            'date_fin': date(2024, 4, 1),
+            'type_periode': 'mensuelle',
+        }
+        base.update(vals)
+        return self.env['souscription.periode'].create(base)
+
+    def test_mois_derive_au_premier_du_mois(self):
+        """`mois` est dérivé de `date_debut`, tronqué au 1er du mois."""
+        periode = self._periode(self.souscription_base, date_debut=date(2024, 3, 15), date_fin=date(2024, 4, 15))
+        self.assertEqual(periode.mois, date(2024, 3, 1))
+
+    def test_mois_deja_au_premier_du_mois(self):
+        """`date_debut` déjà au 1er du mois : `mois` lui est égal."""
+        periode = self._periode(self.souscription_base, date_debut=date(2024, 3, 1), date_fin=date(2024, 4, 1))
+        self.assertEqual(periode.mois, date(2024, 3, 1))
+
+    def test_unicite_mensuelle_meme_mois_rejetee(self):
+        """Deux périodes mensuelles de la même souscription sur le même mois
+        canonique sont rejetées (clé d'idempotence (RSC, mois), ADR 0020 §2)."""
+        self._periode(self.souscription_base)
+        with self.assertRaises(IntegrityError), mute_logger('odoo.sql_db'), self.cr.savepoint():
+            self._periode(self.souscription_base)
+            self.env.flush_all()
+
+    def test_unicite_mensuelle_mois_differents_acceptee(self):
+        """Deux périodes mensuelles de mois canoniques différents cohabitent."""
+        p1 = self._periode(self.souscription_base, date_debut=date(2024, 3, 1), date_fin=date(2024, 4, 1))
+        p2 = self._periode(self.souscription_base, date_debut=date(2024, 4, 1), date_fin=date(2024, 5, 1))
+        self.assertNotEqual(p1.mois, p2.mois)
+
+    def test_regularisations_libres_meme_mois(self):
+        """Les régularisations/ajustements restent libres : plusieurs par mois
+        possibles, hors du scope de l'unicité (ADR 0020 §2)."""
+        self._periode(self.souscription_base, type_periode='regularisation')
+        # Ne lève rien : les périodes non-mensuelles ne sont pas contraintes.
+        self._periode(self.souscription_base, type_periode='regularisation')
+
+    def test_ajustement_ne_bloque_pas_la_mensuelle_du_meme_mois(self):
+        """Une régularisation/ajustement sur un mois n'empêche pas la période
+        mensuelle correspondante (le scope est bien restreint au type mensuel)."""
+        self._periode(self.souscription_base, type_periode='ajustement')
+        # La mensuelle du même mois reste créable.
+        self._periode(self.souscription_base, type_periode='mensuelle')

--- a/tests/test_periode_snapshot.py
+++ b/tests/test_periode_snapshot.py
@@ -90,3 +90,21 @@ class TestPeriodeSnapshotType(SouscriptionsTestCase):
         self.assertNotIn('energie_kwh', champs)
         self.assertNotIn('provision_kwh', champs)
         self.assertNotIn('_fix_provision', champs)
+
+    def test_snapshot_rsc_fige_a_la_creation(self):
+        """La Période snapshotte la RSC de la Souscription à sa création — même
+        logique que le snapshot des paramètres contractuels (#76, ADR 0020 §3)."""
+        self.souscription_base.ref_situation_contractuelle = 'RSC0001234'
+        periode = self._periode(self.souscription_base)
+
+        self.assertEqual(periode.ref_situation_contractuelle, 'RSC0001234')
+
+    def test_snapshot_rsc_ne_suit_pas_un_changement_ulterieur(self):
+        """Un changement de RSC sur la Souscription après coup ne modifie pas la
+        RSC déjà snapshottée sur une Période existante (historisation, ADR 0006)."""
+        self.souscription_base.ref_situation_contractuelle = 'RSC_INITIALE'
+        periode = self._periode(self.souscription_base)
+
+        self.souscription_base.ref_situation_contractuelle = 'RSC_NOUVELLE'
+
+        self.assertEqual(periode.ref_situation_contractuelle, 'RSC_INITIALE')

--- a/tests/test_souscription.py
+++ b/tests/test_souscription.py
@@ -84,3 +84,22 @@ class TestSouscription(TransactionCase):
         )
 
         self.assertTrue(souscription.tarif_solidaire)
+
+    def test_rsc_et_id_affaire_saisissables_a_la_main(self):
+        """`ref_situation_contractuelle` (clé d'articulation) et `id_affaire`
+        (amorce de réconciliation, ADR 0010) sont saisissables à la main tant
+        que le raccordement ne les peuple pas (#76, ADR 0020 §3)."""
+        souscription = self.env['souscription.souscription'].create(
+            {
+                'partner_id': self.partner.id,
+                'pdl': 'PDL_RSC',
+                'puissance_souscrite': '6',
+                'type_tarif': 'base',
+                'etat_facturation_id': self.etat_actif.id,
+                'ref_situation_contractuelle': 'RSC0001234',
+                'id_affaire': 'AFF-56789',
+            }
+        )
+
+        self.assertEqual(souscription.ref_situation_contractuelle, 'RSC0001234')
+        self.assertEqual(souscription.id_affaire, 'AFF-56789')

--- a/views/core/souscription_views.xml
+++ b/views/core/souscription_views.xml
@@ -45,6 +45,15 @@
                         <field name="numero_depannage" widget="phone"/>
                     </group>
 
+                    <!-- Identité electricore (ADR 0010/0020) : RSC = clé d'articulation
+                         du pull de méta-périodes, id_affaire = amorce de réconciliation.
+                         Peuplés par le raccordement à terme ; saisissables à la main
+                         d'ici là. -->
+                    <group string="Identité électricore">
+                        <field name="ref_situation_contractuelle"/>
+                        <field name="id_affaire"/>
+                    </group>
+
                     <group string="Adhésion (captée au raccordement)">
                         <field name="date_validation"/>
                         <field name="renonce_retractation"/>

--- a/views/core/souscriptions_periode_views.xml
+++ b/views/core/souscriptions_periode_views.xml
@@ -37,8 +37,10 @@
                             <field name="date_debut"/>
                             <field name="date_fin"/>
                             <field name="mois_annee"/>
+                            <field name="mois"/>
                             <field name="jours"/>
                             <field name="type_periode"/>
+                            <field name="ref_situation_contractuelle"/>
                         </group>
                         <group string="Contrat (historisé)">
                             <field name="config_cadrans"/>
@@ -49,6 +51,19 @@
                             <field name="provision_mensuelle_kwh_periode"/>
                             <field name="coeff_pro_periode"/>
                         </group>
+                    </group>
+
+                    <!-- Atterrissage du contrat PeriodeMeta v3 electricore (#76,
+                         ADR 0020 §4/§7) : verdicts jumeaux, montants et grandeur
+                         physique servis par le pull, visibles du·de la facturiste. -->
+                    <group string="Atterrissage electricore (v3)">
+                        <field name="qualite"/>
+                        <field name="statut_communication"/>
+                        <field name="has_changement"/>
+                        <field name="puissance_moyenne_kva"/>
+                        <field name="cta_eur"/>
+                        <field name="taux_accise_eur_mwh"/>
+                        <field name="source_hash"/>
                     </group>
 
                     <!-- Énergie : niveau de saisie piloté par le calendrier de comptage
@@ -111,6 +126,8 @@
                                        column_invisible="parent.config_cadrans != '4_cadrans'"/>
                                 <field name="index_hcb"
                                        column_invisible="parent.config_cadrans != '4_cadrans'"/>
+                                <field name="releve_externe_id"/>
+                                <field name="origine"/>
                             </list>
                         </field>
                     </group>


### PR DESCRIPTION
Closes #76

Prépare Souscription, Période et Relevé à recevoir le pull des méta-périodes
electricore v3 (ADR 0020) : RSC + id_affaire sur la Souscription (saisissables
à la main d'ici au raccordement, ADR 0010) ; mois canonique + snapshot RSC +
champs d'atterrissage (qualite, statut_communication, has_changement,
source_hash, cta_eur, taux_accise_eur_mwh, puissance_moyenne_kva) sur la
Période, avec unicité (souscription, mois) scopée aux périodes mensuelles ;
releve_externe_id + origine sur le Relevé pour la dédup au re-pull.

Corrige aussi un bug de la cascade énergie 4_cadrans : elle écrasait HP/HC
à zéro quand ils étaient fournis directement à la création (le cas normal
avec le contrat v3, qui sert HP/HC déjà groupés).

Tous les nouveaux champs sont figés après facturation et visibles sur le
formulaire Période. Migration 19.0.1.5.0 fournie.

Le premier commit est la **tranche docs** qui débloquait cette issue :
ADR 0020 (alignement contrat v3), ADR 0019 (client fin, renommé — collision
avec le 0018 abonnement affine), notes de dérive sur ADR 0010/0011,
corrections CONTEXT.md (pliage HP/HC côté electricore, provenance des
Relevés), AGENTS.md.

Suite complète : **0 failed, 0 error(s) of 185 tests** (docker, DB fraîche).

🤖 Generated with [Claude Code](https://claude.com/claude-code)