### PR TITLE
feat(periode): pull des méta-périodes via electricore-client

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,16 +50,20 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
 
-      - name: Install module and run tests on Odoo 19
-        # The official odoo image entrypoint builds the --db_* flags from the
-        # HOST/PORT/USER/PASSWORD env vars and appends them after the command,
-        # so the DB connection must be configured through these vars.
+      # On teste l'image de docker/Dockerfile (et non le stock odoo:19) : c'est
+      # elle qui installe requirements.txt (electricore-client, #77) — source
+      # unique des dépendances, pas de dérive CI/local. Le code est COPYé dans
+      # l'image, plus besoin de monter le workspace.
+      - name: Build addon image
+        run: docker build -f docker/Dockerfile -t souscriptions-test .
+
+      - name: Run tests on Odoo 19
+        # --entrypoint odoo court-circuite docker-entrypoint-init.sh (init démo) ;
+        # les flags --db_* remplacent les env vars de l'entrypoint officiel.
         run: |
-          docker run --rm --network host \
-            -e HOST=127.0.0.1 -e PORT=5432 -e USER=odoo -e PASSWORD=odoo \
-            -v "${{ github.workspace }}:/mnt/extra-addons/souscriptions_odoo:ro" \
-            odoo:19 odoo \
-              --addons-path=/usr/lib/python3/dist-packages/odoo/addons,/mnt/extra-addons \
-              -d ci_test -i souscriptions_odoo \
-              --test-enable --test-tags /souscriptions_odoo \
-              --stop-after-init --log-level=test
+          docker run --rm --network host --entrypoint odoo souscriptions-test \
+            --addons-path=/usr/lib/python3/dist-packages/odoo/addons,/mnt/extra-addons \
+            --db_host=127.0.0.1 --db_port=5432 --db_user=odoo --db_password=odoo \
+            -d ci_test -i souscriptions_odoo \
+            --test-enable --test-tags /souscriptions_odoo \
+            --stop-after-init --log-level=test

--- a/__manifest__.py
+++ b/__manifest__.py
@@ -23,6 +23,15 @@ Fonctionnalités :
 Les calculs métier et l'ingestion des données Enedis (périmètre, prestations,
 index, TURPE, accise) sont délégués à electricore, qui alimente les périodes
 de facturation via son API.
+
+Le pull des méta-périodes (action facturiste « Récupérer les périodes du
+mois ») consomme le paquet PyPI épinglé ``electricore-client`` (voir
+requirements.txt). Ce paquet n'est volontairement PAS déclaré en
+``external_dependencies`` : Odoo vérifie l'importabilité de ces paquets à
+l'installation et ferait échouer le module entier sur toute instance qui ne
+l'a pas encore — alors que l'AC de l'issue #77 demande un module
+*installable* avec un message clair si le paquet manque. La garde d'import
+vit dans models/wizard/ et ne lève qu'au clic sur l'action du wizard.
 """,
     'installable': True,
     'application': True,
@@ -46,6 +55,7 @@ de facturation via son API.
         'views/core/grille_prix_views.xml',
         'views/core/souscriptions_periode_views.xml',
         'views/core/souscription_refacturation_views.xml',
+        'views/wizard/souscription_pull_meta_periodes_wizard_views.xml',
         'views/core/souscription_portal_menu.xml',
         'views/portal_templates.xml',
         'views/raccordement/raccordement_demande_views.xml',

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -14,7 +14,7 @@ COPY . /mnt/extra-addons/souscriptions_odoo
 # Dépendances Python du module (electricore-client, #77) — épinglées dans
 # requirements.txt, absentes de external_dependencies pour ne pas bloquer
 # l'installation du module sans elles (garde d'import côté wizard).
-RUN pip install --no-cache-dir -r /mnt/extra-addons/souscriptions_odoo/requirements.txt
+RUN pip install --no-cache-dir --break-system-packages --ignore-installed -r /mnt/extra-addons/souscriptions_odoo/requirements.txt
 
 # S'assurer que les permissions sont correctes
 RUN chown -R odoo:odoo /mnt/extra-addons/souscriptions_odoo

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -11,6 +11,11 @@ RUN apt-get update && apt-get install -y \
 # Copier le module souscriptions
 COPY . /mnt/extra-addons/souscriptions_odoo
 
+# Dépendances Python du module (electricore-client, #77) — épinglées dans
+# requirements.txt, absentes de external_dependencies pour ne pas bloquer
+# l'installation du module sans elles (garde d'import côté wizard).
+RUN pip install --no-cache-dir -r /mnt/extra-addons/souscriptions_odoo/requirements.txt
+
 # S'assurer que les permissions sont correctes
 RUN chown -R odoo:odoo /mnt/extra-addons/souscriptions_odoo
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,8 +2,10 @@ FROM odoo:19.0
 
 USER root
 
-# Installer les dépendances système
+# Installer les dépendances système (git : requis par le pin git+https de
+# requirements.txt tant qu'electricore-client n'est pas re-publié sur PyPI)
 RUN apt-get update && apt-get install -y \
+    git \
     python3-watchdog \
     postgresql-client \
     && rm -rf /var/lib/apt/lists/*

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -16,7 +16,11 @@ COPY . /mnt/extra-addons/souscriptions_odoo
 # Dépendances Python du module (electricore-client, #77) — épinglées dans
 # requirements.txt, absentes de external_dependencies pour ne pas bloquer
 # l'installation du module sans elles (garde d'import côté wizard).
-RUN pip install --no-cache-dir --break-system-packages --ignore-installed -r /mnt/extra-addons/souscriptions_odoo/requirements.txt
+# uv plutôt que pip : --break-system-packages reste requis (PEP 668, inhérent
+# au Python système), mais uv shadowe proprement le typing_extensions Debian
+# dans /usr/local sans le marteau --ignore-installed.
+COPY --from=ghcr.io/astral-sh/uv:0.9 /uv /usr/local/bin/uv
+RUN uv pip install --system --break-system-packages -r /mnt/extra-addons/souscriptions_odoo/requirements.txt
 
 # S'assurer que les permissions sont correctes
 RUN chown -R odoo:odoo /mnt/extra-addons/souscriptions_odoo

--- a/models/__init__.py
+++ b/models/__init__.py
@@ -1,1 +1,1 @@
-from . import core, raccordement
+from . import core, raccordement, wizard

--- a/models/core/souscription_periode.py
+++ b/models/core/souscription_periode.py
@@ -536,6 +536,66 @@ class SouscriptionPeriode(models.Model):
 
         return lines_vals
 
+    # === Amorçage depuis le pull electricore (#77, ADR 0011/0019/0020) ===
+
+    # Nature du contrat (`nature_index` de l'ObjetReleve) → nature Odoo du
+    # Relevé (ADR 0020 §6) : réel/corrigé sont tous deux une mesure Enedis
+    # (le "corrigé" est un réel révisé) ; le reste est une estimation.
+    _NATURE_RELEVE = {'reel': 'reel', 'corrige': 'reel'}
+
+    @api.model
+    def _amorcer_depuis_meta(self, souscription, meta):
+        """Mappe une `PeriodeMeta` (contrat v3, duck-typée) vers `create()`.
+
+        Aucune table de traduction (ADR 0020) : les champs du contrat
+        atterrissent sous leur nom. N'écrit rien de son propre chef — construit
+        les vals et délègue à `create()`, qui applique le snapshot contractuel
+        habituel (type_tarif, puissance…) par-dessus. `meta` n'a besoin que des
+        attributs de `PeriodeMeta` (tests : un stub/namedtuple suffit).
+
+        Une période `qualite='incalculable'` est créée quand même, énergies
+        nulles (le brouillon facturable reste la règle, CONTEXT.md).
+        """
+        vals = {
+            'souscription_id': souscription.id,
+            'date_debut': fields.Date.to_date(meta.debut),
+            'date_fin': fields.Date.to_date(meta.fin),
+            'type_periode': 'mensuelle',
+            'puissance_moyenne_kva': meta.puissance_moyenne_kva or 0.0,
+            'energie_base_kwh': meta.energie_base_kwh or 0.0,
+            'energie_hp_kwh': meta.energie_hp_kwh or 0.0,
+            'energie_hc_kwh': meta.energie_hc_kwh or 0.0,
+            'turpe_fixe': meta.turpe_fixe_eur or 0.0,
+            'turpe_variable': meta.turpe_variable_eur or 0.0,
+            'cta_eur': meta.cta_eur or 0.0,
+            'taux_accise_eur_mwh': meta.taux_accise_eur_mwh or 0.0,
+            'has_changement': bool(meta.has_changement),
+            'qualite': meta.qualite or 'incalculable',
+            'statut_communication': meta.statut_communication or False,
+            'source_hash': meta.source_hash,
+            'releve_ids': [(0, 0, self._releve_vals_depuis_objet(releve)) for releve in (meta.releves_utilises or [])],
+        }
+        return self.create(vals)
+
+    def _releve_vals_depuis_objet(self, releve):
+        """Mappe un `ObjetReleve` (contrat v3) vers les vals d'un
+        `souscription.releve` enfant (ADR 0020 §6) : provenance conservée
+        (`releve_externe_id`, `origine`), nature réel/corrigé → `reel`,
+        estimé → `estime`."""
+        return {
+            'date': fields.Date.to_date(releve.date_releve),
+            'nature': self._NATURE_RELEVE.get(releve.nature_index, 'estime'),
+            'index_base': releve.index_base_kwh or 0.0,
+            'index_hp': releve.index_hp_kwh or 0.0,
+            'index_hc': releve.index_hc_kwh or 0.0,
+            'index_hph': releve.index_hph_kwh or 0.0,
+            'index_hpb': releve.index_hpb_kwh or 0.0,
+            'index_hch': releve.index_hch_kwh or 0.0,
+            'index_hcb': releve.index_hcb_kwh or 0.0,
+            'releve_externe_id': releve.releve_id,
+            'origine': releve.evenement or releve.origine_releve,
+        }
+
     def _creer_facture(self):
         """Émet la facture (``account.move``) de cette période.
 

--- a/models/wizard/__init__.py
+++ b/models/wizard/__init__.py
@@ -1,0 +1,1 @@
+from . import souscription_pull_meta_periodes_wizard

--- a/models/wizard/souscription_pull_meta_periodes_wizard.py
+++ b/models/wizard/souscription_pull_meta_periodes_wizard.py
@@ -85,7 +85,12 @@ class SouscriptionPullMetaPeriodesWizard(models.TransientModel):
                         if souscription is None:
                             continue  # RSC hors du filtre demandé, ignorée silencieusement
                         try:
-                            self._amorcer_une(Periode, souscription, meta, creees, existantes)
+                            # Savepoint par élément (skip-and-report, ADR 0011) :
+                            # un échec de mapping/contrainte sur une RSC ne doit
+                            # ni écrire de résultat partiel ni casser le curseur
+                            # pour les RSC suivantes du même lot.
+                            with self.env.cr.savepoint():
+                                self._amorcer_une(Periode, souscription, meta, creees, existantes)
                         except Exception as exc:
                             erreurs.append(f'{souscription.name} ({meta.ref_situation_contractuelle}) : {exc}')
             except IngestionEnCours:
@@ -107,9 +112,11 @@ class SouscriptionPullMetaPeriodesWizard(models.TransientModel):
 
     def _amorcer_une(self, Periode, souscription, meta, creees, existantes):
         """Create-missing-only (ADR 0011) : un `(souscription, mois)` déjà
-        amorcé n'est jamais réécrit. La contrainte unique mensuelle
-        (ADR 0020 §2) fait foi ; on vérifie d'abord pour ne pas dépendre d'un
-        rollback de savepoint par élément."""
+        amorcé n'est jamais réécrit. Recherche explicite d'abord (lisible,
+        rapide) ; la contrainte unique mensuelle (ADR 0020 §2) reste le
+        garde-fou de dernier recours si deux amorçages se recouvraient malgré
+        tout — remontée comme une erreur normale, absorbée par le savepoint
+        appelant."""
         mois_cle = fields.Date.to_date(meta.debut).replace(day=1)
         existante = Periode.search(
             [

--- a/models/wizard/souscription_pull_meta_periodes_wizard.py
+++ b/models/wizard/souscription_pull_meta_periodes_wizard.py
@@ -10,13 +10,10 @@ wizard échoue avec un message actionnable.
 
 from __future__ import annotations
 
-import logging
 from datetime import timedelta
 
 from odoo import api, fields, models
 from odoo.exceptions import UserError
-
-_logger = logging.getLogger(__name__)
 
 # Garde d'import (#77 AC1) : `electricore_client` est un paquet PyPI épinglé
 # (requirements.txt), pas une dépendance dure Odoo — `external_dependencies`
@@ -31,7 +28,7 @@ try:
     from electricore_client.exceptions import PreconditionNonRemplie
 
     ELECTRICORE_CLIENT_DISPONIBLE = True
-except ImportError:  # pragma: no cover - exercé par test_client_manquant
+except ImportError:  # pragma: no cover - exercé par test_paquet_manquant_leve_userror_actionnable
     ELECTRICORE_CLIENT_DISPONIBLE = False
 
 

--- a/models/wizard/souscription_pull_meta_periodes_wizard.py
+++ b/models/wizard/souscription_pull_meta_periodes_wizard.py
@@ -1,0 +1,158 @@
+"""Wizard facturiste « Récupérer les périodes du mois » (#77, ADR 0011/0019).
+
+Brancher le seam décidé : l'addon consomme le paquet `electricore-client`
+(httpx + pydantic) et n'implémente que le mapping vers ses propres modèles
+(`souscription.periode._amorcer_depuis_meta`). Le paquet n'est pas une
+dépendance dure d'installation (cf. `requirements.txt` + garde d'import
+ci-dessous) : un déploiement sans le paquet installe le module, le bouton du
+wizard échoue avec un message actionnable.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import timedelta
+
+from odoo import api, fields, models
+from odoo.exceptions import UserError
+
+_logger = logging.getLogger(__name__)
+
+# Garde d'import (#77 AC1) : `electricore_client` est un paquet PyPI épinglé
+# (requirements.txt), pas une dépendance dure Odoo — `external_dependencies`
+# ferait échouer l'installation du module sur toute instance qui ne l'a pas
+# encore, ce qui contredit « module installable » (cf. rapport de la PR).
+try:
+    from electricore_client import (
+        ContractVersionError,
+        ElectricoreClient,
+        IngestionEnCours,
+    )
+    from electricore_client.exceptions import PreconditionNonRemplie
+
+    ELECTRICORE_CLIENT_DISPONIBLE = True
+except ImportError:  # pragma: no cover - exercé par test_client_manquant
+    ELECTRICORE_CLIENT_DISPONIBLE = False
+
+
+class SouscriptionPullMetaPeriodesWizard(models.TransientModel):
+    _name = 'souscription.pull.meta.periodes.wizard'
+    _description = 'Récupérer les périodes du mois (pull electricore)'
+
+    mois = fields.Date(
+        string='Mois',
+        required=True,
+        default=lambda self: self._default_mois(),
+        help="Mois à récupérer — n'importe quelle date du mois convient, seuls l'année et le mois comptent.",
+    )
+    state = fields.Selection([('form', 'Formulaire'), ('done', 'Résultat')], default='form')
+    resultat = fields.Text(string='Résumé', readonly=True)
+
+    @api.model
+    def _default_mois(self):
+        """1er du mois précédent — même calcul que `ajouter_periodes_mensuelles`
+        (souscription.py), sans dépendance à dateutil."""
+        premier_mois_courant = fields.Date.context_today(self).replace(day=1)
+        return (premier_mois_courant - timedelta(days=1)).replace(day=1)
+
+    def action_lancer(self):
+        """Récupère les méta-périodes du mois pour toutes les souscriptions à
+        RSC, crée les périodes manquantes (create-missing-only), résume le
+        résultat (créées / déjà existantes / sans RSC / erreurs)."""
+        self.ensure_one()
+        if not ELECTRICORE_CLIENT_DISPONIBLE:
+            raise UserError(
+                "Le paquet 'electricore_client' n'est pas installé sur ce serveur. "
+                'Installez-le (pip install electricore-client==0.1.0) puis réessayez.'
+            )
+
+        Souscription = self.env['souscription.souscription']
+        Periode = self.env['souscription.periode']
+
+        avec_rsc = Souscription.search([('ref_situation_contractuelle', '!=', False), ('active', '=', True)])
+        sans_rsc = Souscription.search([('ref_situation_contractuelle', '=', False), ('active', '=', True)])
+        par_rsc = {s.ref_situation_contractuelle: s for s in avec_rsc}
+
+        creees, existantes, erreurs = [], [], []
+
+        if par_rsc:
+            client = self._client()
+            mois_str = fields.Date.to_string(self.mois)
+            try:
+                with client.meta_periodes(mois=mois_str, rsc=list(par_rsc)) as stream:
+                    for meta in stream:
+                        souscription = par_rsc.get(meta.ref_situation_contractuelle)
+                        if souscription is None:
+                            continue  # RSC hors du filtre demandé, ignorée silencieusement
+                        try:
+                            self._amorcer_une(Periode, souscription, meta, creees, existantes)
+                        except Exception as exc:
+                            erreurs.append(f'{souscription.name} ({meta.ref_situation_contractuelle}) : {exc}')
+            except IngestionEnCours:
+                raise UserError("L'ingestion electricore est en cours (verrou base) : réessayez plus tard.")
+            except PreconditionNonRemplie as exc:
+                raise UserError(f'Précondition non remplie côté electricore : {exc}')
+            except ContractVersionError as exc:
+                raise UserError(f'Contrat electricore obsolète : {exc}')
+
+        self.resultat = self._formatter_resultat(creees, existantes, sans_rsc, erreurs)
+        self.state = 'done'
+        return {
+            'type': 'ir.actions.act_window',
+            'res_model': self._name,
+            'res_id': self.id,
+            'view_mode': 'form',
+            'target': 'new',
+        }
+
+    def _amorcer_une(self, Periode, souscription, meta, creees, existantes):
+        """Create-missing-only (ADR 0011) : un `(souscription, mois)` déjà
+        amorcé n'est jamais réécrit. La contrainte unique mensuelle
+        (ADR 0020 §2) fait foi ; on vérifie d'abord pour ne pas dépendre d'un
+        rollback de savepoint par élément."""
+        mois_cle = fields.Date.to_date(meta.debut).replace(day=1)
+        existante = Periode.search(
+            [
+                ('souscription_id', '=', souscription.id),
+                ('mois', '=', mois_cle),
+                ('type_periode', '=', 'mensuelle'),
+            ],
+            limit=1,
+        )
+        if existante:
+            existantes.append(f'{souscription.name} ({meta.mois_annee})')
+            return
+        Periode._amorcer_depuis_meta(souscription, meta)
+        creees.append(f'{souscription.name} ({meta.mois_annee})')
+
+    @staticmethod
+    def _formatter_resultat(creees, existantes, sans_rsc, erreurs):
+        lignes = [
+            f'Créées : {len(creees)}',
+            f'Déjà existantes : {len(existantes)}',
+            f'Sans RSC (ignorées) : {len(sans_rsc)}',
+            f'Erreurs : {len(erreurs)}',
+            '',
+        ]
+        if creees:
+            lignes += ['Périodes créées :'] + [f'  - {ligne}' for ligne in creees] + ['']
+        if existantes:
+            lignes += ['Déjà existantes (non réécrites) :'] + [f'  - {ligne}' for ligne in existantes] + ['']
+        if sans_rsc:
+            lignes += ['Souscriptions sans RSC (ignorées) :'] + [f'  - {s.name}' for s in sans_rsc] + ['']
+        if erreurs:
+            lignes += ['Erreurs :'] + [f'  - {ligne}' for ligne in erreurs]
+        return '\n'.join(lignes)
+
+    def _client(self):
+        """Construit le client electricore depuis `ir.config_parameter`
+        (`souscriptions.electricore_url` / `souscriptions.electricore_api_key`)."""
+        ICP = self.env['ir.config_parameter'].sudo()
+        url = ICP.get_param('souscriptions.electricore_url')
+        api_key = ICP.get_param('souscriptions.electricore_api_key')
+        if not url or not api_key:
+            raise UserError(
+                'Configuration electricore manquante : renseignez les paramètres système '
+                "'souscriptions.electricore_url' et 'souscriptions.electricore_api_key'."
+            )
+        return ElectricoreClient(url=url, api_key=api_key)

--- a/models/wizard/souscription_pull_meta_periodes_wizard.py
+++ b/models/wizard/souscription_pull_meta_periodes_wizard.py
@@ -60,7 +60,7 @@ class SouscriptionPullMetaPeriodesWizard(models.TransientModel):
         if not ELECTRICORE_CLIENT_DISPONIBLE:
             raise UserError(
                 "Le paquet 'electricore_client' n'est pas installé sur ce serveur. "
-                'Installez-le (pip install electricore-client==0.1.0) puis réessayez.'
+                'Installez la dépendance épinglée dans requirements.txt puis réessayez.'
             )
 
         Souscription = self.env['souscription.souscription']

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,10 @@
+# Dépendances Python du module Odoo, hors dépendances du framework
+# (déjà fournies par l'image odoo:19.0). Lu automatiquement par odoo.sh ;
+# pour Docker, voir docker/Dockerfile.
+#
+# electricore-client : client fin (httpx+pydantic) vers l'API facturiste
+# electricore (#77, ADR 0019). Épinglé — pas dans `external_dependencies` du
+# manifeste : l'absence du paquet ne doit pas empêcher l'installation du
+# module (garde d'import dans models/wizard/souscription_pull_meta_periodes_wizard.py,
+# UserError explicite au clic si absent).
+electricore-client==0.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,7 @@
 # manifeste : l'absence du paquet ne doit pas empêcher l'installation du
 # module (garde d'import dans models/wizard/souscription_pull_meta_periodes_wizard.py,
 # UserError explicite au clic si absent).
-electricore-client==0.1.0
+# Pin git (SHA sur main d'electricore) : le 0.1.0 publié sur PyPI est antérieur
+# à PreconditionNonRemplie (#424 côté electricore) dont le wizard a besoin.
+# À re-pinner en `electricore-client==0.1.1` dès qu'une version fraîche est publiée.
+electricore-client @ git+https://github.com/Energie-De-Nantes/electricore.git@76a8b3d8c26a18081f0c4ab92d6cbb09f6e50c94#subdirectory=packages/electricore-client

--- a/security/ir.model.access.csv
+++ b/security/ir.model.access.csv
@@ -25,3 +25,5 @@ access_souscription_periode_portal,souscription.periode portal,model_souscriptio
 access_souscription_releve_portal,souscription.releve portal,model_souscription_releve,base.group_portal,1,0,0,0
 access_souscription_etat_portal,souscription.etat portal,model_souscription_etat,base.group_portal,1,0,0,0
 access_account_move_portal,account.move portal,account.model_account_move,base.group_portal,1,0,0,0
+access_souscription_pull_meta_periodes_wizard_user,souscription.pull.meta.periodes.wizard user,model_souscription_pull_meta_periodes_wizard,group_souscriptions_user,1,1,1,1
+access_souscription_pull_meta_periodes_wizard_manager,souscription.pull.meta.periodes.wizard manager,model_souscription_pull_meta_periodes_wizard,group_souscriptions_manager,1,1,1,1

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -11,6 +11,7 @@ from . import (
     test_periode_form,
     test_periode_snapshot,
     test_portal,
+    test_pull_meta_periodes,
     test_raccordement,
     test_refacturation,
     test_releve,

--- a/tests/test_pull_meta_periodes.py
+++ b/tests/test_pull_meta_periodes.py
@@ -1,0 +1,165 @@
+"""
+Tests du pull des méta-périodes (#77, ADR 0011/0019/0020).
+
+Deux tranches :
+- `_amorcer_depuis_meta` / `_releve_vals_depuis_objet` : mapping pur
+  `PeriodeMeta`/`ObjetReleve` → `create()`, testé avec des stubs duck-typés
+  (aucune dépendance à `electricore_client`, cf. la garde d'import du wizard).
+- Le wizard « Récupérer les périodes du mois » : create-missing-only,
+  skip-and-report, erreurs typées mappées — client mocké.
+
+Fixtures RSC/PDL : identifiants factices (jamais des vrais échantillons).
+"""
+
+from datetime import date
+from types import SimpleNamespace
+
+from odoo.tests.common import tagged
+
+from .common import SouscriptionsTestCase
+
+
+def _objet_releve(**kwargs):
+    """Stub duck-typé d'`ObjetReleve` (contrat v3) : mêmes attributs, valeurs
+    par défaut à None pour les champs optionnels du contrat."""
+    base = dict(
+        releve_id='ELC-RELEVE-001',
+        date_releve='2024-01-31',
+        nature_index='reel',
+        origine_releve='flux_R151',
+        evenement=None,
+        index_base_kwh=None,
+        index_hp_kwh=None,
+        index_hc_kwh=None,
+        index_hph_kwh=None,
+        index_hch_kwh=None,
+        index_hpb_kwh=None,
+        index_hcb_kwh=None,
+    )
+    base.update(kwargs)
+    return SimpleNamespace(**base)
+
+
+def _periode_meta(**kwargs):
+    """Stub duck-typé de `PeriodeMeta` (contrat v3) : mêmes attributs que le
+    modèle pydantic réel, mêmes noms — le mapping ne fait aucune traduction."""
+    base = dict(
+        ref_situation_contractuelle='RSC-00000000000001',
+        pdl='14000000000001',
+        mois_annee='2024-01',
+        debut='2024-01-01',
+        fin='2024-02-01',
+        nb_jours=31,
+        puissance_moyenne_kva=6.0,
+        formule_tarifaire_acheminement='CU4',
+        energie_base_kwh=280.0,
+        energie_hp_kwh=None,
+        energie_hc_kwh=None,
+        turpe_fixe_eur=8.5,
+        turpe_variable_eur=4.2,
+        cta_eur=1.1,
+        taux_accise_eur_mwh=21.0,
+        has_changement=False,
+        qualite='reelle',
+        statut_communication='communicante',
+        releves_utilises=[],
+        source_hash='hash-abc123',
+    )
+    base.update(kwargs)
+    return SimpleNamespace(**base)
+
+
+@tagged('souscriptions', 'souscriptions_pull_meta', 'post_install', '-at_install')
+class TestAmorcerDepuisMeta(SouscriptionsTestCase):
+    """Mapping pur `PeriodeMeta` → `create()` (aucun client requis)."""
+
+    def test_mappe_les_champs_du_contrat_sans_traduction(self):
+        meta = _periode_meta()
+        periode = self.env['souscription.periode']._amorcer_depuis_meta(self.souscription_base, meta)
+
+        self.assertEqual(periode.date_debut, date(2024, 1, 1))
+        self.assertEqual(periode.date_fin, date(2024, 2, 1))
+        self.assertEqual(periode.puissance_moyenne_kva, 6.0)
+        self.assertEqual(periode.energie_base_kwh, 280.0)
+        self.assertEqual(periode.turpe_fixe, 8.5)
+        self.assertEqual(periode.turpe_variable, 4.2)
+        self.assertEqual(periode.cta_eur, 1.1)
+        self.assertEqual(periode.taux_accise_eur_mwh, 21.0)
+        self.assertEqual(periode.qualite, 'reelle')
+        self.assertEqual(periode.statut_communication, 'communicante')
+        self.assertEqual(periode.source_hash, 'hash-abc123')
+        self.assertFalse(periode.has_changement)
+
+    def test_qualite_incalculable_creee_quand_meme(self):
+        """Une période incalculable est créée, énergies nulles (brouillon
+        facturable, CONTEXT.md / ADR 0020 §4)."""
+        meta = _periode_meta(
+            qualite='incalculable',
+            statut_communication=None,
+            energie_base_kwh=None,
+            energie_hp_kwh=None,
+            energie_hc_kwh=None,
+        )
+        periode = self.env['souscription.periode']._amorcer_depuis_meta(self.souscription_base, meta)
+
+        self.assertEqual(periode.qualite, 'incalculable')
+        self.assertEqual(periode.energie_base_kwh, 0.0)
+
+    def test_releves_utilises_deviennent_des_enfants_avec_provenance(self):
+        """`releves_utilises` -> relevés enfants, provenance conservée
+        (releve_externe_id, origine) — ADR 0020 §6."""
+        meta = _periode_meta(
+            releves_utilises=[
+                _objet_releve(
+                    releve_id='ELC-RELEVE-100',
+                    date_releve='2024-01-01',
+                    nature_index='reel',
+                    origine_releve='flux_R151',
+                    index_base_kwh=1000,
+                ),
+                _objet_releve(
+                    releve_id='ELC-RELEVE-101',
+                    date_releve='2024-01-31',
+                    nature_index='estime',
+                    origine_releve='estimation_electricore',
+                    index_base_kwh=1280,
+                ),
+            ]
+        )
+        periode = self.env['souscription.periode']._amorcer_depuis_meta(self.souscription_base, meta)
+
+        self.assertEqual(len(periode.releve_ids), 2)
+        premier, second = periode.releve_ids.sorted('date')
+        self.assertEqual(premier.releve_externe_id, 'ELC-RELEVE-100')
+        self.assertEqual(premier.origine, 'flux_R151')
+        self.assertEqual(premier.nature, 'reel')
+        self.assertEqual(premier.index_base, 1000.0)
+        self.assertEqual(second.nature, 'estime')
+
+    def test_nature_corrige_devient_reel(self):
+        """`nature_index='corrige'` (réel révisé) atterrit en `reel` (ADR 0020 §6)."""
+        meta = _periode_meta(
+            releves_utilises=[_objet_releve(nature_index='corrige')],
+        )
+        periode = self.env['souscription.periode']._amorcer_depuis_meta(self.souscription_base, meta)
+        self.assertEqual(periode.releve_ids.nature, 'reel')
+
+    def test_evenement_prime_sur_origine_releve_pour_lorigine(self):
+        """Un relevé d'événement C15 documente son origine par `evenement`
+        (précision), sinon on retombe sur `origine_releve` (ADR 0020 §6)."""
+        meta = _periode_meta(
+            releves_utilises=[
+                _objet_releve(origine_releve='flux_C15', evenement='CHGCPT'),
+            ],
+        )
+        periode = self.env['souscription.periode']._amorcer_depuis_meta(self.souscription_base, meta)
+        self.assertEqual(periode.releve_ids.origine, 'CHGCPT')
+
+    def test_create_missing_only_ne_reecrit_jamais_lexistant(self):
+        """Un `(souscription, mois)` déjà amorcé n'est jamais réécrit
+        automatiquement (ADR 0011) : garde vérifiée au niveau wizard, pas ici —
+        ce test verrouille la clé (contrainte unique mensuelle, ADR 0020 §2)."""
+        self.env['souscription.periode']._amorcer_depuis_meta(self.souscription_base, _periode_meta())
+        with self.assertRaises(Exception):
+            with self.env.cr.savepoint():
+                self.env['souscription.periode']._amorcer_depuis_meta(self.souscription_base, _periode_meta())

--- a/tests/test_pull_meta_periodes.py
+++ b/tests/test_pull_meta_periodes.py
@@ -11,6 +11,7 @@ Deux tranches :
 Fixtures RSC/PDL : identifiants factices (jamais des vrais échantillons).
 """
 
+import unittest
 from contextlib import contextmanager
 from datetime import date
 from types import SimpleNamespace
@@ -367,3 +368,55 @@ class TestWizardPullMetaPeriodes(SouscriptionsTestCase):
             wizard.action_lancer()
             MockClient.assert_not_called()
         self.assertIn('Sans RSC', wizard.resultat)
+
+
+@unittest.skipIf(
+    not wizard_module.ELECTRICORE_CLIENT_DISPONIBLE,
+    'electricore_client non installé : test exercé uniquement là où le paquet réel est présent (CI Docker).',
+)
+@tagged('souscriptions', 'souscriptions_pull_meta', 'post_install', '-at_install')
+class TestAmorcerDepuisMetaAvecPaquetReel(SouscriptionsTestCase):
+    """`_amorcer_depuis_meta` face aux vrais modèles pydantic `PeriodeMeta`/
+    `ObjetReleve` (contrat v3) — pas seulement les stubs duck-typés ci-dessus.
+    Vérifie que le mapping accepte le type réel que le client renverra en
+    production, sans écart de champ (ADR 0019 : contrat single-source)."""
+
+    def test_mappe_un_vrai_periode_meta_pydantic(self):
+        from electricore_client import ObjetReleve, PeriodeMeta
+
+        meta = PeriodeMeta(
+            ref_situation_contractuelle='RSC-00000000000001',
+            pdl='14000000000001',
+            mois_annee='2024-01',
+            debut='2024-01-01',
+            fin='2024-02-01',
+            nb_jours=31,
+            puissance_moyenne_kva=6.0,
+            energie_base_kwh=280.0,
+            turpe_fixe_eur=8.5,
+            turpe_variable_eur=4.2,
+            cta_eur=1.1,
+            taux_accise_eur_mwh=21.0,
+            has_changement=False,
+            qualite='reelle',
+            statut_communication='communicante',
+            releves_utilises=[
+                ObjetReleve(
+                    releve_id='ELC-RELEVE-100',
+                    date_releve='2024-01-01',
+                    nature_index='reel',
+                    origine_releve='flux_R151',
+                    index_base_kwh=1000,
+                )
+            ],
+            source_hash='hash-abc123',
+        )
+
+        periode = self.env['souscription.periode']._amorcer_depuis_meta(self.souscription_base, meta)
+
+        self.assertEqual(periode.date_debut, date(2024, 1, 1))
+        self.assertEqual(periode.energie_base_kwh, 280.0)
+        self.assertEqual(periode.qualite, 'reelle')
+        self.assertEqual(len(periode.releve_ids), 1)
+        self.assertEqual(periode.releve_ids.releve_externe_id, 'ELC-RELEVE-100')
+        self.assertEqual(periode.releve_ids.index_base, 1000.0)

--- a/tests/test_pull_meta_periodes.py
+++ b/tests/test_pull_meta_periodes.py
@@ -11,12 +11,21 @@ Deux tranches :
 Fixtures RSC/PDL : identifiants factices (jamais des vrais échantillons).
 """
 
+from contextlib import contextmanager
 from datetime import date
 from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
 
+from odoo.addons.souscriptions_odoo.models.wizard import souscription_pull_meta_periodes_wizard as wizard_module
+from odoo.exceptions import UserError
 from odoo.tests.common import tagged
 
 from .common import SouscriptionsTestCase
+
+# Cible de patch en toutes lettres (mock.patch résout par import string) : on
+# tape sur les noms importés *dans le module wizard*, jamais sur le paquet
+# electricore_client lui-même (qui peut être absent du sandbox de tests).
+_WIZARD = 'odoo.addons.souscriptions_odoo.models.wizard.souscription_pull_meta_periodes_wizard'
 
 
 def _objet_releve(**kwargs):
@@ -163,3 +172,198 @@ class TestAmorcerDepuisMeta(SouscriptionsTestCase):
         with self.assertRaises(Exception):
             with self.env.cr.savepoint():
                 self.env['souscription.periode']._amorcer_depuis_meta(self.souscription_base, _periode_meta())
+
+
+# === Wizard « Récupérer les périodes du mois » : client mocké ===
+#
+# Exceptions factices mirant exactement les noms/sémantiques d'
+# electricore_client.exceptions (le paquet réel peut être absent du sandbox
+# d'exécution des tests ; le module wizard ne les utilise que par leur nom
+# importé, patché ci-dessous).
+
+
+class _FakeIngestionEnCours(Exception):
+    pass
+
+
+class _FakePreconditionNonRemplie(Exception):
+    pass
+
+
+class _FakeContractVersionError(Exception):
+    pass
+
+
+@contextmanager
+def _stream(metas):
+    """Mime `JsonlStream` : context manager itérable, cf.
+    electricore_client.streaming.JsonlStream."""
+    yield iter(metas)
+
+
+def _fake_client(metas=(), *, leve=None):
+    """Client factice : `.meta_periodes(mois=, rsc=)` renvoie un flux
+    (context manager) qui itère `metas`, ou lève `leve` à l'ouverture."""
+    client = MagicMock()
+    if leve is not None:
+        client.meta_periodes.side_effect = leve
+    else:
+        client.meta_periodes.return_value = _stream(metas)
+    return client
+
+
+@tagged('souscriptions', 'souscriptions_pull_meta', 'post_install', '-at_install')
+class TestWizardPullMetaPeriodes(SouscriptionsTestCase):
+    def setUp(self):
+        super().setUp()
+        # Le wizard résout ses paramètres via ir.config_parameter : posés une
+        # fois pour tous les tests de cette classe (pas de vrai réseau).
+        ICP = self.env['ir.config_parameter'].sudo()
+        ICP.set_param('souscriptions.electricore_url', 'https://electricore.example.test')
+        ICP.set_param('souscriptions.electricore_api_key', 'fake-api-key')
+
+        patcher_dispo = patch(f'{_WIZARD}.ELECTRICORE_CLIENT_DISPONIBLE', True)
+        patcher_dispo.start()
+        self.addCleanup(patcher_dispo.stop)
+
+        patcher_exc = patch.multiple(
+            wizard_module,
+            IngestionEnCours=_FakeIngestionEnCours,
+            PreconditionNonRemplie=_FakePreconditionNonRemplie,
+            ContractVersionError=_FakeContractVersionError,
+        )
+        patcher_exc.start()
+        self.addCleanup(patcher_exc.stop)
+
+    def _wizard(self, mois=date(2024, 1, 1)):
+        return self.env['souscription.pull.meta.periodes.wizard'].create({'mois': mois})
+
+    def _lancer_avec_client(self, client, mois=date(2024, 1, 1)):
+        wizard = self._wizard(mois)
+        with patch.object(wizard_module, 'ElectricoreClient', return_value=client):
+            wizard.action_lancer()
+        return wizard
+
+    def test_paquet_manquant_leve_userror_actionnable(self):
+        """AC1 : message clair si le paquet manque — pas d'appel réseau."""
+        with patch(f'{_WIZARD}.ELECTRICORE_CLIENT_DISPONIBLE', False):
+            wizard = self._wizard()
+            with self.assertRaises(UserError) as cm:
+                wizard.action_lancer()
+        self.assertIn('electricore_client', str(cm.exception))
+
+    def test_config_manquante_leve_userror(self):
+        self.souscription_base.ref_situation_contractuelle = 'RSC-00000000000001'
+        self.env['ir.config_parameter'].sudo().set_param('souscriptions.electricore_api_key', False)
+        wizard = self._wizard()
+        with self.assertRaises(UserError):
+            wizard.action_lancer()
+
+    def test_cree_les_periodes_manquantes_pour_les_souscriptions_a_rsc(self):
+        """AC2 : le wizard crée les périodes manquantes du mois pour les
+        souscriptions à RSC."""
+        self.souscription_base.ref_situation_contractuelle = 'RSC-00000000000001'
+        meta = _periode_meta(
+            ref_situation_contractuelle='RSC-00000000000001',
+            debut='2024-01-01',
+            fin='2024-02-01',
+        )
+        client = _fake_client([meta])
+
+        wizard = self._lancer_avec_client(client)
+
+        periode = self.env['souscription.periode'].search(
+            [('souscription_id', '=', self.souscription_base.id), ('mois', '=', date(2024, 1, 1))]
+        )
+        self.assertEqual(len(periode), 1)
+        self.assertIn('Créées : 1', wizard.resultat)
+        self.assertEqual(wizard.state, 'done')
+        client.meta_periodes.assert_called_once_with(mois='2024-01-01', rsc=['RSC-00000000000001'])
+
+    def test_ne_reecrit_jamais_une_periode_existante(self):
+        """AC2 : create-missing-only — une période déjà amorcée n'est jamais
+        réécrite, même avec des valeurs différentes dans le payload."""
+        self.souscription_base.ref_situation_contractuelle = 'RSC-00000000000001'
+        existante = self.create_test_periode(
+            self.souscription_base, date_debut=date(2024, 1, 1), date_fin=date(2024, 2, 1)
+        )
+        existante.cta_eur = 1.23
+
+        meta = _periode_meta(
+            ref_situation_contractuelle='RSC-00000000000001',
+            debut='2024-01-01',
+            fin='2024-02-01',
+            cta_eur=999.0,
+        )
+        wizard = self._lancer_avec_client(_fake_client([meta]))
+
+        self.assertEqual(existante.cta_eur, 1.23)
+        self.assertIn('Déjà existantes : 1', wizard.resultat)
+        self.assertIn('Créées : 0', wizard.resultat)
+
+    def test_resume_les_souscriptions_sans_rsc(self):
+        """AC3 : résumé skip-and-report — souscriptions sans RSC comptées à part."""
+        self.assertFalse(self.souscription_hphc.ref_situation_contractuelle)
+        wizard = self._lancer_avec_client(_fake_client([]))
+        self.assertIn('Sans RSC (ignorées) :', wizard.resultat)
+        self.assertNotIn('Sans RSC (ignorées) : 0', wizard.resultat)
+
+    def test_releves_crees_avec_identifiant_externe_et_origine(self):
+        """AC4 : relevés créés avec identifiant externe + origine."""
+        self.souscription_base.ref_situation_contractuelle = 'RSC-00000000000001'
+        meta = _periode_meta(
+            ref_situation_contractuelle='RSC-00000000000001',
+            debut='2024-01-01',
+            fin='2024-02-01',
+            releves_utilises=[_objet_releve(releve_id='ELC-999', origine_releve='flux_R151')],
+        )
+        self._lancer_avec_client(_fake_client([meta]))
+
+        releve = self.env['souscription.releve'].search([('releve_externe_id', '=', 'ELC-999')])
+        self.assertEqual(len(releve), 1)
+        self.assertEqual(releve.origine, 'flux_R151')
+
+    def test_erreur_par_periode_ne_bloque_pas_le_lot(self):
+        """Skip-and-report par élément : une erreur d'amorçage sur une RSC
+        n'empêche pas les autres d'être traitées, et apparaît dans le résumé."""
+        self.souscription_base.ref_situation_contractuelle = 'RSC-00000000000001'
+        meta_invalide = _periode_meta(
+            ref_situation_contractuelle='RSC-00000000000001',
+            debut=None,  # déclenche une erreur de mapping (Date invalide)
+            fin='2024-02-01',
+        )
+        wizard = self._lancer_avec_client(_fake_client([meta_invalide]))
+        self.assertIn('Erreurs : 1', wizard.resultat)
+
+    def test_ingestion_en_cours_mappee_en_userror_reessayable(self):
+        """AC5 : IngestionEnCours -> message « réessayer plus tard »."""
+        self.souscription_base.ref_situation_contractuelle = 'RSC-00000000000001'
+        client = _fake_client(leve=_FakeIngestionEnCours('verrou'))
+        with self.assertRaises(UserError) as cm:
+            self._lancer_avec_client(client)
+        self.assertIn('plus tard', str(cm.exception))
+
+    def test_precondition_non_remplie_mappee_en_userror_actionnable(self):
+        """AC5 : PreconditionNonRemplie -> message actionnable du serveur conservé."""
+        self.souscription_base.ref_situation_contractuelle = 'RSC-00000000000001'
+        client = _fake_client(leve=_FakePreconditionNonRemplie('réconciliez les RSC avant de facturer'))
+        with self.assertRaises(UserError) as cm:
+            self._lancer_avec_client(client)
+        self.assertIn('réconciliez les RSC', str(cm.exception))
+
+    def test_contract_version_error_mappee_en_erreur_dure(self):
+        """AC5 : ContractVersionError -> erreur dure (UserError, pas de retry implicite)."""
+        self.souscription_base.ref_situation_contractuelle = 'RSC-00000000000001'
+        client = _fake_client(leve=_FakeContractVersionError('serveur v2 < attendu v3'))
+        with self.assertRaises(UserError) as cm:
+            self._lancer_avec_client(client)
+        self.assertIn('v2', str(cm.exception))
+
+    def test_aucune_souscription_a_rsc_naboutit_pas_a_un_appel_client(self):
+        """Aucune RSC facturable -> le client n'est même pas construit (pas de
+        round-trip réseau inutile)."""
+        with patch.object(wizard_module, 'ElectricoreClient') as MockClient:
+            wizard = self._wizard()
+            wizard.action_lancer()
+            MockClient.assert_not_called()
+        self.assertIn('Sans RSC', wizard.resultat)

--- a/views/wizard/souscription_pull_meta_periodes_wizard_views.xml
+++ b/views/wizard/souscription_pull_meta_periodes_wizard_views.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <record id="view_souscription_pull_meta_periodes_wizard_form" model="ir.ui.view">
+        <field name="name">souscription.pull.meta.periodes.wizard.form</field>
+        <field name="model">souscription.pull.meta.periodes.wizard</field>
+        <field name="arch" type="xml">
+            <form>
+                <group invisible="state != 'form'">
+                    <field name="mois"/>
+                    <p class="text-muted">
+                        Récupère les méta-périodes du mois pour toutes les souscriptions
+                        portant une RSC, via electricore. Les périodes déjà existantes
+                        pour ce mois ne sont jamais réécrites.
+                    </p>
+                </group>
+                <group invisible="state != 'done'">
+                    <field name="resultat" nolabel="1" widget="text" readonly="1"/>
+                </group>
+                <footer>
+                    <button name="action_lancer" type="object" string="Récupérer les périodes"
+                            class="btn-primary" invisible="state != 'form'"/>
+                    <button string="Fermer" special="cancel" class="btn-primary" invisible="state != 'done'"/>
+                    <button string="Annuler" special="cancel" invisible="state != 'form'"/>
+                </footer>
+            </form>
+        </field>
+    </record>
+
+    <record id="action_souscription_pull_meta_periodes_wizard" model="ir.actions.act_window">
+        <field name="name">Récupérer les périodes du mois</field>
+        <field name="res_model">souscription.pull.meta.periodes.wizard</field>
+        <field name="view_mode">form</field>
+        <field name="target">new</field>
+    </record>
+
+    <menuitem
+        id="menu_souscription_pull_meta_periodes_wizard"
+        name="Récupérer les périodes du mois"
+        parent="menu_souscription_root"
+        action="action_souscription_pull_meta_periodes_wizard"
+        sequence="25"/>
+</odoo>


### PR DESCRIPTION
## Résumé

Ajoute l'action facturiste « Récupérer les périodes du mois » : un wizard appelle `electricore_client.meta_periodes(mois, rsc=[...])` pour toutes les souscriptions à RSC et crée les périodes manquantes du mois (create-missing-only, jamais de réécriture de l'existant). Le mapping `PeriodeMeta → create()` vit sur `souscription.periode._amorcer_depuis_meta`, sans table de traduction (ADR 0019/0020) ; les relevés justificatifs (`releves_utilises`) deviennent des relevés enfants avec provenance (`releve_externe_id`, `origine`). Résumé skip-and-report (créées / déjà existantes / sans RSC / erreurs) affiché au facturiste ; erreurs transport/contrat (`IngestionEnCours`, `PreconditionNonRemplie`, `ContractVersionError`) mappées en messages actionnables.

## Dépendance

`electricore-client` est épinglé dans `requirements.txt` **par SHA git** (pas `external_dependencies` : le module reste installable sans le paquet — garde d'import, UserError explicite au clic). Le 0.1.0 publié sur PyPI est antérieur à `PreconditionNonRemplie` (electricore #424) ; à re-pinner en `electricore-client==0.1.1` dès qu'une version fraîche est publiée (« pin tag git d'abord, cible PyPI »). Le Dockerfile installe les deps via **uv** (`uv pip install --system --break-system-packages` — le forçage PEP 668 est inhérent au Python système ; uv évite en revanche le marteau `--ignore-installed` en shadowant proprement le `typing_extensions` Debian) et embarque `git` pour le pin.

## Tests

Suite complète verte en Docker (image rebuildée avec uv, paquet réel installé) : **0 failed, 0 error(s) of 210 tests** — dont les 18 nouveaux (mapping sur stubs, wizard client-mocké, et mapping contre les vrais modèles pydantic).

Closes #77

🤖 Generated with [Claude Code](https://claude.com/claude-code)