### PR TITLE
chore(deps): re-pin electricore-client==0.2.0 (PyPI) — retire le pin git

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,10 +2,8 @@ FROM odoo:19.0
 
 USER root
 
-# Installer les dépendances système (git : requis par le pin git+https de
-# requirements.txt tant qu'electricore-client n'est pas re-publié sur PyPI)
+# Installer les dépendances système
 RUN apt-get update && apt-get install -y \
-    git \
     python3-watchdog \
     postgresql-client \
     && rm -rf /var/lib/apt/lists/*

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,4 @@
 # manifeste : l'absence du paquet ne doit pas empêcher l'installation du
 # module (garde d'import dans models/wizard/souscription_pull_meta_periodes_wizard.py,
 # UserError explicite au clic si absent).
-# Pin git (SHA sur main d'electricore) : le 0.1.0 publié sur PyPI est antérieur
-# à PreconditionNonRemplie (#424 côté electricore) dont le wizard a besoin.
-# À re-pinner en `electricore-client==0.1.1` dès qu'une version fraîche est publiée.
-electricore-client @ git+https://github.com/Energie-De-Nantes/electricore.git@76a8b3d8c26a18081f0c4ab92d6cbb09f6e50c94#subdirectory=packages/electricore-client
+electricore-client==0.2.0


### PR DESCRIPTION
Boucle le plan du handoff « pin git d'abord, cible PyPI » (#84, a68ecae) :

- `requirements.txt` : `electricore-client==0.2.0` (PyPI) à la place du pin par SHA git — le 0.2.0 embarque `PreconditionNonRemplie` (ré-exportée top-level) et la discrimination `X-Error-Kind` (electricore #424).
- `docker/Dockerfile` : retrait de `git`, qui n'était requis que par le pin `git+https`.

La CI valide en conditions réelles : build de l'image (install PyPI) + suite Odoo 19 en conteneur.

🤖 Generated with [Claude Code](https://claude.com/claude-code)