### PR TITLE
feat(raccordement): suivi des affaires Enedis — identité, service RSC, poll quotidien, kanban piloté par les faits

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -8,8 +8,9 @@ accise, CTA, périmètre, événements C15) est calculé par
 
 ## Vocabulaire partagé (défini ailleurs)
 
-Le vocabulaire métier neutre — **PDL, RSC, cadran, HP/HC/Base, FTA, TURPE, accise, CTA,
-méta-période, provision d'énergie, contrat lissé, facturation calendaire, régularisation** —
+Le vocabulaire métier neutre — **PDL, RSC, affaire / id_Affaire, cadran, HP/HC/Base, FTA,
+TURPE, accise, CTA, méta-période, provision d'énergie, contrat lissé, facturation calendaire,
+régularisation** —
 est défini dans le glossaire core d'electricore (`electricore/core/CONTEXT.md`). Ce fichier
 ne redéfinit aucun de ces termes ; il ne définit que les notions propres à la représentation
 Odoo et au rôle fournisseur.
@@ -25,11 +26,24 @@ Le contrat de fourniture d'électricité conclu avec un·e *souscripteur·rice*,
 `souscription.souscription`. Système de référence de toutes les données métier/contractuelles
 côté fournisseur ; n'est *pas* stocké dans le module comptable. Porte la *RSC* electricore
 comme clé d'articulation — réconciliée depuis l'`id_Affaire` Enedis (amorce capturée au
-*raccordement*) — le PDL restant un attribut d'affichage/recherche.
+*raccordement*) — le PDL restant un attribut d'affichage/recherche. Naît **en instance** au
+*raccordement*, devient **en service** — facturable — à l'acquisition de la RSC (cf. *En
+instance / En service*).
 _Éviter_ : **abonnement** (collision triple — le module Odoo de facturation récurrente qu'on
 remplace, le terme pipeline d'electricore, la catégorie produit « Abonnements ») ; **devis**,
 **commande**, `sale.order` (explicitement non utilisés : pas de cycle de vente) ; contrat
 (trop générique).
+
+**En instance / En service** :
+États de cycle de vie de la *Souscription*, **calculés depuis les faits**, jamais saisis.
+**En instance** : née au *raccordement* (signée, complète commercialement — les *conditions
+particulières* peuvent partir) mais **sans RSC** : non facturable, ignorée du pull de
+facturation. **En service** : la RSC est acquise (raccordement effectif côté Enedis) —
+facturable. La correction passe par le **fait** (la RSC), jamais par l'état. La résiliation
+est un chantier distinct.
+_Éviter_ : **brouillon** (la Souscription est conclue et signée ; « brouillon » est réservé à
+la *Période* et à la *Facture*) ; « active » (collision avec l'archivage Odoo) ;
+« raccordement effectué » comme bascule manuelle (l'état découle de la RSC, ADR 0021).
 
 **Souscripteur·rice** :
 La personne ou l'organisation titulaire d'une *Souscription*. Désigné·e *usager·ère* dans le
@@ -202,16 +216,30 @@ pour la file par défaut** (c'est *à refacturer*).
 Rôle métier qui conduit la facturation mensuelle depuis Odoo et **vérifie les données avant
 émission** des factures. Public cible de l'interface de vérification.
 
+**Accueilliste** :
+Rôle métier qui instruit les demandes de *raccordement* au quotidien : accueil des nouvelles
+demandes, demandes SGE (mise en service F120 / changement de fournisseur F130, demande de
+mesures M023), saisie de l'*id_Affaire*, suivi des affaires Enedis jusqu'à la mise en
+service. Le kanban de raccordement est son tableau de bord.
+_Éviter_ : le confondre avec le·la *facturiste* (facturation mensuelle, autre rôle).
+
 **Raccordement** :
-Le workflow d'**entrée** (kanban `raccordement.demande`) qui instruit une demande de fourniture,
-de la demande jusqu'à l'étape **« Souscrit »** ; à sa clôture il **crée** le·la
-*souscripteur·rice*, le compte bancaire et la *Souscription*. C'est le point de **capture** des
-données saisies à l'adhésion — **dont les consentements et la signature** (équivalent du *LSD* de
+Le workflow d'**entrée** (kanban `raccordement.demande`), conduit par l'*accueilliste*, qui
+instruit une demande de fourniture de l'arrivée du formulaire jusqu'à la **mise en service**
+(étape « En service ») : demande SGE selon la situation d'entrée (mise en service F120 /
+changement de fournisseur F130), saisie de l'*id_Affaire*, puis **suivi de l'affaire** Enedis —
+automatisé par la résolution périodique `id_Affaire → RSC` (ADR 0021). À la **validation de
+l'abonnement** (provisions estimées, signature captée) il **crée** le·la *souscripteur·rice*,
+le compte bancaire et la *Souscription* — née *en instance* (cf. *En instance / En service*).
+Les étapes à entrée **factuelle** (id_Affaire saisi, RSC acquise) avancent seules et ne se
+forcent pas : on corrige le fait, la carte suit. C'est le point de **capture** des données
+saisies à l'adhésion — **dont les consentements et la signature** (équivalent du *LSD* de
 prod) —, **recopiées** sur la *Souscription* qui en devient **propriétaire** (système de
 référence) ; la *demande* reste un intake transitoire. Les *conditions particulières* lisent ces
 données sur la *Souscription*, jamais sur la demande.
 _Éviter_ : confondre la **demande de raccordement** (intake) et la *Souscription* (l'enregistrement
-qu'elle engendre) ; « raccordement » au sens réseau Enedis (mise en service physique du PDL).
+qu'elle engendre) ; « raccordement » au sens réseau Enedis (mise en service physique du PDL) ;
+**« Souscrit » comme fin du workflow** (la chaîne va jusqu'à « En service »).
 
 **Portail** :
 Espace en ligne en lecture du·de la *souscripteur·rice* (contrats, factures, infos utiles),

--- a/__manifest__.py
+++ b/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Souscriptions Électricité',
-    'version': '19.0.1.5.0',
+    'version': '19.0.1.6.0',
     'depends': ['base', 'mail', 'contacts', 'account', 'portal'],
     'author': 'Virgile Daugé',
     'category': 'Energy',
@@ -48,6 +48,7 @@ vit dans models/wizard/ et ne lève qu'au clic sur l'action du wizard.
         'data/produits_prestation.xml',
         'data/raccordement_sequence.xml',
         'data/raccordement_stages.xml',
+        'data/ir_cron_poll_affaires_enedis.xml',
         'reports/souscription_conditions_particulieres_report.xml',
         'reports/souscription_attestation_report.xml',
         'reports/facture_energie_template.xml',

--- a/data/ir_cron_poll_affaires_enedis.xml
+++ b/data/ir_cron_poll_affaires_enedis.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data noupdate="1">
+        <!-- Poll quotidien des affaires Enedis (#89, ADR 0021 §3-4) : remplace
+             la vérification manuelle sur le portail SGE. Calé après
+             l'ingestion des flux côté electricore (nuit). -->
+        <record id="cron_poll_affaires_enedis" model="ir.cron">
+            <field name="name">Souscriptions : poll quotidien des affaires Enedis (RSC)</field>
+            <field name="model_id" ref="model_souscription_souscription"/>
+            <field name="state">code</field>
+            <field name="code">model._cron_poll_affaires_enedis()</field>
+            <field name="interval_number">1</field>
+            <field name="interval_type">days</field>
+            <field name="active">True</field>
+        </record>
+    </data>
+</odoo>

--- a/data/raccordement_stages.xml
+++ b/data/raccordement_stages.xml
@@ -8,35 +8,36 @@
             <field name="color">1</field>
             <field name="description">Nouvelle demande de raccordement à traiter</field>
         </record>
-        
+
         <record id="stage_iban_valide" model="raccordement.stage">
             <field name="name">IBAN validé</field>
             <field name="sequence">20</field>
             <field name="color">2</field>
             <field name="description">Coordonnées bancaires vérifiées et validées</field>
         </record>
-        
+
         <record id="stage_demande_sge" model="raccordement.stage">
             <field name="name">Demande SGE faite</field>
             <field name="sequence">30</field>
             <field name="color">3</field>
             <field name="description">Demande transmise au Système de Gestion des Échanges</field>
+            <field name="entree_factuelle">True</field>
         </record>
-        
+
         <record id="stage_demande_mesures" model="raccordement.stage">
             <field name="name">Demande mesures faite</field>
             <field name="sequence">40</field>
             <field name="color">4</field>
             <field name="description">Demande des données de consommation historiques</field>
         </record>
-        
+
         <record id="stage_estimation" model="raccordement.stage">
             <field name="name">Estimation mensualité</field>
             <field name="sequence">50</field>
             <field name="color">5</field>
             <field name="description">Calcul des provisions mensuelles basé sur l'historique</field>
         </record>
-        
+
         <record id="stage_souscrit" model="raccordement.stage">
             <field name="name">Souscrit</field>
             <field name="sequence">60</field>
@@ -44,6 +45,18 @@
             <field name="fold">True</field>
             <field name="is_close">True</field>
             <field name="description">Raccordement finalisé - Souscription créée</field>
+        </record>
+
+        <!-- Étape finale (#90, ADR 0021 §5-6) : atteinte seule quand la RSC de
+             la Souscription est acquise (poll ou saisie manuelle) — jamais de
+             rôle de création, celui-ci reste sur « Souscrit ». -->
+        <record id="stage_en_service" model="raccordement.stage">
+            <field name="name">En service</field>
+            <field name="sequence">70</field>
+            <field name="color">10</field>
+            <field name="fold">True</field>
+            <field name="entree_factuelle">True</field>
+            <field name="description">Raccordement effectif côté Enedis — RSC acquise (poll ou saisie manuelle)</field>
         </record>
     </data>
 </odoo>

--- a/docs/adr/0010-identite-souscription-rsc-cle-id-affaire-amorce.md
+++ b/docs/adr/0010-identite-souscription-rsc-cle-id-affaire-amorce.md
@@ -32,6 +32,13 @@ la référence d'affaire renvoyée dès la demande de raccordement — est, elle
    **Odoo écrit son propre champ** — le read-only-vers-Odoo est préservé
    ([ADR-0001](0001-odoo-systeme-ecriture-electricore-api-read-only.md)).
 
+   > **Amendé (2026-07,
+   > [ADR-0021](0021-chaine-raccordement-pilotee-faits-naissance-instance-rsc-poll.md))** :
+   > la « bascule raccordement effectué » n'existe pas comme transition manuelle dans le
+   > modèle. La réconciliation est réalisée par un **poll quotidien** de l'endpoint de
+   > résolution, qui écrit la RSC et fait passer la *Souscription* d'*en instance* à
+   > *en service* — c'est ce flip, **calculé**, qui conditionne la facturabilité.
+
 4. **Aucun repli flou sur le flux vif.** La facturation ne démarrant qu'après « raccordement
    effectué » (⇒ MES ⇒ C15/X12 existent ⇒ RSC résoluble), la RSC est **toujours présente au
    moment de facturer**. Le couple **PDL + date** ne survit **que** comme outil de **migration

--- a/docs/adr/0021-chaine-raccordement-pilotee-faits-naissance-instance-rsc-poll.md
+++ b/docs/adr/0021-chaine-raccordement-pilotee-faits-naissance-instance-rsc-poll.md
@@ -1,0 +1,113 @@
+# Chaîne de raccordement pilotée par les faits : naissance *en instance*, RSC acquise par poll
+
+[ADR-0010](0010-identite-souscription-rsc-cle-id-affaire-amorce.md) a fait de la RSC la clé
+d'articulation de la *Souscription*, acquise en résolvant l'`id_Affaire`, et conditionnait la
+facturabilité à une « bascule raccordement effectué » — transition qui n'existe pas dans le
+modèle. Le kanban prod (« souscription différée », ~1 000 demandes) montre le process réel,
+pensé par et pour les *accueillistes* : deux situations d'entrée (MES F120 / CFNE F130), un
+suivi d'affaire aujourd'hui **manuel** sur le portail SGE (le help du champ prod pointe l'écran
+de recherche d'affaire), et un abonnement créé **avant** l'effectivité. electricore expose
+désormais la résolution batch `POST /facturation/rsc` (contrat figé `docs/contrat-rsc.md` :
+un résultat par `id_affaire`, **xor** RSC/motif d'erreur). Cet ADR fixe la chaîne cible
+(issue #79).
+
+## Décision
+
+1. **Naissance *en instance*, avant l'effectivité.** La *Souscription* est créée à la
+   **validation de l'abonnement** (après le calcul des mensualités, comme en prod), avec
+   l'`id_affaire` recopié de la demande. Elle est signée et complète **commercialement** — les
+   *conditions particulières* peuvent partir
+   ([ADR-0016](0016-documents-contractuels-projection-souscription-consentements-raccordement.md)
+   intact) — mais **non facturable** tant que la RSC manque.
+
+2. **État de cycle de vie explicite mais calculé.** Un champ `etat` (selection,
+   compute/store) dérivé des faits, jamais inscriptible : **en instance** (RSC absente),
+   **en service** (RSC présente), résiliée (date de fin — chantier dédié ultérieur).
+   **Facturable ≡ RSC présente** : le pull
+   d'[ADR-0011](0011-contrat-pull-facturation-electricore-cle-rsc-mois.md) continue d'ignorer
+   les en-instance. Pas d'état saisi = pas de dérive possible entre l'état et le fait.
+
+3. **Acquisition de la RSC par poll quotidien.** Un cron quotidien (calé après l'ingestion des
+   flux côté electricore) + une action manuelle « résoudre maintenant » (utile après correction
+   d'un `id_affaire`). Cible : les Souscriptions **en instance avec `id_affaire`** — indépendant
+   de la demande, donc les souscriptions saisies à la main sont couvertes. Un seul POST batch
+   `resoudre_rsc` ; electricore *calcule-et-renvoie*, **Odoo écrit son propre champ**
+   ([ADR-0001](0001-odoo-systeme-ecriture-electricore-api-read-only.md) préservé). L'interdit
+   de cron d'ADR-0011 ne s'applique pas ici : écriture idempotente d'un champ vide, aucun
+   brouillon à écraser, aucune pression — on n'écrit que ce qu'Enedis a confirmé.
+
+4. **Mapping des motifs du contrat RSC.**
+   - **Résolue** → RSC écrite, la Souscription passe *en service*, la demande liée avance à
+     « En service », trace au chatter.
+   - **Connue (X12) sans situation contractuelle C15** → attente silencieuse : c'est l'état
+     normal du suivi.
+   - **Affaire inconnue** → tolérée **3 jours** après la saisie de l'`id_affaire` (décalage
+     d'ingestion X12 : une affaire créée aujourd'hui dans SGE n'y est pas encore), puis alerte
+     (typo probable).
+   - **Résolution ambiguë** → alerte immédiate (décision humaine).
+
+   Alerte = kanban « bloqué » sur la demande + **une** activité pour l'accueilliste (pas de
+   spam quotidien) + motif et date de dernière résolution stockés sur la Souscription.
+
+5. **Étapes pilotées par les faits.** Une étape dont l'entrée est un fait vérifiable ne se
+   force pas à la main ; on corrige le **fait**, la carte suit :
+   - saisie de l'`id_affaire` → la carte avance seule à « demande SGE en cours »
+     (drag-in interdit) ;
+   - RSC résolue → « En service » (drag-in interdit) ;
+   - échappatoire quand Enedis/electricore déraille : la RSC reste saisissable à la main
+     (groupe restreint) — l'état calculé et la carte suivent.
+
+   Les gestes humains restent des drags/boutons : acceptation + IBAN, « Validé sur SGE »
+   (automatisable plus tard si le contrat RSC expose un `statut` additif), lancement des
+   mensualités, validation de l'abonnement.
+
+6. **Chaîne cible = la chaîne prod, sans F305.** Nouveau → PRO à valider → Accepté et IBAN
+   vérifié → { F130 CFNE en cours | F120 MES en cours } → Validé sur SGE → Calcul de
+   mensualités → *(naissance)* → En attente Enedis → **En service** (finale, repliée). La
+   refonte complète du kanban (branches MES/CFNE, PRO, champs manquants) et l'**estimation
+   automatique des provisions** (M023 → flux R67 → endpoint provisions ; electricore
+   ADR-0047/0048) sont des chantiers séparés qui s'emboîtent dans cette chaîne.
+
+## Conséquences
+
+- ADR-0010 §3 amendé : la « bascule raccordement effectué » n'est pas une transition
+  manuelle — c'est le flip *en instance → en service* produit par l'acquisition de la RSC.
+- Nouveaux champs : `id_affaire` (demande + Souscription), `ref_situation_contractuelle`,
+  `etat` calculé, motif/date de dernière résolution (Souscription).
+- La création des entrées Odoo (partner, banque, Souscription) quitte l'étape finale du kanban
+  (`is_close`) pour la validation de l'abonnement ; l'étape finale devient « En service »,
+  atteinte par le poll.
+- La demande vit jusqu'à « En service » mais reste un intake transitoire : la RSC et l'état
+  vivent sur la Souscription, la carte ne fait que refléter.
+- Le poll remplace la vérification manuelle des affaires sur le portail SGE.
+- `CONTEXT.md` : nouveaux termes *Accueilliste*, *En instance / En service* ; entrée
+  *Raccordement* réécrite (la chaîne va jusqu'à « En service », plus jusqu'à « Souscrit »).
+
+## Options écartées
+
+- **Souscription créée seulement à la RSC résolue** : la CP ne pourrait partir qu'à
+  l'effectivité, des jours/semaines après la signature — or elle projette la Souscription
+  (ADR-0016). L'intention (« rien de facturable sans RSC ») est tenue par l'état calculé.
+- **Champ d'état inscriptible** : deux vérités (état vs RSC) qui peuvent diverger, invariants
+  à surveiller.
+- **Suivi porté par la demande (RSC sur la demande)** : les souscriptions nées hors
+  raccordement (migration, saisie manuelle) seraient hors poll ; ADR-0010 met la RSC sur la
+  Souscription.
+- **Réutiliser `souscription.etat`** : mélangerait le cycle mensuel de facturation
+  (À facturer/Facturé) et le cycle de vie.
+- **Poll manuel façon ADR-0011** : reproduirait la charge de suivi quotidienne qu'on cherche
+  à éliminer ; les raisons anti-cron de 0011 ne s'appliquent pas ici.
+- **Forçage d'étape toléré sur les étapes factuelles** : une carte « En service » sans RSC
+  redeviendrait possible — le kanban pourrait mentir.
+- **Étape kanban « En attente MES » sans naissance anticipée** (demande close à « Souscrit »,
+  suivi hors kanban) : le kanban est le tableau de bord réel des accueillistes en prod — le
+  suivi doit y être visible.
+
+## Raison
+
+Le kanban est le tableau de bord des accueillistes ; l'automatisation ne le remplace pas, elle
+remplace la **vérification manuelle sur SGE** par un fait poll-able. Les étapes deviennent des
+projections de faits — elles ne mentent jamais. La Souscription naît quand elle est complète
+**commercialement** (signature, provisions estimées) et devient facturable quand le **réseau**
+la confirme (RSC) — correction avant automatisation, comme ADR-0010 : on ne facture jamais sur
+une identité douteuse.

--- a/models/core/__init__.py
+++ b/models/core/__init__.py
@@ -1,5 +1,6 @@
 from . import (
     account_move,
+    electricore_rsc_service,
     grille_prix,
     souscription,
     souscription_consentement,

--- a/models/core/electricore_rsc_service.py
+++ b/models/core/electricore_rsc_service.py
@@ -1,0 +1,80 @@
+"""Service transport unique vers l'endpoint de résolution RSC d'electricore
+(#88, ADR 0021 §3, contrat figé `docs/contrat-rsc.md` côté electricore).
+
+Enveloppe le paquet PyPI épinglé `electricore-client` (requirements.txt),
+même garde d'import et mêmes paramètres système que le wizard de pull des
+méta-périodes (#84, `souscriptions.electricore_url` /
+`souscriptions.electricore_api_key`) — dépendance déclarée par le pin +
+la garde, pas par `external_dependencies` (cf. requirements.txt).
+
+C'est l'unique point du module qui parle réseau pour la résolution RSC ; le
+pull des périodes (#12) s'y branchera plus tard.
+"""
+
+from __future__ import annotations
+
+from odoo import models
+from odoo.exceptions import UserError
+
+try:
+    from electricore_client import ContractVersionError, ElectricoreClient
+
+    ELECTRICORE_CLIENT_DISPONIBLE = True
+except ImportError:  # pragma: no cover - exercé par test_paquet_manquant_leve_userror_actionnable
+    ELECTRICORE_CLIENT_DISPONIBLE = False
+
+
+class SouscriptionRscService(models.AbstractModel):
+    _name = 'souscription.rsc.service'
+    _description = 'Résolution RSC electricore (id_Affaire -> ref_situation_contractuelle)'
+
+    def resoudre(self, ids):
+        """Résout un lot d'`id_affaire` en RSC/motif d'erreur — un appel
+        batch, même pour un seul `id_affaire`.
+
+        Args:
+            ids: liste d'`id_affaire` à résoudre. Lot vide -> pas d'appel.
+
+        Returns:
+            dict[str, ResultatResolutionRsc] : un résultat par id_affaire,
+            apparié **par id_affaire** (jamais par position), tolérant au
+            désordre de la réponse.
+
+        Raises:
+            UserError: paquet absent, configuration manquante, ou version de
+                contrat inattendue — dans tous les cas, aucune donnée n'est
+                écrite par l'appelant puisque l'exception interrompt l'appel
+                avant tout accès au résultat.
+        """
+        ids = list(ids)
+        if not ids:
+            return {}
+        if not ELECTRICORE_CLIENT_DISPONIBLE:
+            raise UserError(
+                "Le paquet 'electricore_client' n'est pas installé sur ce serveur. "
+                'Installez la dépendance épinglée dans requirements.txt puis réessayez.'
+            )
+        try:
+            resultats = self._appeler(ids)
+        except ContractVersionError as exc:
+            raise UserError(f'Contrat electricore obsolète : {exc}') from exc
+        return {r.id_affaire: r for r in resultats}
+
+    def _appeler(self, ids):
+        """Point de transport unique : construit le client et appelle
+        `resoudre_rsc`. Seul endroit qui parle réseau — c'est la couture
+        patchée en tests (réponses en boîte, rien d'autre n'est mocké)."""
+        return self._client().resoudre_rsc(ids)
+
+    def _client(self):
+        """Client electricore depuis `ir.config_parameter` — mêmes clés que
+        le wizard de pull des méta-périodes (#84)."""
+        ICP = self.env['ir.config_parameter'].sudo()
+        url = ICP.get_param('souscriptions.electricore_url')
+        api_key = ICP.get_param('souscriptions.electricore_api_key')
+        if not url or not api_key:
+            raise UserError(
+                'Configuration electricore manquante : renseignez les paramètres système '
+                "'souscriptions.electricore_url' et 'souscriptions.electricore_api_key'."
+            )
+        return ElectricoreClient(url=url, api_key=api_key)

--- a/models/core/souscription.py
+++ b/models/core/souscription.py
@@ -246,7 +246,37 @@ class Souscription(models.Model):
             raise AccessError(self._MESSAGE_RSC_RESTREINTE)
         if vals.get('id_affaire') and 'id_affaire_date_saisie' not in vals:
             vals = dict(vals, id_affaire_date_saisie=fields.Date.context_today(self))
-        return super().write(vals)
+
+        # RSC nouvellement acquise (#90) : la demande liée avance à « En
+        # service » — que la RSC vienne du poll (#89) ou d'une saisie
+        # manuelle (#87), l'automatisme s'accroche au fait, pas au canal.
+        rsc_avant = (
+            {s.id: s.ref_situation_contractuelle for s in self} if 'ref_situation_contractuelle' in vals else None
+        )
+
+        res = super().write(vals)
+
+        if rsc_avant is not None:
+            nouvellement_resolues = self.filtered(lambda s: s.ref_situation_contractuelle and not rsc_avant.get(s.id))
+            nouvellement_resolues._avancer_demande_en_service()
+
+        return res
+
+    def _avancer_demande_en_service(self):
+        """Auto-move (#90) : la demande liée avance à « En service »,
+        seulement si elle est encore en amont (jamais de recul), avec trace
+        au chatter de la demande."""
+        stage = self.env.ref('souscriptions_odoo.stage_en_service', raise_if_not_found=False)
+        if not stage:
+            return
+        for sous in self:
+            demande = sous._demande_liee()
+            if not demande or demande.stage_id.sequence >= stage.sequence:
+                continue
+            demande.with_context(raccordement_automove=True).stage_id = stage.id
+            demande.message_post(
+                body=f'Étape avancée automatiquement à « En service » (RSC {sous.ref_situation_contractuelle} acquise).'
+            )
 
     def action_resoudre_rsc_maintenant(self):
         """Bouton « résoudre la RSC maintenant » (#88) : résout la RSC des

--- a/models/core/souscription.py
+++ b/models/core/souscription.py
@@ -2,7 +2,7 @@ import logging
 from datetime import date, timedelta
 
 from odoo import api, fields, models
-from odoo.exceptions import UserError
+from odoo.exceptions import AccessError, UserError
 
 _logger = logging.getLogger(__name__)
 
@@ -144,37 +144,96 @@ class Souscription(models.Model):
     ref_compteur = fields.Char(string='Référence compteur')
     numero_depannage = fields.Char(string='Numéro de dépannage')
 
-    # Identité électricore (ADR 0010, ADR 0020 §3). `ref_situation_contractuelle`
+    # Identité électricore (ADR 0010, ADR 0020 §3, ADR 0021). `ref_situation_contractuelle`
     # est la clé d'articulation du pull de méta-périodes (RSC, unique par couple
     # PDL/usager·ère) ; `id_affaire` est l'amorce de réconciliation (référence
-    # d'affaire Enedis, connue tôt et non ambiguë). Peuplés à terme par le
-    # raccordement (id_Affaire capturé au raccordement, RSC résolue à la bascule
-    # « raccordement effectué » — issue dédiée) ; saisissables à la main d'ici là.
+    # d'affaire Enedis, connue tôt et non ambiguë). `id_affaire` est recopié depuis
+    # raccordement.demande à la création (#87) ; la RSC est acquise par le poll
+    # quotidien ou l'action manuelle (#88/#89) — écriture restreinte au groupe
+    # gestionnaire (ADR 0021 §5), c'est l'échappatoire quand Enedis/electricore
+    # déraille.
     ref_situation_contractuelle = fields.Char(
         string='RSC (référence situation contractuelle)',
         tracking=True,
         help="Clé d'articulation du pull de méta-périodes electricore, unique par "
-        'couple PDL/usager·ère. Non affichée dans SGE : peuplée par le raccordement '
-        "à terme (résolution id_Affaire → RSC), saisissable à la main d'ici là.",
+        'couple PDL/usager·ère. Non affichée dans SGE : acquise par le poll quotidien '
+        'des affaires Enedis, ou saisissable à la main (groupe gestionnaire) quand '
+        'le suivi automatique déraille.',
     )
     id_affaire = fields.Char(
         string="N° d'affaire Enedis",
         tracking=True,
         help="Référence d'affaire Enedis, renvoyée dès la demande de raccordement. "
         'Amorce de réconciliation (audit + ré-résolution de la RSC) — recopiée '
-        "depuis raccordement.demande à terme, saisissable à la main d'ici là.",
+        'depuis raccordement.demande à la création, corrigeable ensuite (rattrapage de typo).',
     )
+    id_affaire_date_saisie = fields.Date(
+        string="Date de saisie de l'id_Affaire",
+        help="Date de saisie de l'id_Affaire — recopiée depuis raccordement.demande à la "
+        'création, ré-amorcée à chaque correction. Amorce le délai de grâce du poll '
+        'quotidien des affaires Enedis (#89).',
+    )
+    etat = fields.Selection(
+        [('en_instance', 'En instance'), ('en_service', 'En service'), ('resiliee', 'Résiliée')],
+        string='État',
+        compute='_compute_etat',
+        store=True,
+        tracking=True,
+        help='Cycle de vie calculé depuis les faits (ADR 0021), jamais saisi : '
+        '*en instance* (RSC absente, non facturable), *en service* (RSC acquise, '
+        'facturable), *résiliée* (date de fin passée — logique minimale, chantier '
+        'dédié ultérieur). Se corrige par le fait (la RSC), jamais par ce champ.',
+    )
+
+    @api.depends('ref_situation_contractuelle', 'date_fin')
+    def _compute_etat(self):
+        today = fields.Date.context_today(self)
+        for sous in self:
+            if sous.date_fin and sous.date_fin < today:
+                sous.etat = 'resiliee'
+            elif sous.ref_situation_contractuelle:
+                sous.etat = 'en_service'
+            else:
+                sous.etat = 'en_instance'
 
     @api.model_create_multi
     def create(self, vals_list):
         for vals in vals_list:
+            if vals.get('ref_situation_contractuelle') and not self._peut_ecrire_rsc():
+                raise AccessError(self._MESSAGE_RSC_RESTREINTE)
             if vals.get('name', 'Nouveau') == 'Nouveau':
                 vals['name'] = self.env['ir.sequence'].next_by_code('souscription.sequence') or 'Nouveau'
             # Amorçage du calendrier de comptage tant qu'electricore ne l'alimente
             # pas (#12) : par défaut aligné sur le type de tarif.
             if not vals.get('config_cadrans'):
                 vals['config_cadrans'] = '4_cadrans' if vals.get('type_tarif') == 'hphc' else 'base'
+            # id_Affaire saisi/corrigé (#87) : date de saisie auto-stampée, sauf
+            # si le vals la fixe explicitement (recopie depuis la demande, tests
+            # antidatant la grâce du poll #89).
+            if vals.get('id_affaire') and not vals.get('id_affaire_date_saisie'):
+                vals['id_affaire_date_saisie'] = fields.Date.context_today(self)
         return super().create(vals_list)
+
+    _MESSAGE_RSC_RESTREINTE = (
+        'La RSC (référence situation contractuelle) ne peut être modifiée que par '
+        'un·e gestionnaire Souscriptions, ou par la résolution automatique (#88/#89).'
+    )
+
+    def _peut_ecrire_rsc(self):
+        """Écriture RSC restreinte (#87, ADR 0021 §5) : gestionnaire, ou
+        résolution automatique (poll/bouton, #88/#89) via la clé de contexte
+        `rsc_automatisme` — la RSC vient alors d'electricore, pas d'une saisie
+        manuelle."""
+        return bool(self.env.context.get('rsc_automatisme')) or self.env.user.has_group(
+            'souscriptions_odoo.group_souscriptions_manager'
+        )
+
+    def write(self, vals):
+        if 'ref_situation_contractuelle' in vals and not self._peut_ecrire_rsc():
+            raise AccessError(self._MESSAGE_RSC_RESTREINTE)
+        if vals.get('id_affaire') and 'id_affaire_date_saisie' not in vals:
+            vals = dict(vals, id_affaire_date_saisie=fields.Date.context_today(self))
+        return super().write(vals)
 
     @api.depends('periode_ids.facture_id')
     def _compute_factures_via_periodes(self):

--- a/models/core/souscription.py
+++ b/models/core/souscription.py
@@ -184,6 +184,16 @@ class Souscription(models.Model):
         'facturable), *résiliée* (date de fin passée — logique minimale, chantier '
         'dédié ultérieur). Se corrige par le fait (la RSC), jamais par ce champ.',
     )
+    motif_resolution_rsc = fields.Char(
+        string='Motif dernière résolution RSC',
+        help='Motif renvoyé par electricore (contrat RSC) quand la dernière tentative '
+        "de résolution (poll ou manuelle, #88/#89) n'a pas renvoyé de RSC. Effacé dès "
+        'que la RSC est résolue.',
+    )
+    date_derniere_resolution_rsc = fields.Date(
+        string='Date de dernière résolution RSC',
+        help='Date de la dernière tentative de résolution RSC (#88/#89), succès ou échec.',
+    )
 
     @api.depends('ref_situation_contractuelle', 'date_fin')
     def _compute_etat(self):
@@ -234,6 +244,47 @@ class Souscription(models.Model):
         if vals.get('id_affaire') and 'id_affaire_date_saisie' not in vals:
             vals = dict(vals, id_affaire_date_saisie=fields.Date.context_today(self))
         return super().write(vals)
+
+    def action_resoudre_rsc_maintenant(self):
+        """Bouton « résoudre la RSC maintenant » (#88) : résout la RSC des
+        Souscriptions sélectionnées via le service electricore, en un seul
+        appel batch même pour une seule Souscription. Idempotent : une
+        Souscription déjà *en service* n'est jamais re-ciblée — aucun appel
+        si le lot filtré est vide."""
+        cibles = self.filtered(lambda s: s.etat != 'en_service')
+        if not cibles:
+            return
+        sans_affaire = cibles.filtered(lambda s: not s.id_affaire)
+        if sans_affaire:
+            raise UserError(
+                f'Impossible de résoudre la RSC : id_Affaire manquant sur : {", ".join(sans_affaire.mapped("name"))}.'
+            )
+        cibles._resoudre_rsc()
+
+    def _resoudre_rsc(self):
+        """Résout `self` en un seul appel batch via le service electricore
+        (#88) et applique le mapping des motifs du contrat RSC (xor
+        `ref_situation_contractuelle`/`error`) : succès -> RSC écrite
+        (bascule *en service* + trace au chatter, #87) ; motif -> stocké
+        avec la date de tentative, visible sur la Souscription. Ne filtre
+        pas `self` : à l'appelant de ne cibler que ce qui doit l'être
+        (idempotence du bouton, ciblage du poll #89)."""
+        if not self:
+            return
+        resultats = self.env['souscription.rsc.service'].resoudre(self.mapped('id_affaire'))
+        today = fields.Date.context_today(self)
+        for sous in self:
+            resultat = resultats.get(sous.id_affaire)
+            if resultat is None:
+                continue  # ne devrait pas arriver (contrat : une réponse par entrée)
+            if resultat.ref_situation_contractuelle:
+                sous.with_context(rsc_automatisme=True).write(
+                    {'ref_situation_contractuelle': resultat.ref_situation_contractuelle}
+                )
+                sous.write({'motif_resolution_rsc': False, 'date_derniere_resolution_rsc': today})
+                sous.message_post(body=f'RSC résolue par electricore : {resultat.ref_situation_contractuelle}')
+            else:
+                sous.write({'motif_resolution_rsc': resultat.error, 'date_derniere_resolution_rsc': today})
 
     @api.depends('periode_ids.facture_id')
     def _compute_factures_via_periodes(self):

--- a/models/core/souscription.py
+++ b/models/core/souscription.py
@@ -20,7 +20,10 @@ class SouscriptionEtat(models.Model):
 class Souscription(models.Model):
     _name = 'souscription.souscription'
     _description = 'Souscription Électricité'
-    _inherit = ['mail.thread']
+    # mail.activity.mixin (#89) : porte l'alerte du poll quotidien des affaires
+    # Enedis quand la Souscription n'a pas de demande de raccordement liée
+    # (saisie manuelle) — sinon l'alerte est portée par la demande.
+    _inherit = ['mail.thread', 'mail.activity.mixin']
 
     name = fields.Char(string='Référence', required=True, copy=False, readonly=True, default='Nouveau')
     partner_id = fields.Many2one('res.partner', string='Souscripteur·trice')
@@ -285,6 +288,88 @@ class Souscription(models.Model):
                 sous.message_post(body=f'RSC résolue par electricore : {resultat.ref_situation_contractuelle}')
             else:
                 sous.write({'motif_resolution_rsc': resultat.error, 'date_derniere_resolution_rsc': today})
+
+    # --- Poll quotidien des affaires Enedis (#89, ADR 0021 §3-4) ---
+
+    _DELAI_GRACE_INCONNUE_JOURS = 3
+    _ACTIVITY_SUMMARY_RSC = 'Anomalie affaire Enedis (RSC)'
+
+    @api.model
+    def _cron_poll_affaires_enedis(self):
+        """Cron quotidien : cible les Souscriptions en instance à id_Affaire
+        renseigné, non archivées — indépendamment de l'existence d'une
+        demande, donc les Souscriptions saisies à la main sont couvertes.
+        Un seul appel batch. Échec réseau/service : skip silencieux total
+        (aucun état modifié, aucune activité), nouvel essai au poll suivant."""
+        cibles = self.search([('etat', '=', 'en_instance'), ('id_affaire', '!=', False), ('active', '=', True)])
+        if not cibles:
+            return
+        try:
+            cibles._resoudre_rsc()
+        except Exception:
+            _logger.warning('Poll RSC : échec réseau/service, nouvel essai au poll suivant.', exc_info=True)
+            return
+        cibles._appliquer_alertes_rsc()
+
+    def _appliquer_alertes_rsc(self):
+        """Mapping des motifs -> alerte (#89, ADR 0021 §4) pour les
+        Souscriptions venant d'être poll-ées. *Résolue* : lève toute alerte
+        (attente silencieuse). *Connue sans C15* : attente silencieuse,
+        c'est l'état normal du suivi. *Inconnue* : tolérée
+        `_DELAI_GRACE_INCONNUE_JOURS` jours depuis la saisie de l'id_Affaire,
+        puis alerte. *Ambiguë* : alerte immédiate. Une alerte n'est jamais
+        recréée tant qu'elle persiste ; elle se lève dès que le motif
+        disparaît."""
+        today = fields.Date.context_today(self)
+        for sous in self:
+            if sous.etat == 'en_service':
+                sous._lever_alerte_rsc()
+                continue
+            motif = sous.motif_resolution_rsc or ''
+            if motif.startswith('Résolution ambiguë'):
+                sous._signaler_alerte_rsc()
+            elif motif.startswith('Affaire inconnue'):
+                saisie = sous.id_affaire_date_saisie
+                en_grace = bool(saisie) and (today - saisie).days <= sous._DELAI_GRACE_INCONNUE_JOURS
+                if en_grace:
+                    sous._lever_alerte_rsc()
+                else:
+                    sous._signaler_alerte_rsc()
+            else:  # « connue sans C15 » ou motif inattendu : attente silencieuse
+                sous._lever_alerte_rsc()
+
+    def _demande_liee(self):
+        """La demande de raccordement ayant engendré `self`, s'il y en a une
+        (les Souscriptions saisies à la main n'en ont pas)."""
+        self.ensure_one()
+        return self.env['raccordement.demande'].search([('souscription_id', '=', self.id)], limit=1)
+
+    def _signaler_alerte_rsc(self):
+        """Alerte : carte bloquée (demande liée) + une activité unique pour
+        l'accueilliste, jamais recréée tant que l'anomalie persiste.
+        Souscription sans demande liée -> activité portée par elle-même."""
+        self.ensure_one()
+        demande = self._demande_liee()
+        cible = demande or self
+        if demande and demande.kanban_state != 'blocked':
+            demande.kanban_state = 'blocked'
+        deja_signalee = cible.activity_ids.filtered(lambda a: a.summary == self._ACTIVITY_SUMMARY_RSC)
+        if not deja_signalee:
+            cible.activity_schedule(
+                'mail.mail_activity_data_todo',
+                summary=self._ACTIVITY_SUMMARY_RSC,
+                note=f"Suivi de l'affaire {self.id_affaire} bloqué : {self.motif_resolution_rsc}",
+            )
+
+    def _lever_alerte_rsc(self):
+        """Lève l'alerte #89 : débloque la carte de la demande liée et
+        retire l'activité de suivi si elles existent (no-op sinon)."""
+        self.ensure_one()
+        demande = self._demande_liee()
+        cible = demande or self
+        if demande and demande.kanban_state == 'blocked':
+            demande.kanban_state = 'normal'
+        cible.activity_ids.filtered(lambda a: a.summary == self._ACTIVITY_SUMMARY_RSC).unlink()
 
     @api.depends('periode_ids.facture_id')
     def _compute_factures_via_periodes(self):

--- a/models/raccordement/raccordement_demande.py
+++ b/models/raccordement/raccordement_demande.py
@@ -200,6 +200,9 @@ class RaccordementDemande(models.Model):
         for record in records:
             if not record.stage_id:
                 record.stage_id = self._get_default_stage_id()
+        # id_Affaire déjà renseigné à la création (rare, mais cohérent avec
+        # l'auto-move de write(), #90) : avance la carte si elle est en amont.
+        records.filtered('id_affaire')._avancer_stage_demande_sge()
         return records
 
     @api.model
@@ -311,6 +314,12 @@ class RaccordementDemande(models.Model):
 
     def write(self, vals):
         """Override write pour les actions automatiques de base"""
+        # Étapes pilotées par les faits (#90, ADR 0021 §5) : le drag-in
+        # manuel y est refusé, sauf pour les automatismes du module
+        # (contournement de contexte `raccordement_automove`).
+        if 'stage_id' in vals and not self.env.context.get('raccordement_automove'):
+            self._verifier_pas_de_drag_in_factuel(vals['stage_id'])
+
         # id_Affaire saisi/corrigé (#87) : date de saisie auto-stampée, sauf
         # si le vals la fixe explicitement (rattrapage de typo, tests
         # antidatant la grâce du poll #89).
@@ -326,7 +335,38 @@ class RaccordementDemande(models.Model):
                 if record.stage_id.is_close and not record.souscription_id:
                     record._create_odoo_entries()
 
+        # id_Affaire saisi/corrigé (#90) : la carte avance seule à « Demande
+        # SGE faite » si elle est en amont — jamais en aval (pas de recul).
+        if 'id_affaire' in vals:
+            self._avancer_stage_demande_sge()
+
         return res
+
+    def _verifier_pas_de_drag_in_factuel(self, nouveau_stage_id):
+        """Refuse le drag-in manuel vers une étape pilotée par un fait
+        (#90) : on corrige le fait, la carte suit — jamais l'inverse. Ne
+        s'applique qu'aux demandes qui *changent* réellement d'étape : une
+        ré-écriture sans changement (resync des données, module upgrade) ne
+        déclenche pas la garde."""
+        nouveau_stage = self.env['raccordement.stage'].browse(nouveau_stage_id)
+        if not nouveau_stage.entree_factuelle:
+            return
+        deplacees = self.filtered(lambda r: r.stage_id.id != nouveau_stage_id)
+        if deplacees:
+            raise UserError(
+                f'« {nouveau_stage.name} » est une étape pilotée par un fait : elle ne se force pas à la '
+                'main. Corrigez le fait (id_Affaire saisi, RSC acquise) — la carte suivra automatiquement.'
+            )
+
+    def _avancer_stage_demande_sge(self):
+        """Auto-move (#90) : id_Affaire renseigné -> « Demande SGE faite »,
+        seulement si la demande est encore en amont (jamais de recul)."""
+        stage = self.env.ref('souscriptions_odoo.stage_demande_sge', raise_if_not_found=False)
+        if not stage:
+            return
+        for record in self:
+            if record.id_affaire and record.stage_id.sequence < stage.sequence:
+                record.with_context(raccordement_automove=True).stage_id = stage.id
 
     def _create_odoo_entries(self):
         """Crée automatiquement les entrées Odoo (contact, banque, souscription)"""

--- a/models/raccordement/raccordement_demande.py
+++ b/models/raccordement/raccordement_demande.py
@@ -166,6 +166,18 @@ class RaccordementDemande(models.Model):
     date_demande_mesures = fields.Date(string='Date demande mesures', tracking=True)
     date_estimation = fields.Date(string='Date estimation', tracking=True)
 
+    # Suivi de l'affaire Enedis (#87, ADR 0021). id_affaire est la référence
+    # d'affaire SGE, connue tôt et non ambiguë (ADR 0010) ; sa date de saisie
+    # amorce le délai de grâce du poll quotidien (#89) et est recopiée sur la
+    # Souscription à la création, comme id_affaire lui-même (ADR 0016).
+    id_affaire = fields.Char(string="N° d'affaire Enedis", tracking=True, help='Référence renvoyée dès la demande SGE.')
+    id_affaire_date_saisie = fields.Date(
+        string="Date de saisie de l'id_Affaire",
+        tracking=True,
+        help="Date à laquelle l'id_Affaire a été renseigné — amorce le délai de grâce "
+        'du poll quotidien des affaires Enedis (#89).',
+    )
+
     # Champs liés après création
     partner_id = fields.Many2one('res.partner', string='Contact créé', readonly=True, tracking=True)
     partner_bank_id = fields.Many2one('res.partner.bank', string='Compte bancaire créé', readonly=True, tracking=True)
@@ -181,6 +193,8 @@ class RaccordementDemande(models.Model):
         for vals in vals_list:
             if vals.get('name', 'Nouveau') == 'Nouveau':
                 vals['name'] = self.env['ir.sequence'].next_by_code('raccordement.demande.sequence') or 'Nouveau'
+            if vals.get('id_affaire') and not vals.get('id_affaire_date_saisie'):
+                vals['id_affaire_date_saisie'] = fields.Date.context_today(self)
         records = super().create(vals_list)
         # Définir l'étape initiale si non définie
         for record in records:
@@ -297,6 +311,12 @@ class RaccordementDemande(models.Model):
 
     def write(self, vals):
         """Override write pour les actions automatiques de base"""
+        # id_Affaire saisi/corrigé (#87) : date de saisie auto-stampée, sauf
+        # si le vals la fixe explicitement (rattrapage de typo, tests
+        # antidatant la grâce du poll #89).
+        if vals.get('id_affaire') and 'id_affaire_date_saisie' not in vals:
+            vals = dict(vals, id_affaire_date_saisie=fields.Date.context_today(self))
+
         res = super().write(vals)
 
         # Si on change l'étape
@@ -430,6 +450,10 @@ class RaccordementDemande(models.Model):
             'date_validation': self.date_validation,
             'renonce_retractation': self.renonce_retractation,
             'cotitulaires': [(6, 0, self.cotitulaires.ids)],
+            # Identité electricore (ADR 0010/0021) : id_Affaire recopié comme
+            # amorce de réconciliation, avec sa date de saisie (grâce du poll #89).
+            'id_affaire': self.id_affaire,
+            'id_affaire_date_saisie': self.id_affaire_date_saisie,
         }
 
         # Ajouter les provisions selon le type de tarif

--- a/models/raccordement/raccordement_stage.py
+++ b/models/raccordement/raccordement_stage.py
@@ -16,4 +16,14 @@ class RaccordementStage(models.Model):
         string='Étape finale', help='Indique si cette étape correspond à la finalisation du raccordement'
     )
 
+    # Étapes pilotées par les faits (#90, ADR 0021 §5) : la demande y avance
+    # seule quand son fait déclencheur est vérifié (id_Affaire saisi, RSC
+    # acquise). Le drag-in manuel y est refusé — on corrige le fait, la carte
+    # suit — sauf pour les automatismes (contournement de contexte).
+    entree_factuelle = fields.Boolean(
+        string='Étape pilotée par un fait',
+        help="Le drag-in manuel est refusé sur cette étape : elle n'avance que par "
+        "un automatisme (saisie de l'id_Affaire, acquisition de la RSC).",
+    )
+
     demande_ids = fields.One2many('raccordement.demande', 'stage_id', string='Demandes')

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -10,6 +10,7 @@ from . import (
     test_periode_facture,
     test_periode_form,
     test_periode_snapshot,
+    test_poll_affaires_enedis,
     test_portal,
     test_pull_meta_periodes,
     test_raccordement,

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -18,4 +18,5 @@ from . import (
     test_releve_demo,
     test_security,
     test_souscription,
+    test_souscription_etat,
 )

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -16,6 +16,7 @@ from . import (
     test_refacturation,
     test_releve,
     test_releve_demo,
+    test_rsc_service,
     test_security,
     test_souscription,
     test_souscription_etat,

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -14,6 +14,7 @@ from . import (
     test_portal,
     test_pull_meta_periodes,
     test_raccordement,
+    test_raccordement_kanban_faits,
     test_refacturation,
     test_releve,
     test_releve_demo,

--- a/tests/test_poll_affaires_enedis.py
+++ b/tests/test_poll_affaires_enedis.py
@@ -1,0 +1,240 @@
+"""Tests #89 — poll quotidien des affaires Enedis : ciblage, mapping des
+motifs, grâce de 3 jours, alertes sans spam, résolution en cours de vie,
+échec réseau silencieux (ADR 0021 §3-4).
+
+Réutilise la couture de #88 : on patche `_appeler`, la méthode transport du
+service RSC, avec des réponses en boîte. La grâce est testée en antidatant
+`id_affaire_date_saisie` — pas de mock du temps.
+"""
+
+from datetime import date, timedelta
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from odoo.addons.souscriptions_odoo.models.core import electricore_rsc_service as service_module
+from odoo.tests.common import tagged
+
+from .common import SouscriptionsTestCase
+
+_SERVICE = service_module.SouscriptionRscService
+
+_MOTIF_SANS_C15 = (
+    'Affaire connue (X12) sans situation contractuelle C15 (précurseur en cours ou affaire non contractuelle).'
+)
+
+
+def _resultat(id_affaire, rsc=None, error=None):
+    return SimpleNamespace(id_affaire=id_affaire, ref_situation_contractuelle=rsc, error=error)
+
+
+@tagged('souscriptions', 'souscriptions_poll_rsc', 'post_install', '-at_install')
+class TestPollAffairesEnedis(SouscriptionsTestCase):
+    def setUp(self):
+        super().setUp()
+        # Le paquet peut être absent du sandbox d'exécution des tests : forcé
+        # disponible (même garde que le wizard #84 et le service #88).
+        patcher = patch.object(service_module, 'ELECTRICORE_CLIENT_DISPONIBLE', True)
+        patcher.start()
+        self.addCleanup(patcher.stop)
+        ICP = self.env['ir.config_parameter'].sudo()
+        ICP.set_param('souscriptions.electricore_url', 'https://electricore.example.test')
+        ICP.set_param('souscriptions.electricore_api_key', 'fake-api-key')
+
+    def _patch_appeler(self, return_value=None, side_effect=None):
+        return patch.object(_SERVICE, '_appeler', return_value=return_value, side_effect=side_effect)
+
+    def create_demande_avec_souscription(self, id_affaire=None, email='poll-rsc@example.com'):
+        """Demande complète menée jusqu'à « Souscrit » : Souscription créée,
+        liée à sa demande via souscription_id."""
+        demande = self.env['raccordement.demande'].create(
+            {
+                'pdl': 'PDL_POLL_' + email,
+                'date_debut_souhaitee': date.today() + timedelta(days=30),
+                'puissance_souscrite': '6',
+                'type_tarif': 'base',
+                'provision_mensuelle_kwh': 250.0,
+                'contact_nom': 'Test',
+                'contact_email': email,
+                'contact_street': 'Test Street',
+                'contact_zip': '12345',
+                'contact_city': 'Test City',
+                'id_affaire': id_affaire,
+            }
+        )
+        demande.stage_id = self.env.ref('souscriptions_odoo.stage_souscrit')
+        return demande
+
+    # --- Ciblage du lot ---
+
+    def test_cible_en_instance_id_affaire_actif_seulement(self):
+        """AC1 : cible en instance + id_Affaire renseigné + non archivée,
+        indépendamment de l'existence d'une demande — un seul appel batch."""
+        cible_1 = self.souscription_base
+        cible_1.id_affaire = 'AFF-CIBLE-1'  # souscription saisie à la main, sans demande
+
+        sans_affaire = self.souscription_hphc
+        self.assertFalse(sans_affaire.id_affaire)
+
+        self.create_demande_avec_souscription(id_affaire='AFF-CIBLE-2')
+
+        deja_en_service = self.env['souscription.souscription'].create(
+            {
+                'partner_id': self.partner_test.id,
+                'pdl': 'PDL_DEJA_SERVICE',
+                'puissance_souscrite': '6',
+                'type_tarif': 'base',
+                'etat_facturation_id': self.etat_facturation.id,
+                'id_affaire': 'AFF-DEJA-SERVICE',
+            }
+        )
+        deja_en_service.with_context(rsc_automatisme=True).write({'ref_situation_contractuelle': 'RSC-X'})
+
+        archivee = self.env['souscription.souscription'].create(
+            {
+                'partner_id': self.partner_test.id,
+                'pdl': 'PDL_ARCHIVEE',
+                'puissance_souscrite': '6',
+                'type_tarif': 'base',
+                'etat_facturation_id': self.etat_facturation.id,
+                'id_affaire': 'AFF-ARCHIVEE',
+                'active': False,
+            }
+        )
+
+        with self._patch_appeler(
+            return_value=[
+                _resultat('AFF-CIBLE-1', error=_MOTIF_SANS_C15),
+                _resultat('AFF-CIBLE-2', error=_MOTIF_SANS_C15),
+            ]
+        ) as mock_appeler:
+            self.env['souscription.souscription']._cron_poll_affaires_enedis()
+
+        mock_appeler.assert_called_once()
+        lot_envoye = set(mock_appeler.call_args.args[0])
+        self.assertEqual(lot_envoye, {'AFF-CIBLE-1', 'AFF-CIBLE-2'})
+        self.assertNotIn(sans_affaire.id_affaire, lot_envoye)
+        self.assertNotIn(deja_en_service.id_affaire, lot_envoye)
+        self.assertNotIn(archivee.id_affaire, lot_envoye)
+
+    def test_lot_vide_naboutit_pas_a_un_appel(self):
+        self.assertFalse(self.souscription_base.id_affaire)
+        self.assertFalse(self.souscription_hphc.id_affaire)
+        with self._patch_appeler() as mock_appeler:
+            self.env['souscription.souscription']._cron_poll_affaires_enedis()
+        mock_appeler.assert_not_called()
+
+    # --- Mapping des motifs ---
+
+    def test_connue_sans_c15_attente_silencieuse(self):
+        """AC2 : ni activité, ni blocage — motif/date rafraîchis."""
+        demande = self.create_demande_avec_souscription(id_affaire='AFF-SILENCE')
+        souscription = demande.souscription_id
+
+        with self._patch_appeler(return_value=[_resultat('AFF-SILENCE', error=_MOTIF_SANS_C15)]):
+            self.env['souscription.souscription']._cron_poll_affaires_enedis()
+
+        self.assertEqual(souscription.motif_resolution_rsc, _MOTIF_SANS_C15)
+        self.assertEqual(souscription.date_derniere_resolution_rsc, date.today())
+        self.assertEqual(demande.kanban_state, 'normal')
+        self.assertFalse(demande.activity_ids)
+
+    def test_ambigue_alerte_immediate(self):
+        """AC3 : résolution ambiguë alerte immédiatement, même à J+0."""
+        demande = self.create_demande_avec_souscription(id_affaire='AFF-AMBIGUE')
+        motif = "Résolution ambiguë : 2 situations contractuelles pour l'affaire AFF-AMBIGUE (X, Y)."
+
+        with self._patch_appeler(return_value=[_resultat('AFF-AMBIGUE', error=motif)]):
+            self.env['souscription.souscription']._cron_poll_affaires_enedis()
+
+        self.assertEqual(demande.kanban_state, 'blocked')
+        self.assertEqual(len(demande.activity_ids), 1)
+
+    def test_inconnue_toleree_dans_le_delai_de_grace(self):
+        """AC3 : à J+3 (borne incluse), pas d'alerte."""
+        demande = self.create_demande_avec_souscription(id_affaire='AFF-GRACE')
+        souscription = demande.souscription_id
+        souscription.write({'id_affaire_date_saisie': date.today() - timedelta(days=3)})
+
+        with self._patch_appeler(return_value=[_resultat('AFF-GRACE', error='Affaire inconnue : AFF-GRACE')]):
+            self.env['souscription.souscription']._cron_poll_affaires_enedis()
+
+        self.assertEqual(demande.kanban_state, 'normal')
+        self.assertFalse(demande.activity_ids)
+
+    def test_inconnue_alerte_passe_le_delai_de_grace(self):
+        """AC3 : à J+4, alerte (typo probable)."""
+        demande = self.create_demande_avec_souscription(id_affaire='AFF-GRACE-EXPIREE')
+        souscription = demande.souscription_id
+        souscription.write({'id_affaire_date_saisie': date.today() - timedelta(days=4)})
+
+        with self._patch_appeler(
+            return_value=[_resultat('AFF-GRACE-EXPIREE', error='Affaire inconnue : AFF-GRACE-EXPIREE')]
+        ):
+            self.env['souscription.souscription']._cron_poll_affaires_enedis()
+
+        self.assertEqual(demande.kanban_state, 'blocked')
+        self.assertEqual(len(demande.activity_ids), 1)
+
+    # --- Alertes sans spam / résolution en cours de vie ---
+
+    def test_deux_polls_en_erreur_consecutifs_une_seule_activite(self):
+        demande = self.create_demande_avec_souscription(id_affaire='AFF-SPAM')
+        motif = "Résolution ambiguë : 2 situations contractuelles pour l'affaire AFF-SPAM (X, Y)."
+
+        with self._patch_appeler(return_value=[_resultat('AFF-SPAM', error=motif)]):
+            self.env['souscription.souscription']._cron_poll_affaires_enedis()
+            self.env['souscription.souscription']._cron_poll_affaires_enedis()
+
+        self.assertEqual(len(demande.activity_ids), 1)
+
+    def test_resolution_leve_lalerte(self):
+        """AC5 : la carte se débloque et l'activité disparaît dès que le
+        motif disparaît (RSC résolue au poll suivant)."""
+        demande = self.create_demande_avec_souscription(id_affaire='AFF-RESOUT')
+        souscription = demande.souscription_id
+        motif = "Résolution ambiguë : 2 situations contractuelles pour l'affaire AFF-RESOUT (X, Y)."
+
+        with self._patch_appeler(return_value=[_resultat('AFF-RESOUT', error=motif)]):
+            self.env['souscription.souscription']._cron_poll_affaires_enedis()
+        self.assertEqual(demande.kanban_state, 'blocked')
+        self.assertEqual(len(demande.activity_ids), 1)
+
+        with self._patch_appeler(return_value=[_resultat('AFF-RESOUT', rsc='RSC-RESOLUE')]):
+            self.env['souscription.souscription']._cron_poll_affaires_enedis()
+
+        self.assertEqual(souscription.ref_situation_contractuelle, 'RSC-RESOLUE')
+        self.assertEqual(demande.kanban_state, 'normal')
+        self.assertFalse(demande.activity_ids)
+
+    def test_souscription_sans_demande_liee_alerte_portee_par_elle_meme(self):
+        souscription = self.env['souscription.souscription'].create(
+            {
+                'partner_id': self.partner_test.id,
+                'pdl': 'PDL_SANS_DEMANDE',
+                'puissance_souscrite': '6',
+                'type_tarif': 'base',
+                'etat_facturation_id': self.etat_facturation.id,
+                'id_affaire': 'AFF-SANS-DEMANDE',
+            }
+        )
+        motif = "Résolution ambiguë : 2 situations contractuelles pour l'affaire AFF-SANS-DEMANDE (X, Y)."
+
+        with self._patch_appeler(return_value=[_resultat('AFF-SANS-DEMANDE', error=motif)]):
+            self.env['souscription.souscription']._cron_poll_affaires_enedis()
+
+        self.assertEqual(len(souscription.activity_ids), 1)
+
+    # --- Échec réseau/service ---
+
+    def test_echec_reseau_skip_silencieux_sans_effet(self):
+        demande = self.create_demande_avec_souscription(id_affaire='AFF-RESEAU')
+        souscription = demande.souscription_id
+
+        with self._patch_appeler(side_effect=ConnectionError('timeout')):
+            self.env['souscription.souscription']._cron_poll_affaires_enedis()
+
+        self.assertEqual(souscription.etat, 'en_instance')
+        self.assertFalse(souscription.motif_resolution_rsc)
+        self.assertFalse(souscription.date_derniere_resolution_rsc)
+        self.assertEqual(demande.kanban_state, 'normal')
+        self.assertFalse(demande.activity_ids)

--- a/tests/test_raccordement_kanban_faits.py
+++ b/tests/test_raccordement_kanban_faits.py
@@ -1,0 +1,165 @@
+"""Tests #90 — kanban de raccordement piloté par les faits (ADR 0021 §5) :
+auto-move à la saisie de l'id_Affaire et à l'acquisition de la RSC, drag-in
+manuel interdit sur ces deux étapes factuelles, pas de recul, non-régression
+de la création à « Souscrit »."""
+
+from datetime import date, timedelta
+
+from odoo.exceptions import UserError
+from odoo.tests.common import TransactionCase, tagged
+
+from .common import SouscriptionsTestMixin
+
+
+@tagged('souscriptions', 'souscriptions_raccordement_faits', 'post_install', '-at_install')
+class TestKanbanPiloteParLesFaits(SouscriptionsTestMixin, TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.setUpSouscriptionsData()
+        cls.stage_recue = cls.env.ref('souscriptions_odoo.stage_demande_recue')
+        cls.stage_iban = cls.env.ref('souscriptions_odoo.stage_iban_valide')
+        cls.stage_demande_sge = cls.env.ref('souscriptions_odoo.stage_demande_sge')
+        cls.stage_souscrit = cls.env.ref('souscriptions_odoo.stage_souscrit')
+        cls.stage_en_service = cls.env.ref('souscriptions_odoo.stage_en_service')
+
+    def create_demande(self, email, **kwargs):
+        defaults = {
+            'pdl': 'PDL_FAITS_' + email,
+            'date_debut_souhaitee': date.today() + timedelta(days=30),
+            'puissance_souscrite': '6',
+            'type_tarif': 'base',
+            'provision_mensuelle_kwh': 250.0,
+            'contact_nom': 'Test',
+            'contact_email': email,
+            'contact_street': 'Test Street',
+            'contact_zip': '12345',
+            'contact_city': 'Test City',
+        }
+        defaults.update(kwargs)
+        return self.env['raccordement.demande'].create(defaults)
+
+    # --- Stage « En service » : nouvelle étape ---
+
+    def test_stage_en_service_finale_repliee_sans_role_de_creation(self):
+        self.assertGreater(self.stage_en_service.sequence, self.stage_souscrit.sequence)
+        self.assertTrue(self.stage_en_service.fold)
+        self.assertFalse(self.stage_en_service.is_close)
+        self.assertTrue(self.stage_en_service.entree_factuelle)
+        self.assertTrue(self.stage_demande_sge.entree_factuelle)
+
+    # --- Auto-move : id_Affaire -> Demande SGE faite ---
+
+    def test_auto_move_a_la_saisie_id_affaire(self):
+        demande = self.create_demande('faits1@example.com')
+        self.assertEqual(demande.stage_id, self.stage_recue)
+
+        demande.id_affaire = '38233180'
+
+        self.assertEqual(demande.stage_id, self.stage_demande_sge)
+
+    def test_auto_move_id_affaire_ne_recule_pas(self):
+        """Une demande déjà en aval (Souscrit) ne recule jamais vers
+        « Demande SGE faite » quand l'id_Affaire est (re)saisi."""
+        demande = self.create_demande(
+            'faits2@example.com',
+            mode_paiement='virement',
+        )
+        demande.stage_id = self.stage_souscrit
+        self.assertEqual(demande.stage_id, self.stage_souscrit)
+
+        demande.id_affaire = '38233181'
+
+        self.assertEqual(demande.stage_id, self.stage_souscrit)
+
+    # --- Drag-in manuel interdit ---
+
+    def test_drag_in_manuel_refuse_vers_demande_sge(self):
+        demande = self.create_demande('faits3@example.com')
+        with self.assertRaises(UserError) as cm:
+            demande.stage_id = self.stage_demande_sge
+        self.assertIn('pilotée par un fait', str(cm.exception))
+        self.assertEqual(demande.stage_id, self.stage_recue)
+
+    def test_drag_in_manuel_refuse_vers_en_service(self):
+        demande = self.create_demande('faits4@example.com', mode_paiement='virement')
+        demande.stage_id = self.stage_souscrit
+        with self.assertRaises(UserError) as cm:
+            demande.stage_id = self.stage_en_service
+        self.assertIn('pilotée par un fait', str(cm.exception))
+        self.assertEqual(demande.stage_id, self.stage_souscrit)
+
+    def test_drag_in_manuel_autorise_vers_etape_non_factuelle(self):
+        """Les étapes non pilotées par un fait restent librement draggables."""
+        demande = self.create_demande('faits5@example.com')
+        demande.stage_id = self.stage_iban
+        self.assertEqual(demande.stage_id, self.stage_iban)
+
+    def test_contournement_de_contexte_reserve_aux_automatismes(self):
+        demande = self.create_demande('faits6@example.com')
+        demande.with_context(raccordement_automove=True).stage_id = self.stage_demande_sge
+        self.assertEqual(demande.stage_id, self.stage_demande_sge)
+
+    # --- Auto-move : RSC acquise -> En service ---
+
+    def test_auto_move_en_service_a_la_rsc_manuelle(self):
+        demande = self.create_demande('faits7@example.com', mode_paiement='virement', id_affaire='38233182')
+        demande.stage_id = self.stage_souscrit
+        souscription = demande.souscription_id
+        self.assertTrue(souscription)
+        self.assertEqual(souscription.id_affaire, '38233182')
+
+        souscription.write({'ref_situation_contractuelle': 'RSC-9001'})  # gestionnaire (superuser en test)
+
+        self.assertEqual(demande.stage_id, self.stage_en_service)
+        messages = demande.message_ids.mapped('body')
+        self.assertTrue(any('En service' in body for body in messages))
+
+    def test_auto_move_en_service_a_la_rsc_du_poll(self):
+        """L'automatisme s'accroche au fait, pas au canal : une RSC écrite
+        via le contournement `rsc_automatisme` (poll #89) avance la carte
+        exactement comme une écriture manuelle."""
+        demande = self.create_demande('faits8@example.com', mode_paiement='virement', id_affaire='38233183')
+        demande.stage_id = self.stage_souscrit
+        souscription = demande.souscription_id
+
+        souscription.with_context(rsc_automatisme=True).write({'ref_situation_contractuelle': 'RSC-9002'})
+
+        self.assertEqual(demande.stage_id, self.stage_en_service)
+
+    def test_auto_move_en_service_ne_recule_jamais(self):
+        """Une nouvelle résolution RSC (re-résolution) sur une demande déjà
+        « En service » ne provoque ni erreur ni recul."""
+        demande = self.create_demande('faits9@example.com', mode_paiement='virement', id_affaire='38233184')
+        demande.stage_id = self.stage_souscrit
+        souscription = demande.souscription_id
+        souscription.write({'ref_situation_contractuelle': 'RSC-9003'})
+        self.assertEqual(demande.stage_id, self.stage_en_service)
+
+        # Ré-écriture (même valeur) : no-op côté auto-move (pas de nouvelle
+        # trace, la demande reste en service).
+        souscription.write({'ref_situation_contractuelle': 'RSC-9003'})
+        self.assertEqual(demande.stage_id, self.stage_en_service)
+
+    def test_souscription_sans_demande_liee_ne_leve_pas_derreur(self):
+        """Une Souscription sans demande (saisie manuelle) : la RSC s'écrit
+        normalement, sans erreur d'auto-move (rien à avancer)."""
+        souscription = self.env['souscription.souscription'].create(
+            {
+                'partner_id': self.partner_test.id,
+                'pdl': 'PDL_MANUEL',
+                'puissance_souscrite': '6',
+                'type_tarif': 'base',
+                'etat_facturation_id': self.etat_facturation.id,
+            }
+        )
+        souscription.write({'ref_situation_contractuelle': 'RSC-MANUEL'})
+        self.assertEqual(souscription.etat, 'en_service')
+
+    # --- Non-régression : « Souscrit » garde son rôle de création ---
+
+    def test_souscrit_garde_son_role_de_creation(self):
+        demande = self.create_demande('faits10@example.com', mode_paiement='virement')
+        demande.stage_id = self.stage_souscrit
+        self.assertTrue(demande.souscription_id)
+        self.assertTrue(demande.partner_id)

--- a/tests/test_rsc_service.py
+++ b/tests/test_rsc_service.py
@@ -1,0 +1,186 @@
+"""Tests #88 — service transport unique de résolution RSC + bouton
+« résoudre la RSC maintenant » (ADR 0021 §3, contrat figé
+`docs/contrat-rsc.md`).
+
+Couture de test du module (réutilisée par #89) : on patche `_appeler`, la
+méthode transport du service, avec des réponses en boîte mirant les quatre
+motifs du contrat RSC. Rien d'autre n'est mocké : pas de mock
+d'`electricore_client` lui-même, pas de HTTP, pas de mock du temps.
+"""
+
+from datetime import date
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from odoo.addons.souscriptions_odoo.models.core import electricore_rsc_service as service_module
+from odoo.exceptions import UserError
+from odoo.tests.common import tagged
+
+from .common import SouscriptionsTestCase
+
+_SERVICE_MODEL = 'souscription.rsc.service'
+
+
+class _FakeContractVersionError(Exception):
+    pass
+
+
+def _resultat(id_affaire, rsc=None, error=None):
+    """Stub duck-typé de `ResultatResolutionRsc` (xor rsc/error)."""
+    return SimpleNamespace(id_affaire=id_affaire, ref_situation_contractuelle=rsc, error=error)
+
+
+@tagged('souscriptions', 'souscriptions_rsc_service', 'post_install', '-at_install')
+class TestServiceRscTransport(SouscriptionsTestCase):
+    """Le service (`souscription.rsc.service`) isolément : appariement,
+    lot vide, garde d'import, config manquante, version de contrat."""
+
+    def _patch_appeler(self, return_value=None, side_effect=None):
+        return patch.object(
+            service_module.SouscriptionRscService, '_appeler', return_value=return_value, side_effect=side_effect
+        )
+
+    def test_lot_vide_naboutit_pas_a_un_appel(self):
+        with self._patch_appeler() as mock_appeler:
+            resultat = self.env[_SERVICE_MODEL].resoudre([])
+        self.assertEqual(resultat, {})
+        mock_appeler.assert_not_called()
+
+    def test_apparie_par_id_affaire_tolerant_au_desordre(self):
+        """Le lot est apparié par id_affaire, jamais par position : la
+        réponse renvoyée dans le désordre reste correctement appariée."""
+        reponse_desordonnee = [
+            _resultat('B', rsc='RSC-B'),
+            _resultat('A', rsc='RSC-A'),
+        ]
+        with self._patch_appeler(return_value=reponse_desordonnee):
+            resultat = self.env[_SERVICE_MODEL].resoudre(['A', 'B'])
+        self.assertEqual(resultat['A'].ref_situation_contractuelle, 'RSC-A')
+        self.assertEqual(resultat['B'].ref_situation_contractuelle, 'RSC-B')
+
+    def test_quatre_motifs_du_contrat(self):
+        """Les quatre motifs du contrat RSC (succès + 3 erreurs) traversent
+        le service sans traduction, xor rsc/error."""
+        reponse = [
+            _resultat('OK', rsc='RSC-001'),
+            _resultat('INCONNUE', error='Affaire inconnue : INCONNUE'),
+            _resultat(
+                'SANS-C15',
+                error='Affaire connue (X12) sans situation contractuelle C15 '
+                '(précurseur en cours ou affaire non contractuelle).',
+            ),
+            _resultat(
+                'AMBIGUE', error="Résolution ambiguë : 2 situations contractuelles pour l'affaire AMBIGUE (X, Y)."
+            ),
+        ]
+        with self._patch_appeler(return_value=reponse):
+            resultat = self.env[_SERVICE_MODEL].resoudre(['OK', 'INCONNUE', 'SANS-C15', 'AMBIGUE'])
+
+        self.assertEqual(resultat['OK'].ref_situation_contractuelle, 'RSC-001')
+        self.assertIsNone(resultat['OK'].error)
+        self.assertTrue(resultat['INCONNUE'].error.startswith('Affaire inconnue'))
+        self.assertTrue(resultat['SANS-C15'].error.startswith('Affaire connue'))
+        self.assertTrue(resultat['AMBIGUE'].error.startswith('Résolution ambiguë'))
+
+    def test_paquet_manquant_leve_userror_actionnable(self):
+        with patch.object(service_module, 'ELECTRICORE_CLIENT_DISPONIBLE', False):
+            with self.assertRaises(UserError) as cm:
+                self.env[_SERVICE_MODEL].resoudre(['A'])
+        self.assertIn('electricore_client', str(cm.exception))
+
+    def test_config_manquante_leve_userror(self):
+        self.env['ir.config_parameter'].sudo().set_param('souscriptions.electricore_api_key', False)
+        with patch.object(service_module, 'ELECTRICORE_CLIENT_DISPONIBLE', True):
+            with self.assertRaises(UserError):
+                self.env[_SERVICE_MODEL].resoudre(['A'])
+
+    def test_version_de_contrat_inattendue_signalee_sans_ecriture(self):
+        """AC2 : version de contrat inattendue -> signalée (UserError), le
+        service n'écrit jamais de donnée (l'exception interrompt l'appel
+        avant tout accès au résultat)."""
+        with patch.object(service_module, 'ContractVersionError', _FakeContractVersionError):
+            with self._patch_appeler(side_effect=_FakeContractVersionError('serveur v2 < attendu v3')):
+                with self.assertRaises(UserError) as cm:
+                    self.env[_SERVICE_MODEL].resoudre(['A'])
+        self.assertIn('Contrat electricore obsolète', str(cm.exception))
+
+
+@tagged('souscriptions', 'souscriptions_rsc_service', 'post_install', '-at_install')
+class TestActionResoudreRscMaintenant(SouscriptionsTestCase):
+    """Le bouton « résoudre la RSC maintenant » sur la Souscription."""
+
+    def _patch_appeler(self, return_value=None, side_effect=None):
+        return patch.object(
+            service_module.SouscriptionRscService, '_appeler', return_value=return_value, side_effect=side_effect
+        )
+
+    def test_succes_ecrit_la_rsc_et_trace_au_chatter(self):
+        self.souscription_base.id_affaire = '38233180'
+        with self._patch_appeler(return_value=[_resultat('38233180', rsc='RSC-9001')]):
+            self.souscription_base.action_resoudre_rsc_maintenant()
+
+        self.assertEqual(self.souscription_base.ref_situation_contractuelle, 'RSC-9001')
+        self.assertEqual(self.souscription_base.etat, 'en_service')
+        self.assertFalse(self.souscription_base.motif_resolution_rsc)
+        self.assertEqual(self.souscription_base.date_derniere_resolution_rsc, date.today())
+        messages = self.souscription_base.message_ids.mapped('body')
+        self.assertTrue(any('RSC-9001' in body for body in messages))
+
+    def test_affaire_inconnue_stocke_le_motif_et_la_date(self):
+        self.souscription_base.id_affaire = 'ZZZ999'
+        with self._patch_appeler(return_value=[_resultat('ZZZ999', error='Affaire inconnue : ZZZ999')]):
+            self.souscription_base.action_resoudre_rsc_maintenant()
+
+        self.assertFalse(self.souscription_base.ref_situation_contractuelle)
+        self.assertEqual(self.souscription_base.etat, 'en_instance')
+        self.assertEqual(self.souscription_base.motif_resolution_rsc, 'Affaire inconnue : ZZZ999')
+        self.assertEqual(self.souscription_base.date_derniere_resolution_rsc, date.today())
+
+    def test_lot_mixte_et_desordre_contenu_envoye_verifie(self):
+        """Deux Souscriptions résolues en un seul appel batch ; la réponse
+        désordonnée est correctement appariée, et le lot envoyé au service
+        est exactement les deux id_affaire attendus."""
+        self.souscription_base.id_affaire = 'AFF-BASE'
+        self.souscription_hphc.id_affaire = 'AFF-HPHC'
+        motif_sans_c15 = (
+            'Affaire connue (X12) sans situation contractuelle C15 (précurseur en cours ou affaire non contractuelle).'
+        )
+        reponse = [
+            _resultat('AFF-HPHC', error=motif_sans_c15),
+            _resultat('AFF-BASE', rsc='RSC-BASE-1'),
+        ]
+        souscriptions = self.souscription_base + self.souscription_hphc
+        with self._patch_appeler(return_value=reponse) as mock_appeler:
+            souscriptions.action_resoudre_rsc_maintenant()
+
+        mock_appeler.assert_called_once_with(['AFF-BASE', 'AFF-HPHC'])
+        self.assertEqual(self.souscription_base.ref_situation_contractuelle, 'RSC-BASE-1')
+        self.assertTrue(self.souscription_hphc.motif_resolution_rsc.startswith('Affaire connue'))
+
+    def test_idempotence_souscription_en_service_jamais_reciblee(self):
+        """Une Souscription déjà en service n'est jamais re-ciblée : aucun
+        appel si le lot filtré est vide."""
+        self.souscription_base.with_context(rsc_automatisme=True).write({'ref_situation_contractuelle': 'RSC-DEJA'})
+        self.assertEqual(self.souscription_base.etat, 'en_service')
+
+        with self._patch_appeler() as mock_appeler:
+            self.souscription_base.action_resoudre_rsc_maintenant()
+        mock_appeler.assert_not_called()
+
+    def test_id_affaire_manquant_leve_userror_sans_appel(self):
+        self.assertFalse(self.souscription_base.id_affaire)
+        with self._patch_appeler() as mock_appeler:
+            with self.assertRaises(UserError):
+                self.souscription_base.action_resoudre_rsc_maintenant()
+        mock_appeler.assert_not_called()
+
+    def test_version_inattendue_naucune_ecriture(self):
+        self.souscription_base.id_affaire = '38233180'
+        with patch.object(service_module, 'ContractVersionError', _FakeContractVersionError):
+            with self._patch_appeler(side_effect=_FakeContractVersionError('serveur v2 < attendu v3')):
+                with self.assertRaises(UserError):
+                    self.souscription_base.action_resoudre_rsc_maintenant()
+
+        self.assertFalse(self.souscription_base.ref_situation_contractuelle)
+        self.assertFalse(self.souscription_base.motif_resolution_rsc)
+        self.assertEqual(self.souscription_base.etat, 'en_instance')

--- a/tests/test_rsc_service.py
+++ b/tests/test_rsc_service.py
@@ -35,6 +35,18 @@ class TestServiceRscTransport(SouscriptionsTestCase):
     """Le service (`souscription.rsc.service`) isolément : appariement,
     lot vide, garde d'import, config manquante, version de contrat."""
 
+    def setUp(self):
+        super().setUp()
+        # Le paquet peut être absent du sandbox d'exécution des tests : forcé
+        # disponible par défaut (même garde que le wizard #84), sauf test
+        # dédié qui le repatche localement à False.
+        patcher = patch.object(service_module, 'ELECTRICORE_CLIENT_DISPONIBLE', True)
+        patcher.start()
+        self.addCleanup(patcher.stop)
+        ICP = self.env['ir.config_parameter'].sudo()
+        ICP.set_param('souscriptions.electricore_url', 'https://electricore.example.test')
+        ICP.set_param('souscriptions.electricore_api_key', 'fake-api-key')
+
     def _patch_appeler(self, return_value=None, side_effect=None):
         return patch.object(
             service_module.SouscriptionRscService, '_appeler', return_value=return_value, side_effect=side_effect
@@ -90,9 +102,8 @@ class TestServiceRscTransport(SouscriptionsTestCase):
 
     def test_config_manquante_leve_userror(self):
         self.env['ir.config_parameter'].sudo().set_param('souscriptions.electricore_api_key', False)
-        with patch.object(service_module, 'ELECTRICORE_CLIENT_DISPONIBLE', True):
-            with self.assertRaises(UserError):
-                self.env[_SERVICE_MODEL].resoudre(['A'])
+        with self.assertRaises(UserError):
+            self.env[_SERVICE_MODEL].resoudre(['A'])
 
     def test_version_de_contrat_inattendue_signalee_sans_ecriture(self):
         """AC2 : version de contrat inattendue -> signalée (UserError), le
@@ -108,6 +119,15 @@ class TestServiceRscTransport(SouscriptionsTestCase):
 @tagged('souscriptions', 'souscriptions_rsc_service', 'post_install', '-at_install')
 class TestActionResoudreRscMaintenant(SouscriptionsTestCase):
     """Le bouton « résoudre la RSC maintenant » sur la Souscription."""
+
+    def setUp(self):
+        super().setUp()
+        patcher = patch.object(service_module, 'ELECTRICORE_CLIENT_DISPONIBLE', True)
+        patcher.start()
+        self.addCleanup(patcher.stop)
+        ICP = self.env['ir.config_parameter'].sudo()
+        ICP.set_param('souscriptions.electricore_url', 'https://electricore.example.test')
+        ICP.set_param('souscriptions.electricore_api_key', 'fake-api-key')
 
     def _patch_appeler(self, return_value=None, side_effect=None):
         return patch.object(

--- a/tests/test_souscription_etat.py
+++ b/tests/test_souscription_etat.py
@@ -1,0 +1,177 @@
+"""Tests #87 — identité & état de la Souscription (ADR 0021 §1-2, ADR 0010
+amendé) : capture de l'id_Affaire côté raccordement (avec sa date de saisie),
+recopie à la création, correction possible, RSC restreinte au groupe
+gestionnaire, état de cycle de vie calculé.
+"""
+
+from datetime import date, timedelta
+
+from odoo.exceptions import AccessError
+from odoo.tests.common import TransactionCase, tagged
+
+from .common import SouscriptionsTestMixin
+
+
+@tagged('souscriptions', 'souscriptions_etat', 'post_install', '-at_install')
+class TestIdAffaireRaccordement(SouscriptionsTestMixin, TransactionCase):
+    """Capture et recopie de l'id_Affaire (demande -> Souscription)."""
+
+    def create_complete_demande(self, **kwargs):
+        defaults = {
+            'pdl': 'TEST123456789',
+            'date_debut_souhaitee': date.today() + timedelta(days=30),
+            'puissance_souscrite': '6',
+            'type_tarif': 'base',
+            'provision_mensuelle_kwh': 250.0,
+            'contact_nom': 'Test',
+            'contact_email': 'test-etat@example.com',
+            'contact_street': 'Test Street',
+            'contact_zip': '12345',
+            'contact_city': 'Test City',
+        }
+        defaults.update(kwargs)
+        return self.env['raccordement.demande'].create(defaults)
+
+    def test_date_de_saisie_enregistree_a_la_saisie_de_lid_affaire(self):
+        """Écrire id_affaire sur une demande sans id_affaire_date_saisie
+        explicite stampe la date du jour."""
+        demande = self.create_complete_demande()
+        self.assertFalse(demande.id_affaire_date_saisie)
+        demande.id_affaire = '38233180'
+        self.assertEqual(demande.id_affaire_date_saisie, date.today())
+
+    def test_date_de_saisie_antidatable_pour_les_tests(self):
+        """La date de saisie reste explicitement pilotable (grâce du poll #89,
+        testée en antidatant)."""
+        demande = self.create_complete_demande()
+        hier = date.today() - timedelta(days=10)
+        demande.write({'id_affaire': '38233180', 'id_affaire_date_saisie': hier})
+        self.assertEqual(demande.id_affaire_date_saisie, hier)
+
+    def test_id_affaire_et_date_recopies_sur_la_souscription_a_la_creation(self):
+        """AC1 : id_affaire (et sa date de saisie) recopiés sur la
+        Souscription engendrée par le raccordement."""
+        demande = self.create_complete_demande()
+        hier = date.today() - timedelta(days=2)
+        demande.write({'id_affaire': '38233180', 'id_affaire_date_saisie': hier})
+
+        stage_final = self.env.ref('souscriptions_odoo.stage_souscrit')
+        demande.stage_id = stage_final
+
+        souscription = demande.souscription_id
+        self.assertTrue(souscription, 'La souscription devrait être créée')
+        self.assertEqual(souscription.id_affaire, '38233180')
+        self.assertEqual(souscription.id_affaire_date_saisie, hier)
+
+    def test_id_affaire_corrigeable_sur_la_souscription_apres_creation(self):
+        """AC2 : rattrapage de typo sur la Souscription — id_affaire n'est
+        pas restreint (seule la RSC l'est)."""
+        self.souscription_base.id_affaire = '38233180'
+        self.assertEqual(self.souscription_base.id_affaire, '38233180')
+        # Correction : la date de saisie est ré-amorcée (nouvelle tentative).
+        self.souscription_base.id_affaire = '38233181'
+        self.assertEqual(self.souscription_base.id_affaire, '38233181')
+        self.assertEqual(self.souscription_base.id_affaire_date_saisie, date.today())
+
+
+@tagged('souscriptions', 'souscriptions_etat', 'post_install', '-at_install')
+class TestRscRestreinte(SouscriptionsTestMixin, TransactionCase):
+    """AC3 : écriture de la RSC réservée au groupe gestionnaire, tracée."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.setUpSouscriptionsData()
+        cls.user = cls.env['res.users'].create(
+            {
+                'name': 'Accueilliste',
+                'login': 'accueilliste_etat',
+                'email': 'accueilliste@souscriptions.test',
+                'group_ids': [(6, 0, [cls.env.ref('souscriptions_odoo.group_souscriptions_user').id])],
+            }
+        )
+        cls.manager = cls.env['res.users'].create(
+            {
+                'name': 'Gestionnaire',
+                'login': 'gestionnaire_etat',
+                'email': 'gestionnaire@souscriptions.test',
+                'group_ids': [(6, 0, [cls.env.ref('souscriptions_odoo.group_souscriptions_manager').id])],
+            }
+        )
+
+    def test_utilisateur_standard_ne_peut_pas_ecrire_la_rsc(self):
+        with self.assertRaises(AccessError):
+            self.souscription_base.with_user(self.user).write({'ref_situation_contractuelle': 'RSC-1'})
+
+    def test_gestionnaire_peut_ecrire_la_rsc(self):
+        self.souscription_base.with_user(self.manager).write({'ref_situation_contractuelle': 'RSC-1'})
+        self.assertEqual(self.souscription_base.ref_situation_contractuelle, 'RSC-1')
+
+    def test_ecriture_rsc_tracee_au_chatter(self):
+        self.souscription_base.with_user(self.manager).write({'ref_situation_contractuelle': 'RSC-1'})
+        tracking_messages = self.souscription_base.message_ids.filtered(lambda m: m.tracking_value_ids)
+        self.assertTrue(tracking_messages, 'Le changement de RSC devrait être tracé au chatter')
+
+    def test_automatisme_peut_ecrire_la_rsc_sans_le_groupe(self):
+        """Le contournement de contexte réservé aux automatismes (#88/#89) :
+        la RSC vient d'electricore, pas d'une saisie manuelle."""
+        self.souscription_base.with_user(self.user).with_context(rsc_automatisme=True).write(
+            {'ref_situation_contractuelle': 'RSC-1'}
+        )
+        self.assertEqual(self.souscription_base.ref_situation_contractuelle, 'RSC-1')
+
+
+@tagged('souscriptions', 'souscriptions_etat', 'post_install', '-at_install')
+class TestEtatCalcule(SouscriptionsTestMixin, TransactionCase):
+    """AC4 : état de cycle de vie calculé, jamais saisi."""
+
+    def test_en_instance_sans_rsc(self):
+        self.assertFalse(self.souscription_base.ref_situation_contractuelle)
+        self.assertEqual(self.souscription_base.etat, 'en_instance')
+
+    def test_bascule_en_service_a_lecriture_de_la_rsc(self):
+        self.souscription_base.write({'ref_situation_contractuelle': 'RSC-1'})
+        self.assertEqual(self.souscription_base.etat, 'en_service')
+
+    def test_resiliee_si_date_fin_passee(self):
+        self.souscription_base.write(
+            {'ref_situation_contractuelle': 'RSC-1', 'date_fin': date.today() - timedelta(days=1)}
+        )
+        self.assertEqual(self.souscription_base.etat, 'resiliee')
+
+    def test_pas_de_vocabulaire_brouillon_dans_la_selection(self):
+        """Vocabulaire du glossaire (CONTEXT.md) : jamais « brouillon », jamais
+        « active » pour le cycle de vie."""
+        libelles = dict(self.env['souscription.souscription']._fields['etat'].selection)
+        self.assertNotIn('brouillon', ' '.join(libelles.values()).lower())
+        self.assertNotIn('active', ' '.join(libelles.values()).lower())
+
+
+@tagged('souscriptions', 'souscriptions_etat', 'post_install', '-at_install')
+class TestFiltresEtat(SouscriptionsTestMixin, TransactionCase):
+    """AC5 : filtres/recherche par état, RSC, id_Affaire — filtre « en
+    instance sans id_Affaire »."""
+
+    def test_filtre_en_instance_sans_id_affaire(self):
+        self.souscription_base.id_affaire = False
+        self.souscription_hphc.write({'id_affaire': '38233180'})
+
+        Souscription = self.env['souscription.souscription']
+        domaine = [('etat', '=', 'en_instance'), ('id_affaire', '=', False)]
+        resultat = Souscription.search(domaine)
+
+        self.assertIn(self.souscription_base, resultat)
+        self.assertNotIn(self.souscription_hphc, resultat)
+
+    def test_recherche_par_rsc_et_id_affaire(self):
+        self.souscription_base.with_context(rsc_automatisme=True).write(
+            {'ref_situation_contractuelle': 'RSC-UNIQUE-001'}
+        )
+        self.souscription_hphc.id_affaire = 'AFFAIRE-UNIQUE-002'
+
+        Souscription = self.env['souscription.souscription']
+        par_rsc = Souscription.search([('ref_situation_contractuelle', '=', 'RSC-UNIQUE-001')])
+        par_affaire = Souscription.search([('id_affaire', '=', 'AFFAIRE-UNIQUE-002')])
+
+        self.assertEqual(par_rsc, self.souscription_base)
+        self.assertEqual(par_affaire, self.souscription_hphc)

--- a/tests/test_souscription_etat.py
+++ b/tests/test_souscription_etat.py
@@ -7,13 +7,13 @@ gestionnaire, état de cycle de vie calculé.
 from datetime import date, timedelta
 
 from odoo.exceptions import AccessError
-from odoo.tests.common import TransactionCase, tagged
+from odoo.tests.common import tagged
 
-from .common import SouscriptionsTestMixin
+from .common import SouscriptionsTestCase
 
 
 @tagged('souscriptions', 'souscriptions_etat', 'post_install', '-at_install')
-class TestIdAffaireRaccordement(SouscriptionsTestMixin, TransactionCase):
+class TestIdAffaireRaccordement(SouscriptionsTestCase):
     """Capture et recopie de l'id_Affaire (demande -> Souscription)."""
 
     def create_complete_demande(self, **kwargs):
@@ -75,13 +75,12 @@ class TestIdAffaireRaccordement(SouscriptionsTestMixin, TransactionCase):
 
 
 @tagged('souscriptions', 'souscriptions_etat', 'post_install', '-at_install')
-class TestRscRestreinte(SouscriptionsTestMixin, TransactionCase):
+class TestRscRestreinte(SouscriptionsTestCase):
     """AC3 : écriture de la RSC réservée au groupe gestionnaire, tracée."""
 
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        cls.setUpSouscriptionsData()
         cls.user = cls.env['res.users'].create(
             {
                 'name': 'Accueilliste',
@@ -109,6 +108,9 @@ class TestRscRestreinte(SouscriptionsTestMixin, TransactionCase):
 
     def test_ecriture_rsc_tracee_au_chatter(self):
         self.souscription_base.with_user(self.manager).write({'ref_situation_contractuelle': 'RSC-1'})
+        # Le tracking est différé au precommit — le forcer pour l'observer.
+        self.env.flush_all()
+        self.env.cr.precommit.run()
         tracking_messages = self.souscription_base.message_ids.filtered(lambda m: m.tracking_value_ids)
         self.assertTrue(tracking_messages, 'Le changement de RSC devrait être tracé au chatter')
 
@@ -122,7 +124,7 @@ class TestRscRestreinte(SouscriptionsTestMixin, TransactionCase):
 
 
 @tagged('souscriptions', 'souscriptions_etat', 'post_install', '-at_install')
-class TestEtatCalcule(SouscriptionsTestMixin, TransactionCase):
+class TestEtatCalcule(SouscriptionsTestCase):
     """AC4 : état de cycle de vie calculé, jamais saisi."""
 
     def test_en_instance_sans_rsc(self):
@@ -148,7 +150,7 @@ class TestEtatCalcule(SouscriptionsTestMixin, TransactionCase):
 
 
 @tagged('souscriptions', 'souscriptions_etat', 'post_install', '-at_install')
-class TestFiltresEtat(SouscriptionsTestMixin, TransactionCase):
+class TestFiltresEtat(SouscriptionsTestCase):
     """AC5 : filtres/recherche par état, RSC, id_Affaire — filtre « en
     instance sans id_Affaire »."""
 

--- a/views/core/souscription_views.xml
+++ b/views/core/souscription_views.xml
@@ -20,6 +20,10 @@
                         <field name="partner_id" />
                         <field name="cotitulaires" widget="many2many_tags" options="{'no_create': True}"/>
                         <field name="active" />
+                        <field name="etat" widget="badge"
+                               decoration-warning="etat == 'en_instance'"
+                               decoration-success="etat == 'en_service'"
+                               decoration-danger="etat == 'resiliee'"/>
                         <field name="etat_facturation_id"/>
                         <field name="date_debut"/>
                         <field name="date_fin"/>
@@ -45,13 +49,14 @@
                         <field name="numero_depannage" widget="phone"/>
                     </group>
 
-                    <!-- Identité electricore (ADR 0010/0020) : RSC = clé d'articulation
-                         du pull de méta-périodes, id_affaire = amorce de réconciliation.
-                         Peuplés par le raccordement à terme ; saisissables à la main
-                         d'ici là. -->
+                    <!-- Identité electricore (ADR 0010/0020/0021) : RSC = clé d'articulation
+                         du pull de méta-périodes, acquise par le poll quotidien ou l'action
+                         manuelle (#88/#89) ; id_affaire = amorce de réconciliation, recopié
+                         du raccordement, corrigeable (rattrapage de typo). -->
                     <group string="Identité électricore">
                         <field name="ref_situation_contractuelle"/>
                         <field name="id_affaire"/>
+                        <field name="id_affaire_date_saisie"/>
                     </group>
 
                     <group string="Adhésion (captée au raccordement)">
@@ -123,6 +128,12 @@
             <field name="name"/>
             <field name="partner_id"/>
             <field name="lisse"/>
+            <field name="etat" widget="badge"
+                   decoration-warning="etat == 'en_instance'"
+                   decoration-success="etat == 'en_service'"
+                   decoration-danger="etat == 'resiliee'"/>
+            <field name="id_affaire" optional="hide"/>
+            <field name="ref_situation_contractuelle" optional="hide"/>
             <field name="active"/>
           </list>
         </field>
@@ -156,11 +167,15 @@
         <field name="arch" type="xml">
             <kanban default_group_by="etat_facturation_id">
                 <field name="etat_facturation_id"/>
+                <field name="etat"/>
                 <templates>
                     <t t-name="card">
                         <div class="oe_kanban_global_click">
                             <strong><field name="name"/></strong><br/>
-                            <span><field name="etat_facturation_id"/></span>
+                            <span><field name="etat_facturation_id"/></span><br/>
+                            <span t-attf-class="badge #{record.etat.raw_value == 'en_service' ? 'text-bg-success' : record.etat.raw_value == 'resiliee' ? 'text-bg-danger' : 'text-bg-warning'}">
+                                <field name="etat"/>
+                            </span>
                         </div>
                     </t>
                 </templates>
@@ -168,10 +183,40 @@
         </field>
     </record>
 
+    <!-- Vue recherche : RSC/id_Affaire recherchables, état filtrable/groupable
+         (#87) — dont le filtre « en instance sans id_Affaire », les invisibles
+         du poll quotidien (#89). -->
+    <record id="view_souscription_search" model="ir.ui.view">
+        <field name="name">souscription.search</field>
+        <field name="model">souscription.souscription</field>
+        <field name="arch" type="xml">
+            <search string="Souscriptions">
+                <field name="name"/>
+                <field name="partner_id"/>
+                <field name="pdl"/>
+                <field name="ref_situation_contractuelle" string="RSC"/>
+                <field name="id_affaire" string="N° d'affaire Enedis"/>
+                <filter string="En instance" name="en_instance" domain="[('etat', '=', 'en_instance')]"/>
+                <filter string="En service" name="en_service" domain="[('etat', '=', 'en_service')]"/>
+                <filter string="Résiliée" name="resiliee" domain="[('etat', '=', 'resiliee')]"/>
+                <separator/>
+                <filter string="En instance sans id_Affaire" name="en_instance_sans_id_affaire"
+                        domain="[('etat', '=', 'en_instance'), ('id_affaire', '=', False)]"/>
+                <separator/>
+                <filter string="Archivée" name="inactive" domain="[('active', '=', False)]"/>
+                <group string="Grouper par">
+                    <filter string="État" name="group_etat" context="{'group_by': 'etat'}"/>
+                    <filter string="État de facturation" name="group_etat_facturation" context="{'group_by': 'etat_facturation_id'}"/>
+                </group>
+            </search>
+        </field>
+    </record>
+
     <record id="action_souscription" model="ir.actions.act_window">
         <field name="name">Souscriptions</field>
         <field name="res_model">souscription.souscription</field>
         <field name="view_mode">kanban,list,form</field>
+        <field name="search_view_id" ref="view_souscription_search"/>
         <field name="view_ids" eval="[(5, 0, 0),
             (0, 0, {'view_mode': 'list', 'view_id': ref('view_souscription_list')}),
             (0, 0, {'view_mode': 'form', 'view_id': ref('view_souscription_form')}),

--- a/views/core/souscription_views.xml
+++ b/views/core/souscription_views.xml
@@ -13,6 +13,10 @@
                     <button name="%(action_souscription_attestation)d"
                             string="Attestation de fourniture"
                             type="action"/>
+                    <button name="action_resoudre_rsc_maintenant"
+                            string="Résoudre la RSC maintenant"
+                            type="object"
+                            invisible="etat == 'en_service'"/>
                 </header>
                 <sheet>
                     <group>
@@ -57,6 +61,8 @@
                         <field name="ref_situation_contractuelle"/>
                         <field name="id_affaire"/>
                         <field name="id_affaire_date_saisie"/>
+                        <field name="motif_resolution_rsc" invisible="not motif_resolution_rsc"/>
+                        <field name="date_derniere_resolution_rsc" invisible="not date_derniere_resolution_rsc"/>
                     </group>
 
                     <group string="Adhésion (captée au raccordement)">

--- a/views/core/souscription_views.xml
+++ b/views/core/souscription_views.xml
@@ -210,7 +210,7 @@
                         domain="[('etat', '=', 'en_instance'), ('id_affaire', '=', False)]"/>
                 <separator/>
                 <filter string="Archivée" name="inactive" domain="[('active', '=', False)]"/>
-                <group string="Grouper par">
+                <group>
                     <filter string="État" name="group_etat" context="{'group_by': 'etat'}"/>
                     <filter string="État de facturation" name="group_etat_facturation" context="{'group_by': 'etat_facturation_id'}"/>
                 </group>

--- a/views/raccordement/raccordement_demande_views.xml
+++ b/views/raccordement/raccordement_demande_views.xml
@@ -41,6 +41,8 @@
                             <field name="date_demande_sge" />
                             <field name="date_demande_mesures" />
                             <field name="date_estimation" />
+                            <field name="id_affaire" />
+                            <field name="id_affaire_date_saisie" readonly="1" />
                             <field name="kanban_state" widget="state_selection" />
                         </group>
                     </group>
@@ -236,6 +238,7 @@
                 <field name="siret" />
                 <field name="contact_nom" />
                 <field name="contact_email" />
+                <field name="id_affaire" string="N° d'affaire Enedis" />
                 <filter string="Professionnel" name="pro" domain="[('pro', '=', True)]" />
                 <filter string="Particulier" name="particulier" domain="[('pro', '=', False)]" />
                 <separator />

--- a/views/raccordement/raccordement_demande_views.xml
+++ b/views/raccordement/raccordement_demande_views.xml
@@ -136,7 +136,7 @@
         <field name="name">raccordement.demande.kanban</field>
         <field name="model">raccordement.demande</field>
         <field name="arch" type="xml">
-            <kanban default_group_by="stage_id" class="o_kanban_small_column">
+            <kanban default_group_by="stage_id" class="o_kanban_small_column" highlight_color="color">
                 <field name="stage_id"
                     options='{"group_by_tooltip": {"description": "Description"}}' />
                 <field name="color" />
@@ -150,8 +150,7 @@
                 <progressbar field="kanban_state" colors='{"done": "success", "blocked": "danger"}' />
                 <templates>
                     <t t-name="card">
-                        <div
-                            t-attf-class="oe_kanban_color_#{kanban_getcolor(record.color.raw_value)} oe_kanban_card oe_kanban_global_click">
+                        <div class="oe_kanban_card oe_kanban_global_click">
                             <div class="oe_kanban_content">
                                 <div class="o_kanban_record_top mb-2">
                                     <div class="o_kanban_record_headings">


### PR DESCRIPTION
## Résumé

Implémente le PRD #86 (issues #87–#90) : le suivi automatique des affaires
Enedis qui remplace la vérification manuelle sur le portail SGE (ADR 0021 —
renuméroté depuis « ADR 0019 » des issues, 0019/0020 ayant été pris par
#84/#85).

- #87 pose le socle : id_Affaire capturé au raccordement (avec sa date de
  saisie) et recopié sur la Souscription à sa création, RSC restreinte au
  groupe gestionnaire et tracée au chatter, état de cycle de vie calculé
  (en instance / en service / résiliée), vues et filtres associés.
- #88 ajoute le premier point HTTP de l'addon : un service transport unique
  qui enveloppe electricore-client (résolution RSC), avec un bouton manuel
  « résoudre la RSC maintenant » sur la Souscription. C'est la tranche qui
  établit la couture de test réutilisée par #89 (méthode transport patchée,
  rien d'autre mocké).
- #89 ajoute le cron quotidien qui cible les Souscriptions en instance à
  id_Affaire renseigné, applique le mapping des quatre motifs du contrat
  RSC et alerte sans spam (kanban bloqué + une activité unique).
- #90 fait suivre le kanban de raccordement aux faits (id_Affaire, RSC) au
  lieu du drag-in manuel sur les étapes concernées, avec la nouvelle étape
  finale « En service ».

La PR embarque aussi les docs de design en premier commit (ADR 0021,
amendement ADR 0010, vocabulaire CONTEXT.md : *En instance / En service*,
*Accueilliste*, *Raccordement* réécrit).

Closes #87
Closes #88
Closes #89
Closes #90

## Test plan

- [x] Suite complète en Docker (odoo:19.0) : `0 failed, 0 error(s) of 258 tests`
- [x] 48 nouveaux tests (4 fichiers, tous importés dans `tests/__init__.py`)
- [x] Non-régression de la suite existante (raccordement, pull méta-périodes, sécurité)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
