### PR TITLE
feat(souscription): contrainte d'unicité sur la RSC

### DIFF
--- a/models/core/souscription.py
+++ b/models/core/souscription.py
@@ -198,6 +198,15 @@ class Souscription(models.Model):
         help='Date de la dernière tentative de résolution RSC (#88/#89), succès ou échec.',
     )
 
+    # Une RSC identifie un contrat unique (#15, ADR 0010) : deux souscriptions
+    # successives sur un même PDL portent des RSC différentes, et le pull clé
+    # sur RSC ne peut pas être ambigu. Les NULL (en instance) ne se gênent pas
+    # entre eux (sémantique UNIQUE de Postgres).
+    _rsc_unique = models.Constraint(
+        'UNIQUE(ref_situation_contractuelle)',
+        'Cette RSC est déjà portée par une autre souscription — une RSC identifie un contrat unique.',
+    )
+
     @api.depends('ref_situation_contractuelle', 'date_fin')
     def _compute_etat(self):
         today = fields.Date.context_today(self)

--- a/tests/test_souscription_etat.py
+++ b/tests/test_souscription_etat.py
@@ -8,6 +8,8 @@ from datetime import date, timedelta
 
 from odoo.exceptions import AccessError
 from odoo.tests.common import tagged
+from odoo.tools import mute_logger
+from psycopg2 import IntegrityError
 
 from .common import SouscriptionsTestCase
 
@@ -177,3 +179,48 @@ class TestFiltresEtat(SouscriptionsTestCase):
 
         self.assertEqual(par_rsc, self.souscription_base)
         self.assertEqual(par_affaire, self.souscription_hphc)
+
+
+@tagged('souscriptions', 'souscriptions_etat', 'post_install', '-at_install')
+class TestRscUnique(SouscriptionsTestCase):
+    """#15 : deux souscriptions successives sur le même PDL sont distinguables
+    sans ambiguïté — l'identité est portée par la RSC, unique par contrat."""
+
+    def _souscription(self, pdl, rsc):
+        return (
+            self.env['souscription.souscription']
+            .with_context(rsc_automatisme=True)
+            .create(
+                {
+                    'partner_id': self.partner_test.id,
+                    'pdl': pdl,
+                    'puissance_souscrite': '6',
+                    'type_tarif': 'base',
+                    'etat_facturation_id': self.etat_facturation.id,
+                    'date_debut': date(2024, 1, 1),
+                    'ref_situation_contractuelle': rsc,
+                }
+            )
+        )
+
+    def test_deux_souscriptions_successives_meme_pdl_distinguables(self):
+        premiere = self._souscription('PDL_PARTAGE', 'RSC-OCCUPANT-1')
+        seconde = self._souscription('PDL_PARTAGE', 'RSC-OCCUPANT-2')
+
+        Souscription = self.env['souscription.souscription']
+        self.assertEqual(len(Souscription.search([('pdl', '=', 'PDL_PARTAGE')])), 2)
+        self.assertEqual(Souscription.search([('ref_situation_contractuelle', '=', 'RSC-OCCUPANT-1')]), premiere)
+        self.assertEqual(Souscription.search([('ref_situation_contractuelle', '=', 'RSC-OCCUPANT-2')]), seconde)
+
+    def test_rsc_dupliquee_refusee(self):
+        self._souscription('PDL_PARTAGE', 'RSC-DOUBLON')
+        with self.assertRaises(IntegrityError), mute_logger('odoo.sql_db'), self.cr.savepoint():
+            self._souscription('PDL_AUTRE', 'RSC-DOUBLON')
+            self.env.flush_all()
+
+    def test_rsc_absente_ne_bloque_pas_les_en_instance(self):
+        """Les souscriptions en instance (RSC NULL) cohabitent librement —
+        sémantique UNIQUE de Postgres, les NULL ne se gênent pas."""
+        self._souscription('PDL_A', False)
+        self._souscription('PDL_B', False)
+        self.env.flush_all()


### PR DESCRIPTION
Closes #15

## Quoi

- `UNIQUE(ref_situation_contractuelle)` sur `souscription.souscription` : une RSC identifie un contrat unique (ADR 0010). Les NULL (souscriptions en instance) cohabitent librement — sémantique `UNIQUE` de Postgres.
- Tests `TestRscUnique` : deux souscriptions successives sur le même PDL distinguables sans ambiguïté par leur RSC (critère d'acceptation #2 de l'issue tel quel), RSC dupliquée refusée en base, RSC absentes non bloquantes.

## Pourquoi

Dernier critère de #15 non matérialisé : la distinguabilité de deux souscriptions successives sur un même PDL n'était garantie que par convention. La contrainte la garantit par construction, et rend impossible l'ombrage silencieux du dict `{rsc: souscription}` dans le wizard de pull des méta-périodes — sans toucher au wizard.

Le reste du contrat de #15 est déjà porté par la pile #91 : champ RSC sur souscription et période (snapshot à la création), recherche par RSC, stratégie de remplissage documentée (ADR 0010 amendé par ADR 0021, résolution `id_Affaire → RSC` par poll quotidien) et testée (~20 tests). Le regroupement des périodes se fait par souscription (1:1 avec la RSC).

## Vérification prod (avant pose de la contrainte)

- `souscription.souscription` n'existe pas en prod (greenfield, ADR 0003) → aucune donnée existante, aucun risque de migration.
- Legacy `sale.order.x_ref_situation_contractuelle` : 48 RSC en doublon sur 926, toutes des chaînes de renouvellement/churn du même contrat (même partenaire) — le défaut de modélisation `sale.order` que la refonte corrige. Un import legacy éventuel devra replier ces chaînes en une souscription par RSC ; la contrainte l'imposera.

## Tests

Suite complète en Docker (odoo:19.0) : **0 failed, 0 error de 261 tests**.

## Pile

Empilée sur #91 (`feat/86-suivi-affaires-enedis`) — GitHub re-ciblera sur `main` à la fusion de #91 ; le `Closes #15` prendra effet à la fusion dans `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)