### PR TITLE
docs(adr): ADR-0022 raccordement aligné prod + ci: permissions GITHUB_TOKEN

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -36,9 +36,9 @@ remplace, le terme pipeline d'electricore, la catégorie produit « Abonnements 
 
 **En instance / En service** :
 États de cycle de vie de la *Souscription*, **calculés depuis les faits**, jamais saisis.
-**En instance** : née au *raccordement* (signée, complète commercialement — les *conditions
-particulières* peuvent partir) mais **sans RSC** : non facturable, ignorée du pull de
-facturation. **En service** : la RSC est acquise (raccordement effectif côté Enedis) —
+**En instance** : née à l'**acceptation** de la demande de *raccordement* (signée, consentements
+journalisés) mais **sans RSC** : non facturable, ignorée du pull de facturation. **En service** :
+la RSC est acquise — le C15 d'effectivité est arrivé, la mise en service est réelle (ADR 0022) —
 facturable. La correction passe par le **fait** (la RSC), jamais par l'état. La résiliation
 est un chantier distinct.
 _Éviter_ : **brouillon** (la Souscription est conclue et signée ; « brouillon » est réservé à
@@ -218,28 +218,46 @@ Rôle métier qui conduit la facturation mensuelle depuis Odoo et **vérifie les
 
 **Accueilliste** :
 Rôle métier qui instruit les demandes de *raccordement* au quotidien : accueil des nouvelles
-demandes, demandes SGE (mise en service F120 / changement de fournisseur F130, demande de
-mesures M023), saisie de l'*id_Affaire*, suivi des affaires Enedis jusqu'à la mise en
-service. Le kanban de raccordement est son tableau de bord.
+demandes, demandes SGE selon la *situation d'entrée* (F120 / F130), saisie de l'*id_Affaire*,
+calcul des mensualités et validation de l'abonnement une fois la mise en service effective.
+Le kanban de raccordement est son tableau de bord.
 _Éviter_ : le confondre avec le·la *facturiste* (facturation mensuelle, autre rôle).
 
 **Raccordement** :
 Le workflow d'**entrée** (kanban `raccordement.demande`), conduit par l'*accueilliste*, qui
-instruit une demande de fourniture de l'arrivée du formulaire jusqu'à la **mise en service**
-(étape « En service ») : demande SGE selon la situation d'entrée (mise en service F120 /
-changement de fournisseur F130), saisie de l'*id_Affaire*, puis **suivi de l'affaire** Enedis —
-automatisé par la résolution périodique `id_Affaire → RSC` (ADR 0021). À la **validation de
-l'abonnement** (provisions estimées, signature captée) il **crée** le·la *souscripteur·rice*,
-le compte bancaire et la *Souscription* — née *en instance* (cf. *En instance / En service*).
+instruit une demande de fourniture de l'arrivée du formulaire jusqu'à la **validation de
+l'abonnement** (étape « Abonnement Validé ») : acceptation (pour les PRO, décision du *collège*),
+demande SGE selon la *situation d'entrée* (F120 / F130), saisie de l'*id_Affaire*, **suivi de
+l'affaire** Enedis — automatisé par la résolution périodique `id_Affaire → RSC` (ADR 0021/0022) —
+puis calcul des mensualités une fois la mise en service effective. À l'**acceptation** il
+**crée** le·la *souscripteur·rice*, le compte bancaire et la *Souscription* — née *en instance*
+(cf. *En instance / En service*) ; un mail de **rassurage** part quand la demande SGE est
+déposée, les *conditions particulières* partent **complètes** à la validation de l'abonnement.
 Les étapes à entrée **factuelle** (id_Affaire saisi, RSC acquise) avancent seules et ne se
-forcent pas : on corrige le fait, la carte suit. C'est le point de **capture** des données
+forcent pas : on corrige le fait, la carte suit. Chaque colonne du kanban dit qui doit agir :
+**action attendue** (un humain), **attente externe** (personne — le poll veille), **fait**.
+C'est le point de **capture** des données
 saisies à l'adhésion — **dont les consentements et la signature** (équivalent du *LSD* de
 prod) —, **recopiées** sur la *Souscription* qui en devient **propriétaire** (système de
 référence) ; la *demande* reste un intake transitoire. Les *conditions particulières* lisent ces
 données sur la *Souscription*, jamais sur la demande.
 _Éviter_ : confondre la **demande de raccordement** (intake) et la *Souscription* (l'enregistrement
 qu'elle engendre) ; « raccordement » au sens réseau Enedis (mise en service physique du PDL) ;
-**« Souscrit » comme fin du workflow** (la chaîne va jusqu'à « En service »).
+**« Souscrit » ou « En service » comme colonnes** (la chaîne se clôt à « Abonnement Validé » ;
+la mise en service est un fait porté par la *Souscription*, reflété par « Validé sur SGE »).
+
+**Situation d'entrée** :
+La voie SGE par laquelle un·e *souscripteur·rice* entre dans le périmètre : **mise en service**
+(F120 — PDL hors service, emménagement) ou **changement de fournisseur** (CFNE F130 — PDL
+alimenté par un autre fournisseur). Déclarée au formulaire de souscription, **corrigeable par
+l'accueilliste** (l'erreur du demandeur est un cas nominal) ; elle route le suivi de l'affaire
+dans la branche F120 ou F130 du *raccordement*.
+_Éviter_ : « type de demande » (trop générique) ; la confondre avec la *Configuration fournisseur*.
+
+**Collège (PRO)** :
+Instance humaine qui **accepte** les demandes professionnelles : elle valide le PRO **et son
+tarif** (la *Majoration PRO* négociée) avant de faire avancer la carte — l'acceptation d'un PRO
+n'est jamais le geste d'un·e seul·e *accueilliste*.
 
 **Portail** :
 Espace en ligne en lecture du·de la *souscripteur·rice* (contrats, factures, infos utiles),

--- a/docs/adr/0022-raccordement-aligne-prod-naissance-acceptation-valide-sge-rsc.md
+++ b/docs/adr/0022-raccordement-aligne-prod-naissance-acceptation-valide-sge-rsc.md
@@ -1,0 +1,94 @@
+# Raccordement aligné sur la prod : naissance à l'acceptation, « Validé sur SGE » par la RSC
+
+[ADR-0021](0021-chaine-raccordement-pilotee-faits-naissance-instance-rsc-poll.md) a fixé la
+chaîne de raccordement cible avec une naissance à la validation de l'abonnement et une attente
+Enedis *post*-naissance (« En attente Enedis » → « En service »). La ré-exploration de la prod
+(étapes, `base.automation`, `mail.template` — session de grill juillet 2026) et un fait métier
+tranché par Virgile invalident cette queue de chaîne : **il n'y a pas de RSC sans le C15
+d'effectivité de la mise en service**. L'attente Enedis se consomme donc *pendant* le suivi
+d'affaire (colonnes F120/F130), pas après la naissance. Par ailleurs la prod n'envoie **rien**
+au·à la souscripteur·rice à l'acceptation (le pack contractuel part à la main, après « Validé
+sur SGE ») — trou que la cible répare. Cet ADR amende ADR-0021 §1, §5 et §6 ; les §3 (poll) et
+§4 (mapping des motifs) restent intacts.
+
+## Décision
+
+1. **Chaîne cible = la chaîne prod, sans F305, avec les deux branches.**
+   🔴 Nouveau → 🔴 PRO à valider *(routage auto à la création si `pro`)* → 🔴 Accepté et IBAN
+   vérifié *(= naissance)* → ⏳ { Changement de fournisseur (F130) en cours | Mise en Service
+   (F120) en cours } *(entrée factuelle : id_Affaire saisi)* → 🔴 Validé sur SGE *(entrée
+   factuelle : RSC résolue)* → 🔴 Calcul de mensualités en cours → ✓ Abonnement Validé
+   *(terminale, repliée, envoi du pack)*. Les étapes « Demande mesures faite », « Estimation
+   mensualité », « Souscrit » et « En service » disparaissent.
+
+2. **Naissance à l'acceptation** *(amende ADR-0021 §1)*. La Souscription est créée **en
+   instance** à l'entrée en « Accepté et IBAN vérifié » (geste humain : acceptation — pour les
+   PRO, après décision du collège). Justification hors CP : le poll continue de cibler les
+   **Souscriptions en instance** (§3 d'ADR-0021 inchangé, pas de suivi côté demande) et le
+   journal de consentement (ADR-0017) est horodaté à la capture, pas des semaines après.
+   L'`id_affaire`, saisi sur la demande *après* la naissance, se recopie au fil de l'eau sur la
+   Souscription (write-through), plus seulement à la création.
+
+3. **« Validé sur SGE » = la RSC est le fait** *(amende ADR-0021 §5)*. Pas de RSC sans C15
+   d'effectivité ⇒ RSC résolue ≡ affaire aboutie ≡ « validé sur SGE ». L'auto-move existant
+   « RSC acquise → En service » est reciblé vers « Validé sur SGE ». Zéro chantier electricore :
+   le contrat RSC actuel (xor RSC/motif) suffit, pas besoin de statut d'affaire additif.
+
+4. **Situation d'entrée (MES F120 / CFNE F130).** Champ de la demande, prérempli par le
+   formulaire de souscription, **éditable par l'accueilliste** (l'erreur du demandeur est un cas
+   nominal). Il route l'auto-move de l'id_Affaire vers la bonne branche ; sa correction
+   re-route la carte déjà en branche (on corrige le fait, la carte suit).
+
+5. **Trichotomie visuelle des colonnes** : 🔴 *action attendue* (orange, liseré de carte),
+   ⏳ *attente externe* — le poll travaille (neutre, pas de liseré), ✓ *fait* (vert, colonne
+   repliée). Portée par le nom d'étape (préfixe) + la couleur d'étape existante, re-purposée
+   (elle était décorative). Pas de champ ni de rendu custom. La progressbar (bloqué = rouge)
+   reste le canal des alertes du poll.
+
+6. **Mails.** À l'entrée des colonnes ⏳ (= la demande SGE vient réellement de partir) : mail
+   de **rassurage** automatique, un template par branche — répare l'oubli CFNE de la prod. À
+   l'entrée en « Abonnement Validé » : **pack de bienvenue** automatique (CP complète — RSC et
+   mensualités réelles — + documents d'accueil, variantes particulier/pro/solidaire), là où la
+   prod l'envoyait à la main. La CP part **en fin de chaîne, complète** ; le rassurage tient le
+   rôle d'accusé de prise en compte.
+
+7. **PRO : le collège valide le pro et son tarif.** La demande capte `coeff_pro` (majoration
+   négociée) pendant « PRO à valider » ; la naissance la recopie sur la Souscription.
+
+## Conséquences
+
+- ADR-0021 : §1 (moment de naissance), §5 (« Validé sur SGE » humain) et §6 (queue « En attente
+  Enedis → En service ») amendés ; §2 (état calculé), §3 (poll), §4 (motifs) intacts. Une
+  Souscription née du raccordement passe toujours par *en instance* ; elle devient *en service*
+  pendant que la carte est en branche ⏳.
+- Pas de migration : le module du repo n'existe pas en prod (la prod tourne sur le modèle
+  Studio `x_souscription_differe`) ; data/demo/tests réécrits dans la même PR.
+- Références code à retoucher : `stage_demande_sge` (éclaté en deux branches),
+  `stage_en_service`/`stage_souscrit` (supprimés), auto-moves reciblés, heuristiques par nom
+  de `_onchange_stage_id` refondues, garde bloquante IBAN valide (si prélèvement) au drag
+  d'acceptation.
+- `CONTEXT.md` : entrée *Raccordement* réécrite (chaîne jusqu'à « Abonnement Validé »),
+  nouveaux termes *Situation d'entrée* et *Collège (PRO)*.
+
+## Options écartées
+
+- **Naissance en fin de chaîne** (modèle prod, « Enregistrement de la souscription » à Validé
+  sur SGE) : pendant l'attente F120/F130 la Souscription n'existerait pas — le poll devrait
+  cibler les demandes et la RSC vivre sur la demande, ce qu'ADR-0010/0021 ont déjà écarté.
+- **CP à l'acceptation avec provisions estimées** : les mensualités réelles exigent les données
+  de conso, qui n'arrivent qu'après l'effectivité ; une CP estimée puis corrigée fait deux
+  vérités. Le rassurage suffit à l'acceptation, la CP part complète.
+- **Statut d'affaire additif exposé par electricore** pour « Validé sur SGE » : sans objet, la
+  RSC est déjà le bon fait (pas de RSC sans C15 d'effectivité).
+- **Champ `nature` d'étape + rendu kanban custom** pour la trichotomie : préfixe de nom +
+  couleur font le même travail sans code ; on ne l'introduira que si le besoin de filtrage
+  apparaît.
+
+## Raison
+
+Le kanban reste le tableau de bord des accueillistes : chaque colonne dit qui doit agir —
+un humain (🔴), personne (⏳, le poll veille), plus personne (✓). Les étapes restent des
+projections de faits (id_Affaire, RSC) qui ne se forcent pas. La naissance anticipée coûte un
+déplacement de déclencheur et garde toute la mécanique poll/état déjà mergée ; l'envoi des
+documents suit le rythme réel du process — accusé de prise en compte tôt, contrat complet
+quand tout est vrai.


### PR DESCRIPTION
## Contenu

Deux sujets embarqués ensemble (tout le WIP de la session) :

### ADR-0022 + CONTEXT.md — raccordement aligné sur la prod
- Nouvel ADR [0022](docs/adr/0022-raccordement-aligne-prod-naissance-acceptation-valide-sge-rsc.md) : amende ADR-0021 §1/§5/§6 après ré-exploration de la prod (grill juillet 2026). Fait métier tranché : **pas de RSC sans C15 d'effectivité** ⇒ l'attente Enedis se consomme *pendant* le suivi d'affaire (branches F120/F130), la chaîne se clôt à « Abonnement Validé ». Naissance de la Souscription à l'**acceptation**, « Validé sur SGE » piloté par la RSC, trichotomie visuelle des colonnes, mails de rassurage + pack de bienvenue, collège PRO.
- CONTEXT.md aligné : entrées *En instance / En service*, *Raccordement*, *Accueilliste* mises à jour ; nouvelles entrées *Situation d'entrée* et *Collège (PRO)*.

### CI — permissions du GITHUB_TOKEN
- `permissions: contents: read` au niveau workflow dans ci.yml : les deux jobs ne font que checkout + build docker. Ferme les deux alertes CodeQL « Workflow does not contain permissions » (branche `main`, lignes 15 et 31).

🤖 Generated with [Claude Code](https://claude.com/claude-code)