### PR TITLE
feat(core): champs d'atterrissage migration — adresse du PDL (souscription), blaze (partenaire)

### DIFF
--- a/__manifest__.py
+++ b/__manifest__.py
@@ -53,6 +53,7 @@ vit dans models/wizard/ et ne lève qu'au clic sur l'action du wizard.
         'reports/souscription_attestation_report.xml',
         'reports/facture_energie_template.xml',
         'views/core/souscription_views.xml',
+        'views/core/res_partner_views.xml',
         'views/core/grille_prix_views.xml',
         'views/core/souscriptions_periode_views.xml',
         'views/core/souscription_refacturation_views.xml',

--- a/docs/adr/0023-migration-contrats-100pct-couture-regul-enjambante-backfill-cible.md
+++ b/docs/adr/0023-migration-contrats-100pct-couture-regul-enjambante-backfill-cible.md
@@ -1,0 +1,30 @@
+# Migration des contrats : reprise à 100 %, mois régularisés réputés soldés, backfill ciblé des mois non régularisés, régularisation enjambante côté nouveau système
+
+Complète l'[ADR-0003](0003-strategie-migration-odoo19-odoo-sh.md) (stratégie d'upgrade et de bascule) en fixant les décisions de **données** de l'ETL `sale.order` (abonnements 17 + champs Studio) → `souscription.*`, instruites par exploration read-only de la prod (juillet 2026, ~1 022 contrats : 823 en cours, 168 résiliés). Point clé découvert : les régularisations prod des contrats lissés sont **~annuelles, à date anniversaire non synchronisée, calculées à la main en xlsx** (sans gérer les changements de compteur) — il n'existe aucun mécanisme de régul fiable dans le système sortant.
+
+**Décisions.**
+
+1. **Reprise à 100 %** : tous les contrats migrent en `souscription.*`, résiliés compris (`date_fin` → état *résiliée* dérivé). Pas de cohabitation opérationnelle avec les abonnements legacy (cassés en 19 de toute façon) ; ils restent en base liftée comme archive morte. Les chaînes de renouvellement fusionnent en **une souscription par RSC** (contrainte d'unicité) ; brouillons et sans-état sortent au rapport pour triage humain.
+2. **Mois régularisés = soldés** (*settled is settled*) : on ne rouvre jamais un mois couvert par une facture de régul prod, même si le calcul xlsx était douteux — rouvrir = avoirs en cascade sur des factures NF inaltérables. La frontière par contrat = fin de couverture de sa dernière facture de régul (parsée dans les lignes « *Mois — Ecart de X kWh* »).
+3. **Backfill ciblé, et seulement lui** : pas de reconstruction des Périodes historiques (réversible : electricore garde tout, un backfill ultérieur reste possible), **sauf** les mois non régularisés des contrats lissés : l'ETL crée ces Périodes depuis les factures prod (provision kWh **facturée**, jours, prix appliqué), liées aux factures legacy. Ce sont des Périodes légitimes au sens du modèle : elles portent du *facturé*.
+4. **Pas de régul générale pré-bascule** : le seul calculateur de confiance est la régularisation du nouveau système (rejeu des Périodes aux prix historiques, ADR-0008, quantités electricore). Sa **première exécution enjambe la couture** et solde le span non régularisé (jusqu'à ~11 mois selon l'anniversaire) avec la machinerie normale — zéro code spécial migration.
+5. **Consentements** : journal vide à la migration — la prod n'a jamais capté de consentement granulaire données de conso (seulement l'acceptation CGV + recontact). Seuls les faits contractuels migrent (date de validation, renonciation à la rétractation dérivée du choix de mise en service). Le trou de conformité sur la collecte quotidienne devient visible → campagne de recueil post-bascule (décision métier, hors migration) ; si les CGV contiennent une clause, une entrée sourcée « CGV vX » reste ajoutable après coup (journal append-only).
+
+## Options écartées
+
+- **Migrer les seuls contrats actifs** : impose de consulter deux systèmes au quotidien avec un legacy dysfonctionnel en 19.
+- **Régul générale en prod avant bascule** : un dernier tour de xlsx à grande échelle sur de vraies factures ; et le délai de consolidation Enedis (~1,5 mois) laisserait de toute façon un résidu non régularisé.
+- **Backfill complet depuis electricore** : archéologie comptable massive adossée à une migration déjà risquée, pour un besoin (portail/analytique rétroactifs) non confirmé — et réversible plus tard, contrairement au reste.
+- **ETL des demandes de raccordement en vol** : ~23 cartes au fil de l'eau ; re-saisie manuelle dans le nouveau kanban (piloté par les faits) = une heure humaine + revue de contrôle gratuite, l'ETL d'un modèle Studio ne s'amortit jamais.
+
+## Conséquences
+
+- **Chantier modèle pré-migration** (bloquant pour le load) : axe *régime de prix* sur `grille.prix` + désignation sur la souscription (~14 contrats Moulin), champ adresse du PDL, champ *blaze* sur le partenaire, support des Périodes d'ouverture backfillées.
+- **Grilles historiques à seeder** jusqu'au plus vieux mois non régularisé du parc (le rapport d'extraction en donne la profondeur) — saisies main, contre-vérifiées par l'ETL sur les prix des lignes prod (`prix ligne = grille(régime, date) × (1 + coeff_pro dérivé)`).
+- Le chantier **régularisation (#20)** devient le jalon aval de la migration ; simple sur le parc communicant, terrain vierge sur le non-communicant → le rapport segmente les lissés par type de compteur.
+- Premières réguls potentiellement grosses (plusieurs mois d'écarts) : communication aux souscripteur·rices à préparer dans la check-list de bascule.
+- Données réelles en dev sous garde-fous : snapshots hors git, SMTP neutralisé, crons off, pas de génération SEPA, instance non exposée.
+
+## Raison
+
+On minimise les actes dans le système mourant (aucune facturation nouvelle pilotée par le legacy, aucune régul xlsx supplémentaire) et on donne au nouveau système exactement les entrées dont sa machinerie normale a besoin pour solder le passé **correctement** — plutôt que de perpétuer un calcul faux pour fabriquer une couture « propre » en apparence.

--- a/models/core/__init__.py
+++ b/models/core/__init__.py
@@ -2,6 +2,7 @@ from . import (
     account_move,
     electricore_rsc_service,
     grille_prix,
+    res_partner,
     souscription,
     souscription_consentement,
     souscription_periode,

--- a/models/core/res_partner.py
+++ b/models/core/res_partner.py
@@ -1,0 +1,12 @@
+from odoo import fields, models
+
+
+class ResPartner(models.Model):
+    _inherit = 'res.partner'
+
+    # Champ d'atterrissage migration (#106, ADR 0023) : nom d'usage choisi par
+    # le contact, distinct du nom légal (`name`) — repris de `x_blaze` (prod).
+    blaze = fields.Char(
+        string='Blaze',
+        help="Nom d'usage choisi par le contact, distinct de son nom légal.",
+    )

--- a/models/core/souscription.py
+++ b/models/core/souscription.py
@@ -146,6 +146,13 @@ class Souscription(models.Model):
     ## Informations
     ref_compteur = fields.Char(string='Référence compteur')
     numero_depannage = fields.Char(string='Numéro de dépannage')
+    # Champ d'atterrissage migration (#106, ADR 0023) : adresse du point de
+    # livraison, distincte de l'adresse du·de la souscripteur·rice
+    # (`partner_id`) — le PDL peut être ailleurs (locatif, second logement...).
+    adresse_pdl = fields.Text(
+        string='Adresse du PDL',
+        help="Adresse du point de livraison, distincte de l'adresse du·de la souscripteur·rice.",
+    )
 
     # Identité électricore (ADR 0010, ADR 0020 §3, ADR 0021). `ref_situation_contractuelle`
     # est la clé d'articulation du pull de méta-périodes (RSC, unique par couple

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -18,6 +18,7 @@ from . import (
     test_refacturation,
     test_releve,
     test_releve_demo,
+    test_res_partner,
     test_rsc_service,
     test_security,
     test_souscription,

--- a/tests/test_res_partner.py
+++ b/tests/test_res_partner.py
@@ -1,0 +1,28 @@
+"""
+Tests du champ blaze sur le partenaire (#106, ADR 0023).
+
+Champ d'atterrissage migration : nom d'usage choisi par le·la
+souscripteur·rice, distinct du nom légal (`name`) — repris de `x_blaze`
+(prod, ~357 cartes du kanban de raccordement portent la valeur).
+"""
+
+from odoo.tests.common import TransactionCase, tagged
+
+
+@tagged('souscriptions', 'post_install', '-at_install')
+class TestResPartnerBlaze(TransactionCase):
+    def test_blaze_creation(self):
+        """Le champ blaze se crée et se lit tel quel."""
+        partner = self.env['res.partner'].create(
+            {
+                'name': 'Test Client',
+                'blaze': 'Titi',
+            }
+        )
+
+        self.assertEqual(partner.blaze, 'Titi')
+
+    def test_blaze_visible_sur_le_formulaire(self):
+        """Le champ blaze est exposé au formulaire partenaire (#106)."""
+        view = self.env['res.partner'].get_view(view_type='form')
+        self.assertIn('blaze', view['arch'])

--- a/tests/test_souscription.py
+++ b/tests/test_souscription.py
@@ -144,3 +144,25 @@ class TestSouscription(TransactionCase):
 
         self.assertEqual(souscription.ref_situation_contractuelle, 'RSC0001234')
         self.assertEqual(souscription.id_affaire, 'AFF-56789')
+
+    def test_adresse_pdl_creation(self):
+        """Champ d'atterrissage migration (#106, ADR 0023) : l'adresse du PDL
+        se crée et se lit telle quelle, distincte de l'adresse du·de la
+        souscripteur·rice (`partner_id`)."""
+        souscription = self.env['souscription.souscription'].create(
+            {
+                'partner_id': self.partner.id,
+                'pdl': 'PDL_ADRESSE',
+                'puissance_souscrite': '6',
+                'type_tarif': 'base',
+                'etat_facturation_id': self.etat_actif.id,
+                'adresse_pdl': '12 rue de la Paix\n44000 Nantes',
+            }
+        )
+
+        self.assertEqual(souscription.adresse_pdl, '12 rue de la Paix\n44000 Nantes')
+
+    def test_adresse_pdl_visible_sur_le_formulaire(self):
+        """L'adresse du PDL est exposée au formulaire Souscription (#106)."""
+        view = self.env['souscription.souscription'].get_view(view_type='form')
+        self.assertIn('adresse_pdl', view['arch'])

--- a/views/core/res_partner_views.xml
+++ b/views/core/res_partner_views.xml
@@ -1,0 +1,14 @@
+<odoo>
+    <!-- Champ d'atterrissage migration (#106, ADR 0023) : blaze, nom d'usage
+         choisi par le contact, distinct du nom légal. -->
+    <record id="view_partner_form_blaze" model="ir.ui.view">
+        <field name="name">res.partner.form.blaze</field>
+        <field name="model">res.partner</field>
+        <field name="inherit_id" ref="base.view_partner_form"/>
+        <field name="arch" type="xml">
+            <field name="category_id" position="after">
+                <field name="blaze"/>
+            </field>
+        </field>
+    </record>
+</odoo>

--- a/views/core/souscription_views.xml
+++ b/views/core/souscription_views.xml
@@ -51,6 +51,7 @@
                     <group string="Infos">
                         <field name="ref_compteur"/>
                         <field name="numero_depannage" widget="phone"/>
+                        <field name="adresse_pdl"/>
                     </group>
 
                     <!-- Identité electricore (ADR 0010/0020/0021) : RSC = clé d'articulation


### PR DESCRIPTION
Closes #106

Ajoute les deux champs d'atterrissage migration prévus par l'ADR 0023 :
l'adresse du PDL sur la Souscription (distincte de l'adresse du·de la
souscripteur·rice) et le blaze (nom d'usage choisi) sur le partenaire.
Chaque champ est visible sur son formulaire respectif ; l'usage du blaze
dans les gabarits de communication reste hors périmètre (chantier séparé).
Tests unitaires ajoutés (création + visibilité formulaire) pour chacun.

Suite docker : 0 failed, 0 error(s) of 265 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)