### PR TITLE
feat(grille): Régime de prix (standard | Moulin) — sélection de grille par (régime, date)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -109,10 +109,27 @@ facturé.
 Barème **fournisseur** daté (`grille.prix`), **tout-compris** : le TURPE y est **absorbé**, jamais
 refacturé ligne à ligne (ADR 0002). Porte le prix d'abonnement **affine** — prix de base 3 kVA +
 coefficient par kVA supplémentaire (ADR 0018) — et le prix de l'énergie par cadran facturé.
-Sélectionnée par les dates d'une *Période*, ce qui permet de facturer une *régularisation* aux prix
+Chaque grille appartient à un *régime de prix* ; elle est sélectionnée par le régime de la
+*Souscription* et les dates d'une *Période*, ce qui permet de facturer une *régularisation* aux prix
 historiques.
 _Éviter_ : tarif (collision avec la FTA / tarif d'acheminement réseau), barème ; « prix par palier »
 (l'abonnement est **affine**, pas tabulé par puissance).
+
+**Régime de prix** :
+L'axe qui désigne **quel barème** s'applique à une *Souscription* : **standard** ou **Moulin**.
+Chaque *Grille de prix* appartient à un régime, et chaque régime versionne ses grilles
+**indépendamment** (les deux barèmes ne bougent ni au même rythme ni pour les mêmes raisons).
+Orthogonal au *Tarif solidaire* (isolation comptable) et à la *Majoration PRO* (surcoût %) : les
+trois axes se composent librement.
+_Éviter_ : confondre avec le *Tarif solidaire* (comptable, pas tarifaire) ; « option » (collision
+avec l'option tarifaire réseau).
+
+**Tarif Moulin** :
+Le *régime de prix* « prix coûtant » proposé aux personnes qui s'engagent dans le commun EDN. Un
+barème à part entière, versionné par ses propres *Grilles de prix* : il évolue avec les coûts du
+commun, jamais en pourcentage du barème standard. Se compose avec le *Tarif solidaire*.
+_Éviter_ : « remise Moulin » (ce n'est pas une remise) ; produits de facturation dédiés (seul le
+**prix** change via la grille — fiscalité et comptes restent ceux du standard).
 
 **Majoration PRO** :
 Surcoût commercial (`coeff_pro`, en %) **propre à chaque *Souscription*** (négocié au cas par cas),

--- a/models/core/grille_prix.py
+++ b/models/core/grille_prix.py
@@ -27,6 +27,23 @@ class GrillePrix(models.Model):
     )
     active = fields.Boolean('Active', default=True)
 
+    # Régime de prix (CONTEXT.md « Régime de prix ») : quel barème s'applique.
+    # Chaque régime versionne ses grilles indépendamment — l'unicité et la
+    # fermeture automatique (create()) jouent PAR régime, jamais tous régimes
+    # confondus. Le Tarif Moulin n'introduit aucun produit dédié : seul ce prix
+    # change, le catalogue (souscription.produit) reste inchangé.
+    regime_prix = fields.Selection(
+        [('standard', 'Standard'), ('moulin', 'Moulin')],
+        string='Régime de prix',
+        default='standard',
+        required=True,
+        tracking=True,
+        help='Barème appliqué par cette grille. Chaque régime versionne ses '
+        'grilles indépendamment : une grille Moulin ouverte coexiste avec une '
+        'grille standard ouverte (anti-chevauchement et fermeture automatique '
+        'scopés par régime).',
+    )
+
     ligne_ids = fields.One2many('grille.prix.ligne', 'grille_id', string='Lignes de prix')
 
     # Champs calculés pour info
@@ -41,12 +58,17 @@ class GrillePrix(models.Model):
     def create(self, vals_list):
         for vals in vals_list:
             date_debut_nouvelle = vals['date_debut']
+            regime = vals.get('regime_prix') or 'standard'
 
-            # Fermer la grille précédente (la plus récente avant cette date)
+            # Fermer la grille précédente DU MÊME RÉGIME (la plus récente avant
+            # cette date) : chaque régime versionne ses grilles indépendamment
+            # (CONTEXT.md « Régime de prix ») — une nouvelle grille Moulin ne
+            # ferme jamais une grille standard, et réciproquement.
             grille_precedente = self.search(
                 [
                     ('date_debut', '<', date_debut_nouvelle),
                     ('date_fin', '=', False),  # Grille ouverte
+                    ('regime_prix', '=', regime),
                 ],
                 order='date_debut desc',
                 limit=1,
@@ -61,18 +83,21 @@ class GrillePrix(models.Model):
         return super().create(vals_list)
 
     @api.model
-    def get_grille_active(self, date_facture=None):
-        """Récupère la grille dont la période de validité couvre la date donnée.
+    def get_grille_active(self, date_facture=None, regime='standard'):
+        """Récupère la grille du régime donné dont la période de validité couvre
+        la date donnée.
 
-        La sélection se fait sur la plage [date_debut, date_fin] (date_fin vide =
-        grille ouverte), et non sur le drapeau ``is_current`` : une facturation
-        rétroactive utilise ainsi la grille en vigueur à la date concernée.
+        La sélection se fait sur ``(régime, plage [date_debut, date_fin])``
+        (date_fin vide = grille ouverte), et non sur le drapeau ``is_current`` :
+        une facturation rétroactive utilise ainsi la grille en vigueur à la date
+        concernée, pour le régime de la Souscription/Période facturée.
         """
         if date_facture is None:
             date_facture = fields.Date.today()
 
         grille = self.search(
             [
+                ('regime_prix', '=', regime),
                 ('date_debut', '<=', date_facture),
                 '|',
                 ('date_fin', '=', False),
@@ -84,15 +109,18 @@ class GrillePrix(models.Model):
 
         if not grille:
             raise UserError(
-                f'Aucune grille de prix ne couvre la date {date_facture}. '
+                f'Aucune grille de prix ({regime}) ne couvre la date {date_facture}. '
                 f'Vérifiez la couverture des grilles (trou de période ?).'
             )
 
         return grille
 
-    @api.constrains('date_debut', 'date_fin')
+    @api.constrains('date_debut', 'date_fin', 'regime_prix')
     def _check_no_overlap(self):
-        """Interdit le chevauchement des périodes de validité entre grilles."""
+        """Interdit le chevauchement des périodes de validité entre grilles DU
+        MÊME RÉGIME. Deux grilles de régimes différents (standard, Moulin) ne se
+        gênent jamais, même sur des dates identiques (CONTEXT.md « Régime de
+        prix » : chaque régime versionne ses grilles indépendamment)."""
         for grille in self:
             if not grille.date_debut:
                 continue
@@ -100,12 +128,13 @@ class GrillePrix(models.Model):
             end_a = grille.date_fin or date.max
             if start_a > end_a:
                 raise ValidationError(f"La grille '{grille.name}' a une date de fin antérieure à sa date de début.")
-            for other in self.search([('id', '!=', grille.id)]):
+            for other in self.search([('id', '!=', grille.id), ('regime_prix', '=', grille.regime_prix)]):
                 start_b = other.date_debut
                 end_b = other.date_fin or date.max
                 if start_a <= end_b and start_b <= end_a:
                     raise ValidationError(
-                        f"La période de la grille '{grille.name}' chevauche celle de la grille '{other.name}'."
+                        f"La période de la grille '{grille.name}' chevauche celle de la grille '{other.name}' "
+                        f'(régime {grille.regime_prix}).'
                     )
 
     def get_prix_dict(self):
@@ -167,12 +196,14 @@ class GrillePrix(models.Model):
                 )
             )
 
-        # Créer la nouvelle grille avec ses lignes
+        # Créer la nouvelle grille avec ses lignes, dans le même régime (une
+        # duplication ne change jamais de régime de prix).
         nouvelle_grille = self.create(
             {
                 'name': f'Copie de {self.name}',
                 'date_debut': today,
                 'date_fin': False,
+                'regime_prix': self.regime_prix,
                 'ligne_ids': lignes_vals,
             }
         )

--- a/models/core/souscription.py
+++ b/models/core/souscription.py
@@ -109,6 +109,22 @@ class Souscription(models.Model):
     )
     tarif_solidaire = fields.Boolean(string='Tarif solidaire', default=False, tracking=True)
 
+    # Régime de prix (CONTEXT.md « Régime de prix », « Tarif Moulin ») : quel
+    # barème s'applique. Orthogonal au Tarif solidaire (isolation comptable) et
+    # à la Majoration PRO (surcoût %) : les trois axes se composent librement
+    # jusqu'à la ligne de facture. Le Moulin ne change QUE le prix via la
+    # Grille — fiscalité et comptes restent ceux du standard (le solidaire, lui,
+    # isole comptablement — ADR 0013).
+    regime_prix = fields.Selection(
+        [('standard', 'Standard'), ('moulin', 'Moulin')],
+        string='Régime de prix',
+        default='standard',
+        required=True,
+        tracking=True,
+        help='Barème appliqué à cette Souscription. Sélectionne la Grille de '
+        'prix par (régime, date) — aucun produit dédié : seul le prix change.',
+    )
+
     # Calendrier de comptage du compteur (cadrans réseau mesurés) — source
     # Configuration Enedis / electricore. Orthogonal au type de tarif facturé
     # (ADR 0005). Détermine le niveau de saisie de l'énergie sur les périodes.
@@ -454,7 +470,7 @@ class Souscription(models.Model):
         self.ensure_one()
         produit = self.env['souscription.produit']
         a_date = a_date or self.date_debut or fields.Date.today()
-        grille = self.env['grille.prix'].get_grille_active(a_date)
+        grille = self.env['grille.prix'].get_grille_active(a_date, regime=self.regime_prix)
         is_company = bool(self.partner_id.is_company)
         is_sol = self.tarif_solidaire
         prix_grille = grille.get_prix_dict()

--- a/models/core/souscription_periode.py
+++ b/models/core/souscription_periode.py
@@ -151,6 +151,15 @@ class SouscriptionPeriode(models.Model):
         help='État du tarif solidaire au moment de la création de cette période',
     )
 
+    regime_prix_periode = fields.Selection(
+        [('standard', 'Standard'), ('moulin', 'Moulin')],
+        string='Régime de prix (période)',
+        readonly=True,
+        help='Régime de prix de la Souscription au moment de la création de '
+        'cette période (snapshot, ADR 0006) — sélectionne la Grille de prix '
+        'par (régime, date de fin de période) lors de la facturation.',
+    )
+
     lisse_periode = fields.Boolean(
         string='Lissé (période)', readonly=True, help='État du lissage au moment de la création de cette période'
     )
@@ -233,6 +242,7 @@ class SouscriptionPeriode(models.Model):
                 {
                     'type_tarif_periode': sous.type_tarif,
                     'tarif_solidaire_periode': sous.tarif_solidaire,
+                    'regime_prix_periode': sous.regime_prix,
                     'lisse_periode': sous.lisse,
                     'puissance_souscrite_periode': float(sous.puissance_souscrite) if sous.puissance_souscrite else 0.0,
                     'provision_mensuelle_kwh_periode': sous.provision_mensuelle_kwh,
@@ -289,6 +299,7 @@ class SouscriptionPeriode(models.Model):
             'turpe_variable',
             'type_tarif_periode',
             'tarif_solidaire_periode',
+            'regime_prix_periode',
             'lisse_periode',
             'puissance_souscrite_periode',
             'provision_mensuelle_kwh_periode',
@@ -604,7 +615,7 @@ class SouscriptionPeriode(models.Model):
         (source unique du lien Période ↔ Facture, ADR 0004).
         """
         self.ensure_one()
-        grille = self.env['grille.prix'].get_grille_active(self.date_fin)
+        grille = self.env['grille.prix'].get_grille_active(self.date_fin, regime=self.regime_prix_periode)
         return self.env['account.move'].create(
             {
                 'move_type': 'out_invoice',

--- a/models/core/souscription_periode.py
+++ b/models/core/souscription_periode.py
@@ -154,6 +154,7 @@ class SouscriptionPeriode(models.Model):
     regime_prix_periode = fields.Selection(
         [('standard', 'Standard'), ('moulin', 'Moulin')],
         string='Régime de prix (période)',
+        default='standard',
         readonly=True,
         help='Régime de prix de la Souscription au moment de la création de '
         'cette période (snapshot, ADR 0006) — sélectionne la Grille de prix '

--- a/tests/test_documents_contractuels.py
+++ b/tests/test_documents_contractuels.py
@@ -13,7 +13,7 @@ from datetime import date, timedelta
 from lxml import etree
 from odoo.tests.common import HttpCase, TransactionCase, tagged
 
-from .common import SouscriptionsTestMixin
+from .common import SouscriptionsTestMixin, build_grille_lignes
 
 
 @tagged('souscriptions', 'souscriptions_documents', 'post_install', '-at_install')
@@ -200,6 +200,24 @@ class TestConditionsParticulieres(SouscriptionsTestMixin, HttpCase):
         self.assertEqual(self.cp_societe.coeff_pro, 0.0)
         base = next(e for e in self.cp_societe._prix_documents()['energies'] if e['code'] == 'base')
         self.assertAlmostEqual(base['prix_kwh'], 0.15, places=6)
+
+    def test_projection_prix_regime_moulin(self):
+        """Régime Moulin (#105) : les Conditions particulières projettent le
+        prix de la grille Moulin, pas celui du standard — même produit, prix
+        différent (aucun produit dédié Moulin, CONTEXT.md)."""
+        grille_moulin = self.env['grille.prix'].create(
+            {
+                'name': 'Grille Moulin CP',
+                'date_debut': date(2024, 1, 1),
+                'date_fin': date(2024, 12, 31),
+                'regime_prix': 'moulin',
+            }
+        )
+        build_grille_lignes(self.env, grille_moulin, prix_base=0.30, prix_hp=0.35, prix_hc=0.25)
+
+        moulin = self.cp_societe.copy({'regime_prix': 'moulin', 'pdl': 'PDL_CP_MOULIN'})
+        base = next(e for e in moulin._prix_documents()['energies'] if e['code'] == 'base')
+        self.assertAlmostEqual(base['prix_kwh'], 0.30, places=6)
 
 
 ATTESTATION_URL = '/report/html/souscriptions_odoo.souscription_attestation_document/%s'

--- a/tests/test_grille_prix.py
+++ b/tests/test_grille_prix.py
@@ -146,3 +146,119 @@ class TestGrillePrix(TransactionCase):
                 }
             )
             self.env.flush_all()
+
+    # === Régime de prix (standard | Moulin) — #105 ===
+
+    def test_regime_prix_defaut_standard(self):
+        """Une grille sans régime précisé est standard par défaut."""
+        self.assertEqual(self.grille.regime_prix, 'standard')
+
+    def test_grilles_moulin_et_standard_coexistent(self):
+        """Deux grilles ouvertes de régimes différents, mêmes dates, coexistent :
+        l'anti-chevauchement joue par régime (CONTEXT.md « Régime de prix »)."""
+        grille_moulin = self.env['grille.prix'].create(
+            {
+                'name': 'Grille Moulin 2024',
+                'date_debut': date(2024, 1, 1),
+                'date_fin': date(2024, 12, 31),
+                'regime_prix': 'moulin',
+            }
+        )
+        self.assertEqual(grille_moulin.regime_prix, 'moulin')
+        # La grille standard n'a pas été affectée par la création de la Moulin.
+        self.assertEqual(self.grille.date_fin, date(2024, 12, 31))
+
+    def test_chevauchement_meme_regime_toujours_interdit(self):
+        """Deux grilles Moulin qui se chevauchent restent interdites (l'anti-
+        chevauchement joue toujours au sein d'un même régime)."""
+        self.env['grille.prix'].create(
+            {
+                'name': 'Grille Moulin A',
+                'date_debut': date(2024, 1, 1),
+                'date_fin': date(2024, 6, 30),
+                'regime_prix': 'moulin',
+            }
+        )
+        with self.assertRaises(ValidationError):
+            self.env['grille.prix'].create(
+                {
+                    'name': 'Grille Moulin B',
+                    'date_debut': date(2024, 6, 1),
+                    'date_fin': date(2024, 12, 31),
+                    'regime_prix': 'moulin',
+                }
+            )
+
+    def test_fermeture_automatique_scopee_par_regime(self):
+        """La création d'une grille ne ferme que la grille OUVERTE précédente du
+        même régime — jamais une grille ouverte d'un autre régime."""
+        standard_ouverte = self.env['grille.prix'].create(
+            {
+                'name': 'Standard 2025',
+                'date_debut': date(2025, 1, 1),
+            }
+        )
+        moulin_1 = self.env['grille.prix'].create(
+            {
+                'name': 'Moulin 2025',
+                'date_debut': date(2025, 1, 1),
+                'regime_prix': 'moulin',
+            }
+        )
+        # La grille standard ouverte n'est pas fermée par la création de la Moulin.
+        self.assertFalse(standard_ouverte.date_fin)
+
+        self.env['grille.prix'].create(
+            {
+                'name': 'Moulin 2025 bis',
+                'date_debut': date(2025, 6, 1),
+                'regime_prix': 'moulin',
+            }
+        )
+        # Seule la grille Moulin précédente est fermée.
+        self.assertEqual(moulin_1.date_fin, date(2025, 5, 31))
+        self.assertFalse(standard_ouverte.date_fin)
+
+    def test_get_grille_active_par_regime(self):
+        """La sélection se fait par (régime, date) : standard et Moulin sont
+        résolus indépendamment, même sur des dates identiques."""
+        grille_moulin = self.env['grille.prix'].create(
+            {
+                'name': 'Grille Moulin 2024',
+                'date_debut': date(2024, 1, 1),
+                'date_fin': date(2024, 12, 31),
+                'regime_prix': 'moulin',
+            }
+        )
+        self.assertEqual(
+            self.env['grille.prix'].get_grille_active(date(2024, 6, 15), regime='standard'),
+            self.grille,
+        )
+        self.assertEqual(
+            self.env['grille.prix'].get_grille_active(date(2024, 6, 15), regime='moulin'),
+            grille_moulin,
+        )
+
+    def test_get_grille_active_defaut_standard(self):
+        """Sans régime précisé, get_grille_active reste sur le standard (compat)."""
+        self.assertEqual(self.env['grille.prix'].get_grille_active(date(2024, 6, 15)), self.grille)
+
+    def test_get_grille_active_moulin_sans_grille_leve(self):
+        """Un trou de couverture Moulin lève, même si le standard couvre la date :
+        les deux régimes ne se substituent jamais l'un à l'autre."""
+        with self.assertRaises(UserError):
+            self.env['grille.prix'].get_grille_active(date(2024, 6, 15), regime='moulin')
+
+    def test_dupliquer_grille_conserve_le_regime(self):
+        """Dupliquer une grille Moulin produit une nouvelle grille Moulin."""
+        grille_moulin = self.env['grille.prix'].create(
+            {
+                'name': 'Grille Moulin 2023',
+                'date_debut': date(2023, 1, 1),
+                'date_fin': date(2023, 12, 31),
+                'regime_prix': 'moulin',
+            }
+        )
+        action = grille_moulin.dupliquer_cette_grille()
+        nouvelle = self.env['grille.prix'].browse(action['res_id'])
+        self.assertEqual(nouvelle.regime_prix, 'moulin')

--- a/tests/test_periode_composition.py
+++ b/tests/test_periode_composition.py
@@ -12,7 +12,7 @@ from datetime import date
 
 from odoo.tests.common import TransactionCase, tagged
 
-from .common import ABO_ANNUEL_STD, SouscriptionsTestCase
+from .common import ABO_ANNUEL_STD, SouscriptionsTestCase, build_grille_lignes
 
 
 @tagged('souscriptions', 'souscriptions_composition', 'post_install', '-at_install')
@@ -219,6 +219,89 @@ class TestPeriodeComposition(SouscriptionsTestCase):
         self.assertIn(ref('souscriptions_product_abonnement_solidaire'), produit_ids)
         self.assertIn(ref('souscriptions_product_energie_base_solidaire'), produit_ids)
         self.assertNotIn(ref('souscriptions_product_abonnement_standard'), produit_ids)
+        self.assertNotIn(ref('souscriptions_product_energie_base'), produit_ids)
+
+    # === Régime de prix (standard | Moulin) — #105 ===
+
+    def _grille_moulin(self, **kwargs):
+        vals = {
+            'name': 'Grille Moulin Test',
+            'date_debut': date(2024, 1, 1),
+            'date_fin': date(2024, 12, 31),
+            'regime_prix': 'moulin',
+        }
+        vals.update(kwargs)
+        grille = self.env['grille.prix'].create(vals)
+        build_grille_lignes(self.env, grille, prix_base=0.30, prix_hp=0.35, prix_hc=0.25)
+        return grille
+
+    def test_regime_moulin_facture_au_bareme_moulin(self):
+        """Une Souscription en régime Moulin facture aux prix de la grille
+        Moulin : la sélection de grille se fait par (régime, date de la
+        Période), pas seulement par date."""
+        self._grille_moulin()
+        sous_moulin = self.env['souscription.souscription'].create(
+            {
+                'partner_id': self.souscription_base.partner_id.id,
+                'pdl': 'PDL_TEST_MOULIN',
+                'puissance_souscrite': '6',
+                'type_tarif': 'base',
+                'regime_prix': 'moulin',
+                'etat_facturation_id': self.souscription_base.etat_facturation_id.id,
+                'date_debut': date(2024, 1, 1),
+            }
+        )
+        periode = self._periode(sous_moulin, energie_base_kwh=200.0)
+        self.assertEqual(periode.regime_prix_periode, 'moulin')
+
+        facture = periode._creer_facture()
+        base = facture.invoice_line_ids.filtered(lambda l: l.name == 'Énergie Base')
+        self.assertAlmostEqual(base.price_unit, 0.30, places=6)
+
+    def test_regime_standard_meme_periode_facture_au_bareme_standard(self):
+        """Une souscription standard, sur la même période qu'une Moulin, facture
+        au barème standard — les deux régimes sont résolus indépendamment."""
+        self._grille_moulin()
+        periode_std = self._periode(self.souscription_base, energie_base_kwh=200.0)
+        self.assertEqual(periode_std.regime_prix_periode, 'standard')
+
+        facture = periode_std._creer_facture()
+        base = facture.invoice_line_ids.filtered(lambda l: l.name == 'Énergie Base')
+        # prix_base = 0.15 dans la grille standard de test (cf. common.py).
+        self.assertAlmostEqual(base.price_unit, 0.15, places=6)
+
+    def test_composition_regime_solidaire_pro_jusqu_a_la_ligne_de_facture(self):
+        """Les trois axes (régime, tarif solidaire, majoration PRO) se composent
+        librement : produit de l'univers solidaire, prix de la grille Moulin,
+        majoré PRO — sans aucun produit dédié Moulin (CONTEXT.md « Tarif
+        Moulin » : seul le prix change, fiscalité/comptes restent standard)."""
+        self._grille_moulin()
+        sous = self.env['souscription.souscription'].create(
+            {
+                'partner_id': self.souscription_base.partner_id.id,
+                'pdl': 'PDL_TEST_MOULIN_SOL_PRO',
+                'puissance_souscrite': '6',
+                'type_tarif': 'base',
+                'regime_prix': 'moulin',
+                'tarif_solidaire': True,
+                'coeff_pro': 10.0,
+                'etat_facturation_id': self.souscription_base.etat_facturation_id.id,
+                'date_debut': date(2024, 1, 1),
+            }
+        )
+        periode = self._periode(sous, energie_base_kwh=200.0)
+        facture = periode._creer_facture()
+
+        def ref(xmlid):
+            return self.env.ref(f'souscriptions_odoo.{xmlid}').id
+
+        produit_energie_sol = ref('souscriptions_product_energie_base_solidaire')
+        ligne = facture.invoice_line_ids.filtered(lambda l: l.product_id.id == produit_energie_sol)
+        self.assertTrue(ligne, 'La ligne doit porter le produit énergie solidaire (aucun produit dédié Moulin).')
+        # Prix Moulin (0.30) x majoration PRO (1.10).
+        self.assertAlmostEqual(ligne.price_unit, 0.30 * 1.10, places=6)
+
+        produit_ids = facture.invoice_line_ids.mapped('product_id').ids
         self.assertNotIn(ref('souscriptions_product_energie_base'), produit_ids)
 
 

--- a/views/core/grille_prix_views.xml
+++ b/views/core/grille_prix_views.xml
@@ -20,6 +20,7 @@
                     <group>
                         <group>
                             <field name="name"/>
+                            <field name="regime_prix"/>
                             <field name="date_debut"/>
                             <field name="date_fin" readonly="1"/>
                         </group>
@@ -54,6 +55,7 @@
         <field name="arch" type="xml">
             <list string="Grilles de Prix">
                 <field name="name"/>
+                <field name="regime_prix"/>
                 <field name="date_debut"/>
                 <field name="date_fin"/>
                 <field name="nb_lignes"/>
@@ -68,6 +70,7 @@
         <field name="arch" type="xml">
             <kanban>
                 <field name="name"/>
+                <field name="regime_prix"/>
                 <field name="date_debut"/>
                 <field name="date_fin"/>
                 <field name="nb_lignes"/>
@@ -79,6 +82,7 @@
                             </div>
                             <div class="oe_kanban_details">
                                 <strong><field name="name"/></strong>
+                                <div><field name="regime_prix"/></div>
                                 <div>Du <field name="date_debut"/></div>
                                 <div t-if="record.date_fin.raw_value">Au <field name="date_fin"/></div>
                                 <div t-if="!record.date_fin.raw_value"><strong>En cours</strong></div>

--- a/views/core/souscription_views.xml
+++ b/views/core/souscription_views.xml
@@ -42,6 +42,7 @@
                         <field name="provision_hp_kwh" invisible="not lisse or type_tarif != 'hphc'" string="Provision HP (kWh)"/>
                         <field name="provision_hc_kwh" invisible="not lisse or type_tarif != 'hphc'" string="Provision HC (kWh)"/>
                         <field name="tarif_solidaire"/>
+                        <field name="regime_prix"/>
                     </group>
                     <group string="Paiement">
                         <field name="mode_paiement"/>

--- a/views/core/souscriptions_periode_views.xml
+++ b/views/core/souscriptions_periode_views.xml
@@ -48,6 +48,7 @@
                             <field name="puissance_souscrite_periode"/>
                             <field name="lisse_periode"/>
                             <field name="tarif_solidaire_periode"/>
+                            <field name="regime_prix_periode"/>
                             <field name="provision_mensuelle_kwh_periode"/>
                             <field name="coeff_pro_periode"/>
                         </group>


### PR DESCRIPTION
Closes #105

Ajoute l'axe *Régime de prix* (standard | Moulin) sur la Grille de prix, avec
désignation du régime sur la Souscription. La sélection de grille se fait
désormais par (régime, date) côté facturation (`_creer_facture`) et
projection des Conditions particulières (`_prix_documents`) ; l'unicité,
l'anti-chevauchement et la fermeture automatique des grilles jouent par
régime, si bien qu'une grille Moulin et une grille standard ouvertes
coexistent sans interférer. Aucun produit de facturation dédié n'est
introduit : seul le prix change via la grille, la composition régime × tarif
solidaire × majoration PRO reste libre jusqu'à la ligne de facture (testé au
niveau ORM).

Suite docker CI : `0 failed, 0 error(s) of 273 tests`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
