### PR TITLE
feat(raccordement): aligné prod — 8 étapes, naissance à l'acceptation, rassurage F120/F130, pack de bienvenue

### DIFF
--- a/__manifest__.py
+++ b/__manifest__.py
@@ -53,6 +53,7 @@ vit dans models/wizard/ et ne lève qu'au clic sur l'action du wizard.
         'reports/souscription_conditions_particulieres_report.xml',
         'reports/souscription_attestation_report.xml',
         'reports/facture_energie_template.xml',
+        'data/mail_templates_bienvenue.xml',
         'views/core/souscription_views.xml',
         'views/core/grille_prix_views.xml',
         'views/core/souscriptions_periode_views.xml',

--- a/__manifest__.py
+++ b/__manifest__.py
@@ -49,6 +49,7 @@ vit dans models/wizard/ et ne lève qu'au clic sur l'action du wizard.
         'data/raccordement_sequence.xml',
         'data/raccordement_stages.xml',
         'data/ir_cron_poll_affaires_enedis.xml',
+        'data/mail_templates_raccordement.xml',
         'reports/souscription_conditions_particulieres_report.xml',
         'reports/souscription_attestation_report.xml',
         'reports/facture_energie_template.xml',

--- a/data/mail_templates_bienvenue.xml
+++ b/data/mail_templates_bienvenue.xml
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data noupdate="1">
+        <!-- Pack de bienvenue (#103, ADR 0022 §6) : envoyé automatiquement à
+             l'entrée en « Abonnement Validé » — conditions particulières
+             complètes (RSC + mensualités réelles) en pièce jointe via
+             report_template_ids (rendu par record, même report que le bouton
+             manuel de la Souscription), + documents d'accueil statiques
+             configurables (attachment_ids du template). Trois variantes
+             reprenant les contenus du pack prod « Bienvenue à EDN », choisies
+             par les faits de la demande (PRO / solidaire / particulier).
+             Wording provisoire, le définitif viendra d'EDN. -->
+
+        <record id="mail_template_bienvenue_particulier" model="mail.template">
+            <field name="name">Raccordement — pack de bienvenue (particulier)</field>
+            <field name="model_id" ref="model_souscription_souscription"/>
+            <field name="subject">Bienvenue à Énergie De Nantes !</field>
+            <field name="partner_to">{{ object.partner_id.id }}</field>
+            <field name="report_template_ids" eval="[(6, 0, [ref('action_souscription_conditions_particulieres')])]"/>
+            <field name="body_html" type="html">
+                <div style="margin: 0px; padding: 0px;">
+                    <p>Bonjour,</p>
+                    <p>
+                        Bienvenue à Énergie De Nantes ! Votre abonnement <t t-out="object.name"/> (PDL
+                        <t t-out="object.pdl"/>) est désormais validé et actif.
+                    </p>
+                    <p>
+                        Vous trouverez ci-joint vos conditions particulières complètes, ainsi que quelques
+                        documents utiles pour bien démarrer avec nous.
+                    </p>
+                    <p>L'équipe Énergie De Nantes</p>
+                </div>
+            </field>
+        </record>
+
+        <record id="mail_template_bienvenue_pro" model="mail.template">
+            <field name="name">Raccordement — pack de bienvenue (professionnel)</field>
+            <field name="model_id" ref="model_souscription_souscription"/>
+            <field name="subject">Bienvenue à Énergie De Nantes !</field>
+            <field name="partner_to">{{ object.partner_id.id }}</field>
+            <field name="report_template_ids" eval="[(6, 0, [ref('action_souscription_conditions_particulieres')])]"/>
+            <field name="body_html" type="html">
+                <div style="margin: 0px; padding: 0px;">
+                    <p>Bonjour,</p>
+                    <p>
+                        Bienvenue à Énergie De Nantes ! L'abonnement professionnel <t t-out="object.name"/>
+                        (PDL <t t-out="object.pdl"/>) est désormais validé et actif.
+                    </p>
+                    <p>
+                        Vous trouverez ci-joint vos conditions particulières complètes, ainsi que quelques
+                        documents utiles pour bien démarrer avec nous.
+                    </p>
+                    <p>L'équipe Énergie De Nantes</p>
+                </div>
+            </field>
+        </record>
+
+        <record id="mail_template_bienvenue_solidaire" model="mail.template">
+            <field name="name">Raccordement — pack de bienvenue (tarif solidaire)</field>
+            <field name="model_id" ref="model_souscription_souscription"/>
+            <field name="subject">Bienvenue à Énergie De Nantes !</field>
+            <field name="partner_to">{{ object.partner_id.id }}</field>
+            <field name="report_template_ids" eval="[(6, 0, [ref('action_souscription_conditions_particulieres')])]"/>
+            <field name="body_html" type="html">
+                <div style="margin: 0px; padding: 0px;">
+                    <p>Bonjour,</p>
+                    <p>
+                        Bienvenue à Énergie De Nantes ! Votre abonnement au tarif solidaire
+                        <t t-out="object.name"/> (PDL <t t-out="object.pdl"/>) est désormais validé et actif.
+                    </p>
+                    <p>
+                        Vous trouverez ci-joint vos conditions particulières complètes, ainsi que quelques
+                        documents utiles pour bien démarrer avec nous.
+                    </p>
+                    <p>L'équipe Énergie De Nantes</p>
+                </div>
+            </field>
+        </record>
+    </data>
+</odoo>

--- a/data/mail_templates_bienvenue.xml
+++ b/data/mail_templates_bienvenue.xml
@@ -9,11 +9,15 @@
              configurables (attachment_ids du template). Trois variantes
              reprenant les contenus du pack prod « Bienvenue à EDN », choisies
              par les faits de la demande (PRO / solidaire / particulier).
-             Wording provisoire, le définitif viendra d'EDN. -->
+             Wording provisoire, le définitif viendra d'EDN.
+             use_default_to=False : le défaut True (Odoo 19) court-circuiterait
+             partner_to au profit de _message_get_default_recipients() —
+             destinataire explicite plutôt qu'implicite. -->
 
         <record id="mail_template_bienvenue_particulier" model="mail.template">
             <field name="name">Raccordement — pack de bienvenue (particulier)</field>
             <field name="model_id" ref="model_souscription_souscription"/>
+            <field name="use_default_to" eval="False"/>
             <field name="subject">Bienvenue à Énergie De Nantes !</field>
             <field name="partner_to">{{ object.partner_id.id }}</field>
             <field name="report_template_ids" eval="[(6, 0, [ref('action_souscription_conditions_particulieres')])]"/>
@@ -36,6 +40,7 @@
         <record id="mail_template_bienvenue_pro" model="mail.template">
             <field name="name">Raccordement — pack de bienvenue (professionnel)</field>
             <field name="model_id" ref="model_souscription_souscription"/>
+            <field name="use_default_to" eval="False"/>
             <field name="subject">Bienvenue à Énergie De Nantes !</field>
             <field name="partner_to">{{ object.partner_id.id }}</field>
             <field name="report_template_ids" eval="[(6, 0, [ref('action_souscription_conditions_particulieres')])]"/>
@@ -58,6 +63,7 @@
         <record id="mail_template_bienvenue_solidaire" model="mail.template">
             <field name="name">Raccordement — pack de bienvenue (tarif solidaire)</field>
             <field name="model_id" ref="model_souscription_souscription"/>
+            <field name="use_default_to" eval="False"/>
             <field name="subject">Bienvenue à Énergie De Nantes !</field>
             <field name="partner_to">{{ object.partner_id.id }}</field>
             <field name="report_template_ids" eval="[(6, 0, [ref('action_souscription_conditions_particulieres')])]"/>

--- a/data/mail_templates_raccordement.xml
+++ b/data/mail_templates_raccordement.xml
@@ -6,11 +6,15 @@
              chez Enedis. Un template par situation d'entrée ; le rassurage
              tient le rôle d'accusé de prise en compte, les conditions
              particulières partant plus tard, complètes (pack de bienvenue,
-             #103). Wording provisoire, le définitif viendra d'EDN. -->
+             #103). Wording provisoire, le définitif viendra d'EDN.
+             use_default_to=False : le défaut True (Odoo 19) ignorerait
+             email_to au profit de _message_get_default_recipients(), vide
+             pour raccordement.demande (contact_email n'y est pas reconnu). -->
 
         <record id="mail_template_raccordement_f120" model="mail.template">
             <field name="name">Raccordement — rassurage F120 (mise en service)</field>
             <field name="model_id" ref="model_raccordement_demande"/>
+            <field name="use_default_to" eval="False"/>
             <field name="subject">Votre emménagement est bien enregistré</field>
             <field name="email_to">{{ object.contact_email }}</field>
             <field name="body_html" type="html">
@@ -30,6 +34,7 @@
         <record id="mail_template_raccordement_f130" model="mail.template">
             <field name="name">Raccordement — rassurage F130 (changement de fournisseur)</field>
             <field name="model_id" ref="model_raccordement_demande"/>
+            <field name="use_default_to" eval="False"/>
             <field name="subject">Votre changement de fournisseur est bien enregistré</field>
             <field name="email_to">{{ object.contact_email }}</field>
             <field name="body_html" type="html">

--- a/data/mail_templates_raccordement.xml
+++ b/data/mail_templates_raccordement.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data noupdate="1">
+        <!-- Mails de rassurage (#102, ADR 0022 §6) : envoyés à l'entrée des
+             branches ⏳ — c'est le moment où la demande SGE part réellement
+             chez Enedis. Un template par situation d'entrée ; le rassurage
+             tient le rôle d'accusé de prise en compte, les conditions
+             particulières partant plus tard, complètes (pack de bienvenue,
+             #103). Wording provisoire, le définitif viendra d'EDN. -->
+
+        <record id="mail_template_raccordement_f120" model="mail.template">
+            <field name="name">Raccordement — rassurage F120 (mise en service)</field>
+            <field name="model_id" ref="model_raccordement_demande"/>
+            <field name="subject">Votre emménagement est bien enregistré</field>
+            <field name="email_to">{{ object.contact_email }}</field>
+            <field name="body_html" type="html">
+                <div style="margin: 0px; padding: 0px;">
+                    <p>Bonjour <t t-out="object.contact_prenom or ''"/> <t t-out="object.contact_nom or ''"/>,</p>
+                    <p>
+                        Votre demande de mise en service (PDL <t t-out="object.pdl"/>) vient d'être transmise
+                        à Enedis. Votre emménagement est bien enregistré : nous vous tiendrons informé·e dès
+                        que le raccordement sera effectif.
+                    </p>
+                    <p>Les conditions particulières complètes de votre contrat vous parviendront à cette étape.</p>
+                    <p>L'équipe Énergie De Nantes</p>
+                </div>
+            </field>
+        </record>
+
+        <record id="mail_template_raccordement_f130" model="mail.template">
+            <field name="name">Raccordement — rassurage F130 (changement de fournisseur)</field>
+            <field name="model_id" ref="model_raccordement_demande"/>
+            <field name="subject">Votre changement de fournisseur est bien enregistré</field>
+            <field name="email_to">{{ object.contact_email }}</field>
+            <field name="body_html" type="html">
+                <div style="margin: 0px; padding: 0px;">
+                    <p>Bonjour <t t-out="object.contact_prenom or ''"/> <t t-out="object.contact_nom or ''"/>,</p>
+                    <p>
+                        Votre demande de changement de fournisseur (PDL <t t-out="object.pdl"/>) vient d'être
+                        transmise à Enedis. Votre dossier est bien enregistré : nous vous tiendrons informé·e
+                        dès que le changement sera effectif.
+                    </p>
+                    <p>Les conditions particulières complètes de votre contrat vous parviendront à cette étape.</p>
+                    <p>L'équipe Énergie De Nantes</p>
+                </div>
+            </field>
+        </record>
+    </data>
+</odoo>

--- a/data/raccordement_stages.xml
+++ b/data/raccordement_stages.xml
@@ -1,62 +1,84 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
     <data noupdate="0">
-        <!-- Étapes de raccordement -->
-        <record id="stage_demande_recue" model="raccordement.stage">
-            <field name="name">Demande reçue</field>
+        <!-- Chaîne de raccordement alignée sur la prod, sans F305 (#100, ADR
+             0022 §1). Trichotomie visuelle portée par le préfixe de nom et la
+             couleur d'étape (re-purposée, #100 ADR 0022 §5) :
+             🔴 action attendue (orange, 2) — ⏳ attente externe, le poll
+             travaille (neutre, 0) — ✓ fait (vert, 10, colonne repliée).
+             Pas de migration : le module n'existe pas en prod. -->
+
+        <record id="stage_nouveau" model="raccordement.stage">
+            <field name="name">🔴 Nouveau</field>
             <field name="sequence">10</field>
-            <field name="color">1</field>
+            <field name="color">2</field>
             <field name="description">Nouvelle demande de raccordement à traiter</field>
         </record>
 
-        <record id="stage_iban_valide" model="raccordement.stage">
-            <field name="name">IBAN validé</field>
+        <record id="stage_pro_a_valider" model="raccordement.stage">
+            <field name="name">🔴 PRO à valider</field>
             <field name="sequence">20</field>
             <field name="color">2</field>
-            <field name="description">Coordonnées bancaires vérifiées et validées</field>
+            <field name="description">Demande professionnelle en attente de validation du Collège (PRO + majoration tarifaire négociée)</field>
         </record>
 
-        <record id="stage_demande_sge" model="raccordement.stage">
-            <field name="name">Demande SGE faite</field>
+        <!-- Naissance de la Souscription (#101, ADR 0022 §2) : le drapeau
+             d'étape finale (is_close) est posé ici à partir de la tranche
+             #101 — état intérimaire #100, il reste sur « Abonnement Validé »
+             (cf. plus bas). -->
+        <record id="stage_accepte_iban_verifie" model="raccordement.stage">
+            <field name="name">🔴 Accepté et IBAN vérifié</field>
             <field name="sequence">30</field>
-            <field name="color">3</field>
-            <field name="description">Demande transmise au Système de Gestion des Échanges</field>
-            <field name="entree_factuelle">True</field>
+            <field name="color">2</field>
+            <field name="description">Demande acceptée (collège pour les PRO) — IBAN vérifié si prélèvement</field>
         </record>
 
-        <record id="stage_demande_mesures" model="raccordement.stage">
-            <field name="name">Demande mesures faite</field>
+        <!-- Branches ⏳ : entrée factuelle (id_Affaire saisi), drag-in manuel
+             refusé (#100, ADR 0022 §1/§4). Routées par situation_entree. -->
+        <record id="stage_f120_mes" model="raccordement.stage">
+            <field name="name">⏳ Mise en Service (F120) en cours</field>
             <field name="sequence">40</field>
-            <field name="color">4</field>
-            <field name="description">Demande des données de consommation historiques</field>
+            <field name="color">0</field>
+            <field name="entree_factuelle">True</field>
+            <field name="description">Suivi de l'affaire Enedis F120 (mise en service, PDL hors service)</field>
         </record>
 
-        <record id="stage_estimation" model="raccordement.stage">
-            <field name="name">Estimation mensualité</field>
+        <record id="stage_f130_cfne" model="raccordement.stage">
+            <field name="name">⏳ Changement de fournisseur (F130) en cours</field>
+            <field name="sequence">41</field>
+            <field name="color">0</field>
+            <field name="entree_factuelle">True</field>
+            <field name="description">Suivi de l'affaire Enedis F130 (changement de fournisseur, PDL déjà alimenté)</field>
+        </record>
+
+        <!-- Entrée factuelle : RSC résolue (#100, ADR 0022 §3 — pas de RSC
+             sans C15 d'effectivité, RSC résolue ≡ validé sur SGE). -->
+        <record id="stage_valide_sge" model="raccordement.stage">
+            <field name="name">🔴 Validé sur SGE</field>
             <field name="sequence">50</field>
-            <field name="color">5</field>
-            <field name="description">Calcul des provisions mensuelles basé sur l'historique</field>
+            <field name="color">2</field>
+            <field name="entree_factuelle">True</field>
+            <field name="description">Affaire aboutie côté Enedis — RSC acquise (poll quotidien ou saisie manuelle)</field>
         </record>
 
-        <record id="stage_souscrit" model="raccordement.stage">
-            <field name="name">Souscrit</field>
+        <record id="stage_calcul_mensualites" model="raccordement.stage">
+            <field name="name">🔴 Calcul de mensualités en cours</field>
             <field name="sequence">60</field>
-            <field name="color">10</field>
-            <field name="fold">True</field>
-            <field name="is_close">True</field>
-            <field name="description">Raccordement finalisé - Souscription créée</field>
+            <field name="color">2</field>
+            <field name="description">Calcul des provisions mensuelles avant validation de l'abonnement</field>
         </record>
 
-        <!-- Étape finale (#90, ADR 0021 §5-6) : atteinte seule quand la RSC de
-             la Souscription est acquise (poll ou saisie manuelle) — jamais de
-             rôle de création, celui-ci reste sur « Souscrit ». -->
-        <record id="stage_en_service" model="raccordement.stage">
-            <field name="name">En service</field>
+        <!-- Terminale, repliée (#100). État intérimaire : le drapeau
+             is_close (naissance de la Souscription) reste ici — son
+             déplacement vers « Accepté et IBAN vérifié » est la tranche
+             #101. -->
+        <record id="stage_abonnement_valide" model="raccordement.stage">
+            <field name="name">✓ Abonnement Validé</field>
             <field name="sequence">70</field>
             <field name="color">10</field>
             <field name="fold">True</field>
-            <field name="entree_factuelle">True</field>
-            <field name="description">Raccordement effectif côté Enedis — RSC acquise (poll ou saisie manuelle)</field>
+            <field name="is_close">True</field>
+            <field name="description">Raccordement finalisé — mise en service effective, mensualités calculées</field>
         </record>
     </data>
 </odoo>

--- a/data/raccordement_stages.xml
+++ b/data/raccordement_stages.xml
@@ -22,15 +22,16 @@
             <field name="description">Demande professionnelle en attente de validation du Collège (PRO + majoration tarifaire négociée)</field>
         </record>
 
-        <!-- Naissance de la Souscription (#101, ADR 0022 §2) : le drapeau
-             d'étape finale (is_close) est posé ici à partir de la tranche
-             #101 — état intérimaire #100, il reste sur « Abonnement Validé »
-             (cf. plus bas). -->
+        <!-- Naissance de la Souscription (#101, ADR 0022 §2) : is_close pose
+             ici le déclencheur de création (contact, banque, Souscription en
+             instance) — déplacé depuis « Abonnement Validé » (état
+             intérimaire #100). Garde bloquante IBAN au drag (#101). -->
         <record id="stage_accepte_iban_verifie" model="raccordement.stage">
             <field name="name">🔴 Accepté et IBAN vérifié</field>
             <field name="sequence">30</field>
             <field name="color">2</field>
-            <field name="description">Demande acceptée (collège pour les PRO) — IBAN vérifié si prélèvement</field>
+            <field name="is_close">True</field>
+            <field name="description">Demande acceptée (collège pour les PRO) — IBAN vérifié si prélèvement — Souscription née en instance</field>
         </record>
 
         <!-- Branches ⏳ : entrée factuelle (id_Affaire saisi), drag-in manuel
@@ -68,16 +69,14 @@
             <field name="description">Calcul des provisions mensuelles avant validation de l'abonnement</field>
         </record>
 
-        <!-- Terminale, repliée (#100). État intérimaire : le drapeau
-             is_close (naissance de la Souscription) reste ici — son
-             déplacement vers « Accepté et IBAN vérifié » est la tranche
-             #101. -->
+        <!-- Terminale, repliée (#100). is_close (naissance) est désormais
+             sur « Accepté et IBAN vérifié » (#101) : cette étape ne fait
+             plus que refléter l'aboutissement, elle ne crée plus rien. -->
         <record id="stage_abonnement_valide" model="raccordement.stage">
             <field name="name">✓ Abonnement Validé</field>
             <field name="sequence">70</field>
             <field name="color">10</field>
             <field name="fold">True</field>
-            <field name="is_close">True</field>
             <field name="description">Raccordement finalisé — mise en service effective, mensualités calculées</field>
         </record>
     </data>

--- a/demo/raccordement_demo.xml
+++ b/demo/raccordement_demo.xml
@@ -1,9 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
     <data>
-        <!-- Demandes de raccordement de démonstration -->
-        
-        <!-- Demande 1: Nouvelle demande -->
+        <!-- Demandes de raccordement de démonstration — chaîne cible prod
+             (#100, ADR 0022 §1) : une demande par étape (sauf la terminale,
+             jamais peuplée en démo — cohérent avec la démo précédente). -->
+
+        <!-- Demande 1: 🔴 Nouveau -->
         <record id="demo_raccordement_1" model="raccordement.demande">
             <field name="pdl">14325698745236</field>
             <field name="date_debut_souhaitee" eval="(DateTime.today() + relativedelta(months=1)).strftime('%Y-%m-%d')"/>
@@ -23,11 +25,11 @@
             <field name="bank_acc_holder_name">Marie Dupont</field>
             <field name="bank_iban">FR1420041010050500013M02606</field>
             <field name="bank_bic">BNPAFRPP</field>
-            <field name="stage_id" ref="stage_demande_recue"/>
+            <field name="stage_id" ref="stage_nouveau"/>
             <field name="notes">Nouvelle demande de raccordement pour un appartement</field>
         </record>
-        
-        <!-- Demande 2: IBAN validé -->
+
+        <!-- Demande 2: 🔴 Accepté et IBAN vérifié -->
         <record id="demo_raccordement_2" model="raccordement.demande">
             <field name="pdl">25874136985247</field>
             <field name="date_debut_souhaitee" eval="(DateTime.today() + relativedelta(weeks=3)).strftime('%Y-%m-%d')"/>
@@ -49,10 +51,10 @@
             <field name="bank_bic">SOGEFRPP</field>
             <field name="sepa_mandate_date" eval="DateTime.today().strftime('%Y-%m-%d')"/>
             <field name="sepa_mandate_ref">SEPA-2024-001</field>
-            <field name="stage_id" ref="stage_iban_valide"/>
+            <field name="stage_id" ref="stage_accepte_iban_verifie"/>
         </record>
-        
-        <!-- Demande 3: Demande SGE faite -->
+
+        <!-- Demande 3: ⏳ Mise en Service (F120) en cours (tarif solidaire) -->
         <record id="demo_raccordement_3" model="raccordement.demande">
             <field name="pdl">36985214736985</field>
             <field name="date_debut_souhaitee" eval="(DateTime.today() + relativedelta(weeks=2)).strftime('%Y-%m-%d')"/>
@@ -74,11 +76,13 @@
             <field name="bank_bic">CMCIFRPP</field>
             <field name="sepa_mandate_date" eval="(DateTime.today() - relativedelta(days=3)).strftime('%Y-%m-%d')"/>
             <field name="sepa_mandate_ref">SEPA-2024-002</field>
-            <field name="date_demande_sge" eval="(DateTime.today() - relativedelta(days=2)).strftime('%Y-%m-%d')"/>
-            <field name="stage_id" ref="stage_demande_sge"/>
+            <field name="situation_entree">mes</field>
+            <field name="id_affaire">DEMO-AFFAIRE-F120</field>
+            <field name="id_affaire_date_saisie" eval="(DateTime.today() - relativedelta(days=2)).strftime('%Y-%m-%d')"/>
+            <field name="stage_id" ref="stage_f120_mes"/>
         </record>
-        
-        <!-- Demande 4: Demande mesures faite (PROFESSIONNELLE) -->
+
+        <!-- Demande 4: ⏳ Changement de fournisseur (F130) en cours (PROFESSIONNELLE, bloquée) -->
         <record id="demo_raccordement_4" model="raccordement.demande">
             <field name="pro">True</field>
             <field name="siret">12345678901234</field>
@@ -100,14 +104,15 @@
             <field name="bank_bic">BNPAGFPP</field>
             <field name="sepa_mandate_date" eval="(DateTime.today() - relativedelta(days=7)).strftime('%Y-%m-%d')"/>
             <field name="sepa_mandate_ref">SEPA-2024-003</field>
-            <field name="date_demande_sge" eval="(DateTime.today() - relativedelta(days=5)).strftime('%Y-%m-%d')"/>
-            <field name="date_demande_mesures" eval="(DateTime.today() - relativedelta(days=3)).strftime('%Y-%m-%d')"/>
-            <field name="stage_id" ref="stage_demande_mesures"/>
-            <field name="notes">Client professionnel - Boulangerie</field>
+            <field name="situation_entree">cfne</field>
+            <field name="id_affaire">DEMO-AFFAIRE-F130</field>
+            <field name="id_affaire_date_saisie" eval="(DateTime.today() - relativedelta(days=5)).strftime('%Y-%m-%d')"/>
+            <field name="stage_id" ref="stage_f130_cfne"/>
+            <field name="notes">Client professionnel - Boulangerie (affaire Enedis en cours de vérification)</field>
             <field name="kanban_state">blocked</field>
         </record>
-        
-        <!-- Demande 5: Estimation mensualité -->
+
+        <!-- Demande 5: 🔴 Validé sur SGE -->
         <record id="demo_raccordement_5" model="raccordement.demande">
             <field name="pdl">58963214789632</field>
             <field name="date_debut_souhaitee" eval="(DateTime.today() + relativedelta(days=15)).strftime('%Y-%m-%d')"/>
@@ -130,14 +135,14 @@
             <field name="bank_bic">AGRIFRPP</field>
             <field name="sepa_mandate_date" eval="(DateTime.today() - relativedelta(days=10)).strftime('%Y-%m-%d')"/>
             <field name="sepa_mandate_ref">SEPA-2024-004</field>
-            <field name="date_demande_sge" eval="(DateTime.today() - relativedelta(days=8)).strftime('%Y-%m-%d')"/>
-            <field name="date_demande_mesures" eval="(DateTime.today() - relativedelta(days=5)).strftime('%Y-%m-%d')"/>
-            <field name="date_estimation" eval="(DateTime.today() - relativedelta(days=1)).strftime('%Y-%m-%d')"/>
-            <field name="stage_id" ref="stage_estimation"/>
+            <field name="situation_entree">mes</field>
+            <field name="id_affaire">DEMO-AFFAIRE-SGE</field>
+            <field name="id_affaire_date_saisie" eval="(DateTime.today() - relativedelta(days=8)).strftime('%Y-%m-%d')"/>
+            <field name="stage_id" ref="stage_valide_sge"/>
             <field name="kanban_state">done</field>
         </record>
-        
-        <!-- Demande 6: Mode paiement autre que prélèvement -->
+
+        <!-- Demande 6: 🔴 Calcul de mensualités en cours (mode paiement autre que prélèvement, tarif solidaire) -->
         <record id="demo_raccordement_6" model="raccordement.demande">
             <field name="pdl">69874521369874</field>
             <field name="date_debut_souhaitee" eval="(DateTime.today() + relativedelta(weeks=5)).strftime('%Y-%m-%d')"/>
@@ -153,11 +158,14 @@
             <field name="contact_zip">59000</field>
             <field name="contact_city">Lille</field>
             <field name="mode_paiement">cheque_energie</field>
-            <field name="stage_id" ref="stage_demande_recue"/>
+            <field name="situation_entree">mes</field>
+            <field name="id_affaire">DEMO-AFFAIRE-MENSU</field>
+            <field name="id_affaire_date_saisie" eval="(DateTime.today() - relativedelta(days=20)).strftime('%Y-%m-%d')"/>
+            <field name="stage_id" ref="stage_calcul_mensualites"/>
             <field name="notes">Bénéficiaire du chèque énergie</field>
         </record>
-        
-        <!-- Demande 7: Professionnelle sans mobile -->
+
+        <!-- Demande 7: 🔴 PRO à valider -->
         <record id="demo_raccordement_7" model="raccordement.demande">
             <field name="pro">True</field>
             <field name="siret">98765432109876</field>
@@ -174,10 +182,11 @@
             <field name="contact_zip">67000</field>
             <field name="contact_city">Strasbourg</field>
             <field name="mode_paiement">virement</field>
-            <field name="stage_id" ref="stage_demande_recue"/>
+            <field name="stage_id" ref="stage_pro_a_valider"/>
+            <field name="notes">En attente de validation du Collège (PRO + majoration tarifaire)</field>
         </record>
-        
-        <!-- Demande 8: IBAN non valide pour test -->
+
+        <!-- Demande 8: 🔴 Nouveau, IBAN non valide pour test -->
         <record id="demo_raccordement_8" model="raccordement.demande">
             <field name="pdl">81234567890123</field>
             <field name="date_debut_souhaitee" eval="(DateTime.today() + relativedelta(weeks=6)).strftime('%Y-%m-%d')"/>
@@ -195,10 +204,10 @@
             <field name="mode_paiement">prelevement</field>
             <field name="bank_acc_holder_name">Marc Richard</field>
             <field name="bank_iban">FR1420041010050500013M02607</field>
-            <field name="stage_id" ref="stage_demande_recue"/>
+            <field name="stage_id" ref="stage_nouveau"/>
             <field name="notes">IBAN à vérifier</field>
             <field name="kanban_state">blocked</field>
         </record>
-        
+
     </data>
 </odoo>

--- a/models/core/souscription.py
+++ b/models/core/souscription.py
@@ -267,15 +267,16 @@ class Souscription(models.Model):
 
         if rsc_avant is not None:
             nouvellement_resolues = self.filtered(lambda s: s.ref_situation_contractuelle and not rsc_avant.get(s.id))
-            nouvellement_resolues._avancer_demande_en_service()
+            nouvellement_resolues._avancer_demande_valide_sge()
 
         return res
 
-    def _avancer_demande_en_service(self):
-        """Auto-move (#90) : la demande liée avance à « En service »,
-        seulement si elle est encore en amont (jamais de recul), avec trace
-        au chatter de la demande."""
-        stage = self.env.ref('souscriptions_odoo.stage_en_service', raise_if_not_found=False)
+    def _avancer_demande_valide_sge(self):
+        """Auto-move (#90, reciblé #100 ADR 0022 §3 — pas de RSC sans C15
+        d'effectivité, RSC résolue ≡ validé sur SGE) : la demande liée avance
+        à « Validé sur SGE », seulement si elle est encore en amont (jamais
+        de recul), avec trace au chatter de la demande."""
+        stage = self.env.ref('souscriptions_odoo.stage_valide_sge', raise_if_not_found=False)
         if not stage:
             return
         for sous in self:
@@ -284,7 +285,7 @@ class Souscription(models.Model):
                 continue
             demande.with_context(raccordement_automove=True).stage_id = stage.id
             demande.message_post(
-                body=f'Étape avancée automatiquement à « En service » (RSC {sous.ref_situation_contractuelle} acquise).'
+                body=f'Étape avancée automatiquement à « Validé sur SGE » (RSC {sous.ref_situation_contractuelle} acquise).'
             )
 
     def action_resoudre_rsc_maintenant(self):

--- a/models/raccordement/raccordement_demande.py
+++ b/models/raccordement/raccordement_demande.py
@@ -432,10 +432,15 @@ class RaccordementDemande(models.Model):
                     "l'IBAN est invalide. Corrigez l'IBAN avant d'accepter."
                 )
 
-    # Branches ⏳ ciblées par situation_entree (#100, ADR 0022 §1/§4).
+    # Branches ⏳ ciblées par situation_entree (#100, ADR 0022 §1/§4), et
+    # leur mail de rassurage associé (#102, ADR 0022 §6).
     _STAGE_XMLID_PAR_SITUATION = {
         'mes': 'souscriptions_odoo.stage_f120_mes',
         'cfne': 'souscriptions_odoo.stage_f130_cfne',
+    }
+    _TEMPLATE_XMLID_PAR_SITUATION = {
+        'mes': 'souscriptions_odoo.mail_template_raccordement_f120',
+        'cfne': 'souscriptions_odoo.mail_template_raccordement_f130',
     }
 
     def _stage_branche_cible(self):
@@ -462,6 +467,10 @@ class RaccordementDemande(models.Model):
           latéralement vers l'autre branche (ni avancement, ni recul) ;
         - en aval des branches (Validé sur SGE et au-delà) : aucun effet — on
           ne recule jamais une carte déjà instruite côté Enedis.
+
+        Chaque entrée effective (initiale ou re-routée) envoie le mail de
+        rassurage (#102) de la branche d'arrivée : c'est le moment où la
+        demande SGE part réellement chez Enedis.
         """
         branches = self._stages_branches_sge()
         for record in self:
@@ -474,6 +483,19 @@ class RaccordementDemande(models.Model):
             en_amont = record.stage_id.sequence < cible.sequence
             if en_branche or en_amont:
                 record.with_context(raccordement_automove=True).stage_id = cible.id
+                record._envoyer_mail_rassurage()
+
+    def _envoyer_mail_rassurage(self):
+        """Mail de rassurage (#102, ADR 0022 §6) à l'entrée effective d'une
+        branche ⏳ — accusé de prise en compte, un template par situation
+        d'entrée. Le re-routage F120<->F130 envoie le mail de la branche
+        d'arrivée (même seuil d'appel que l'avancement initial,
+        `_router_situation_entree`)."""
+        self.ensure_one()
+        xmlid = self._TEMPLATE_XMLID_PAR_SITUATION.get(self.situation_entree)
+        template = self.env.ref(xmlid, raise_if_not_found=False) if xmlid else False
+        if template:
+            template.send_mail(self.id, force_send=False)
 
     def _create_odoo_entries(self):
         """Crée automatiquement les entrées Odoo (contact, banque, souscription)"""

--- a/models/raccordement/raccordement_demande.py
+++ b/models/raccordement/raccordement_demande.py
@@ -41,6 +41,16 @@ class RaccordementDemande(models.Model):
         help="Cocher si c'est une demande professionnelle (création d'une société)",
     )
     siret = fields.Char(string='N° SIRET', tracking=True, help="Numéro SIRET de l'entreprise (14 chiffres)")
+    # Majoration négociée par le Collège pendant « PRO à valider » (#101,
+    # ADR 0022 §7) ; recopiée sur la Souscription à la naissance.
+    coeff_pro = fields.Float(
+        string='Majoration PRO (%)',
+        default=0.0,
+        digits=(5, 2),
+        tracking=True,
+        help='Majoration en % négociée par le Collège pour cette demande PRO — recopiée sur la '
+        'Souscription à sa naissance (0% pour les particuliers).',
+    )
     pdl = fields.Char(string='PDL', required=True, tracking=True)
     date_debut_souhaitee = fields.Date(string='Date de début souhaitée', required=True, tracking=True)
     puissance_souscrite = fields.Selection(
@@ -340,6 +350,8 @@ class RaccordementDemande(models.Model):
         # (contournement de contexte `raccordement_automove`).
         if 'stage_id' in vals and not self.env.context.get('raccordement_automove'):
             self._verifier_pas_de_drag_in_factuel(vals['stage_id'])
+        if 'stage_id' in vals:
+            self._verifier_garde_iban_acceptation(vals['stage_id'])
 
         # id_Affaire saisi/corrigé : la situation d'entrée est requise (#100,
         # ADR 0022 §4) — elle route l'auto-move vers la bonne branche ⏳.
@@ -369,6 +381,21 @@ class RaccordementDemande(models.Model):
         if 'id_affaire' in vals or 'situation_entree' in vals:
             self._router_situation_entree()
 
+        # Write-through post-naissance (#101, ADR 0022 §2) : une fois la
+        # Souscription née, la saisie ou correction de l'id_Affaire sur la
+        # demande se propage à la Souscription liée, avec sa date de saisie
+        # (elle amorce la grâce du poll #89). La RSC et l'état restent portés
+        # par la Souscription — la carte ne fait que refléter.
+        if 'id_affaire' in vals:
+            for record in self:
+                if record.souscription_id and record.id_affaire:
+                    record.souscription_id.write(
+                        {
+                            'id_affaire': record.id_affaire,
+                            'id_affaire_date_saisie': record.id_affaire_date_saisie,
+                        }
+                    )
+
         return res
 
     def _verifier_pas_de_drag_in_factuel(self, nouveau_stage_id):
@@ -386,6 +413,24 @@ class RaccordementDemande(models.Model):
                 f'« {nouveau_stage.name} » est une étape pilotée par un fait : elle ne se force pas à la '
                 'main. Corrigez le fait (id_Affaire saisi, RSC acquise) — la carte suivra automatiquement.'
             )
+
+    def _verifier_garde_iban_acceptation(self, nouveau_stage_id):
+        """Garde bloquante IBAN (#101, ADR 0022 §2) : le drag vers l'étape de
+        naissance (is_close) est refusé si le mode de paiement est le
+        prélèvement et l'IBAN invalide — la colonne « IBAN vérifié » ne ment
+        jamais. Remplace l'ancien avertissement non bloquant (onchange),
+        disparu avec l'étape qui le portait (#100). Vérifiée avant l'écriture
+        (comme la garde factuelle) pour qu'un refus n'altère pas l'étape."""
+        nouveau_stage = self.env['raccordement.stage'].browse(nouveau_stage_id)
+        if not nouveau_stage.is_close:
+            return
+        cible = self.filtered(lambda r: not r.souscription_id and r.stage_id.id != nouveau_stage_id)
+        for record in cible:
+            if record.mode_paiement == 'prelevement' and not record._validate_iban(record.bank_iban):
+                raise UserError(
+                    "Impossible d'accepter la demande : le mode de paiement est le prélèvement et "
+                    "l'IBAN est invalide. Corrigez l'IBAN avant d'accepter."
+                )
 
     # Branches ⏳ ciblées par situation_entree (#100, ADR 0022 §1/§4).
     _STAGE_XMLID_PAR_SITUATION = {
@@ -556,6 +601,8 @@ class RaccordementDemande(models.Model):
             # amorce de réconciliation, avec sa date de saisie (grâce du poll #89).
             'id_affaire': self.id_affaire,
             'id_affaire_date_saisie': self.id_affaire_date_saisie,
+            # Majoration PRO négociée par le Collège (#101, ADR 0022 §7).
+            'coeff_pro': self.coeff_pro,
         }
 
         # Ajouter les provisions selon le type de tarif

--- a/models/raccordement/raccordement_demande.py
+++ b/models/raccordement/raccordement_demande.py
@@ -178,6 +178,20 @@ class RaccordementDemande(models.Model):
         'du poll quotidien des affaires Enedis (#89).',
     )
 
+    # Situation d'entrée (#100, ADR 0021 §4 / ADR 0022 §1 & §4) : voie SGE par
+    # laquelle la demande entre dans le périmètre. Requise à la saisie de
+    # l'id_Affaire (elle route l'auto-move vers la bonne branche ⏳) ;
+    # éditable par l'accueilliste — sa correction re-route une carte déjà en
+    # branche vers l'autre branche, jamais de recul.
+    situation_entree = fields.Selection(
+        [('mes', 'Mise en service (F120)'), ('cfne', 'Changement de fournisseur (F130)')],
+        string="Situation d'entrée",
+        tracking=True,
+        help="Voie SGE d'entrée dans le périmètre : mise en service (F120, PDL hors service) "
+        'ou changement de fournisseur (CFNE F130, PDL déjà alimenté). Requise à la saisie de '
+        "l'id_Affaire ; sa correction re-route la carte déjà en branche vers l'autre branche.",
+    )
+
     # Champs liés après création
     partner_id = fields.Many2one('res.partner', string='Contact créé', readonly=True, tracking=True)
     partner_bank_id = fields.Many2one('res.partner.bank', string='Compte bancaire créé', readonly=True, tracking=True)
@@ -188,27 +202,40 @@ class RaccordementDemande(models.Model):
     # Notes
     notes = fields.Text(string='Notes')
 
+    _MESSAGE_SITUATION_ENTREE_REQUISE = (
+        "La situation d'entrée (mise en service F120 ou changement de fournisseur F130) est "
+        "requise pour saisir l'id_Affaire."
+    )
+
     @api.model_create_multi
     def create(self, vals_list):
         for vals in vals_list:
             if vals.get('name', 'Nouveau') == 'Nouveau':
                 vals['name'] = self.env['ir.sequence'].next_by_code('raccordement.demande.sequence') or 'Nouveau'
+            if vals.get('id_affaire') and not vals.get('situation_entree'):
+                raise UserError(self._MESSAGE_SITUATION_ENTREE_REQUISE)
             if vals.get('id_affaire') and not vals.get('id_affaire_date_saisie'):
                 vals['id_affaire_date_saisie'] = fields.Date.context_today(self)
         records = super().create(vals_list)
-        # Définir l'étape initiale si non définie
+        # Définir l'étape initiale si non définie : routage à la création
+        # (#100, ADR 0022 §1) — PRO coché -> « PRO à valider », sinon
+        # « Nouveau ».
         for record in records:
             if not record.stage_id:
-                record.stage_id = self._get_default_stage_id()
+                record.stage_id = record._get_default_stage_id()
         # id_Affaire déjà renseigné à la création (rare, mais cohérent avec
-        # l'auto-move de write(), #90) : avance la carte si elle est en amont.
-        records.filtered('id_affaire')._avancer_stage_demande_sge()
+        # l'auto-move de write(), #90/#100) : avance la carte si elle est en amont.
+        records.filtered('id_affaire')._router_situation_entree()
         return records
 
-    @api.model
     def _get_default_stage_id(self):
-        """Retourne la première étape par défaut"""
-        return self.env['raccordement.stage'].search([], order='sequence', limit=1)
+        """Étape de routage à la création (#100, ADR 0022 §1) : une demande
+        PRO naît en « PRO à valider » (décision du Collège) ; une demande
+        particulière naît en « Nouveau »."""
+        self.ensure_one()
+        xmlid = 'souscriptions_odoo.stage_pro_a_valider' if self.pro else 'souscriptions_odoo.stage_nouveau'
+        stage = self.env.ref(xmlid, raise_if_not_found=False)
+        return stage or self.env['raccordement.stage'].search([], order='sequence', limit=1)
 
     @api.model
     def _read_group_stage_ids(self, stages, domain):
@@ -283,17 +310,11 @@ class RaccordementDemande(models.Model):
     def _onchange_stage_id(self):
         """Actions lors du changement d'étape"""
         if self.stage_id:
-            # Si on passe à l'étape "IBAN validé"
-            if 'iban' in self.stage_id.name.lower() and 'valid' in self.stage_id.name.lower():
-                if not self.iban_valide:
-                    return {
-                        'warning': {
-                            'title': 'IBAN non valide',
-                            'message': "L'IBAN n'est pas valide. Veuillez le vérifier avant de passer à cette étape.",
-                        }
-                    }
-
-            # Si on passe à l'étape finale "Souscrit"
+            # Étape finale (naissance de la Souscription, is_close) : vérifie
+            # que les informations nécessaires sont présentes. L'ancienne
+            # heuristique par nom (« IBAN validé ») a disparu avec l'étape :
+            # la garde IBAN devient un blocage dur au drag d'acceptation
+            # (#101), plus un avertissement non bloquant ici.
             if self.stage_id.is_close:
                 # Vérifier que toutes les infos nécessaires sont présentes
                 missing = []
@@ -320,6 +341,13 @@ class RaccordementDemande(models.Model):
         if 'stage_id' in vals and not self.env.context.get('raccordement_automove'):
             self._verifier_pas_de_drag_in_factuel(vals['stage_id'])
 
+        # id_Affaire saisi/corrigé : la situation d'entrée est requise (#100,
+        # ADR 0022 §4) — elle route l'auto-move vers la bonne branche ⏳.
+        if vals.get('id_affaire'):
+            for record in self:
+                if not vals.get('situation_entree', record.situation_entree):
+                    raise UserError(self._MESSAGE_SITUATION_ENTREE_REQUISE)
+
         # id_Affaire saisi/corrigé (#87) : date de saisie auto-stampée, sauf
         # si le vals la fixe explicitement (rattrapage de typo, tests
         # antidatant la grâce du poll #89).
@@ -335,10 +363,11 @@ class RaccordementDemande(models.Model):
                 if record.stage_id.is_close and not record.souscription_id:
                     record._create_odoo_entries()
 
-        # id_Affaire saisi/corrigé (#90) : la carte avance seule à « Demande
-        # SGE faite » si elle est en amont — jamais en aval (pas de recul).
-        if 'id_affaire' in vals:
-            self._avancer_stage_demande_sge()
+        # id_Affaire saisi ou situation_entree corrigée (#90/#100) : la carte
+        # avance seule vers la branche ⏳ désignée, ou re-route latéralement
+        # une carte déjà en branche — jamais en aval (pas de recul).
+        if 'id_affaire' in vals or 'situation_entree' in vals:
+            self._router_situation_entree()
 
         return res
 
@@ -358,15 +387,48 @@ class RaccordementDemande(models.Model):
                 'main. Corrigez le fait (id_Affaire saisi, RSC acquise) — la carte suivra automatiquement.'
             )
 
-    def _avancer_stage_demande_sge(self):
-        """Auto-move (#90) : id_Affaire renseigné -> « Demande SGE faite »,
-        seulement si la demande est encore en amont (jamais de recul)."""
-        stage = self.env.ref('souscriptions_odoo.stage_demande_sge', raise_if_not_found=False)
-        if not stage:
-            return
+    # Branches ⏳ ciblées par situation_entree (#100, ADR 0022 §1/§4).
+    _STAGE_XMLID_PAR_SITUATION = {
+        'mes': 'souscriptions_odoo.stage_f120_mes',
+        'cfne': 'souscriptions_odoo.stage_f130_cfne',
+    }
+
+    def _stage_branche_cible(self):
+        """L'étape ⏳ désignée par situation_entree, ou vide si absente/non
+        configurée."""
+        self.ensure_one()
+        xmlid = self._STAGE_XMLID_PAR_SITUATION.get(self.situation_entree)
+        return self.env.ref(xmlid, raise_if_not_found=False) if xmlid else self.env['raccordement.stage']
+
+    def _stages_branches_sge(self):
+        """Les deux étapes ⏳ (branches F120/F130), pour distinguer un
+        re-routage latéral d'un avancement amont->branche."""
+        stage_f120 = self.env.ref('souscriptions_odoo.stage_f120_mes', raise_if_not_found=False)
+        stage_f130 = self.env.ref('souscriptions_odoo.stage_f130_cfne', raise_if_not_found=False)
+        return (stage_f120 or self.env['raccordement.stage']) | (stage_f130 or self.env['raccordement.stage'])
+
+    def _router_situation_entree(self):
+        """Route la carte vers la branche ⏳ désignée par situation_entree
+        (#100, ADR 0021 §5 / ADR 0022 §1 & §4) :
+
+        - en amont des branches (id_Affaire tout juste saisi) : avance seule
+          vers la branche demandée ;
+        - déjà dans une branche : une correction de situation_entree bascule
+          latéralement vers l'autre branche (ni avancement, ni recul) ;
+        - en aval des branches (Validé sur SGE et au-delà) : aucun effet — on
+          ne recule jamais une carte déjà instruite côté Enedis.
+        """
+        branches = self._stages_branches_sge()
         for record in self:
-            if record.id_affaire and record.stage_id.sequence < stage.sequence:
-                record.with_context(raccordement_automove=True).stage_id = stage.id
+            if not record.id_affaire or not record.situation_entree:
+                continue
+            cible = record._stage_branche_cible()
+            if not cible or record.stage_id == cible:
+                continue
+            en_branche = record.stage_id in branches
+            en_amont = record.stage_id.sequence < cible.sequence
+            if en_branche or en_amont:
+                record.with_context(raccordement_automove=True).stage_id = cible.id
 
     def _create_odoo_entries(self):
         """Crée automatiquement les entrées Odoo (contact, banque, souscription)"""

--- a/models/raccordement/raccordement_demande.py
+++ b/models/raccordement/raccordement_demande.py
@@ -366,6 +366,11 @@ class RaccordementDemande(models.Model):
         if vals.get('id_affaire') and 'id_affaire_date_saisie' not in vals:
             vals = dict(vals, id_affaire_date_saisie=fields.Date.context_today(self))
 
+        # Stage avant écriture (#103) : seule une transition *effective* vers
+        # « Abonnement Validé » envoie le pack de bienvenue — une
+        # ré-écriture sans changement n'en envoie pas un second.
+        stage_avant = {r.id: r.stage_id.id for r in self} if 'stage_id' in vals else None
+
         res = super().write(vals)
 
         # Si on change l'étape
@@ -374,6 +379,17 @@ class RaccordementDemande(models.Model):
                 # Si on passe à l'étape finale et qu'on n'a pas encore créé les entrées
                 if record.stage_id.is_close and not record.souscription_id:
                     record._create_odoo_entries()
+
+            stage_abonnement_valide = self.env.ref(
+                'souscriptions_odoo.stage_abonnement_valide', raise_if_not_found=False
+            )
+            if stage_abonnement_valide:
+                for record in self:
+                    if (
+                        record.stage_id == stage_abonnement_valide
+                        and stage_avant.get(record.id) != stage_abonnement_valide.id
+                    ):
+                        record._envoyer_pack_bienvenue()
 
         # id_Affaire saisi ou situation_entree corrigée (#90/#100) : la carte
         # avance seule vers la branche ⏳ désignée, ou re-route latéralement
@@ -496,6 +512,33 @@ class RaccordementDemande(models.Model):
         template = self.env.ref(xmlid, raise_if_not_found=False) if xmlid else False
         if template:
             template.send_mail(self.id, force_send=False)
+
+    # Variante du pack de bienvenue (#103, ADR 0022 §6) par faits de la
+    # demande : PRO, sinon solidaire, sinon particulier.
+    _TEMPLATE_XMLID_BIENVENUE_PRO = 'souscriptions_odoo.mail_template_bienvenue_pro'
+    _TEMPLATE_XMLID_BIENVENUE_SOLIDAIRE = 'souscriptions_odoo.mail_template_bienvenue_solidaire'
+    _TEMPLATE_XMLID_BIENVENUE_PARTICULIER = 'souscriptions_odoo.mail_template_bienvenue_particulier'
+
+    def _envoyer_pack_bienvenue(self):
+        """Pack de bienvenue (#103, ADR 0022 §6) à l'entrée effective en
+        « Abonnement Validé » : conditions particulières complètes (RSC +
+        mensualités réelles) en pièce jointe (`report_template_ids` du
+        template, rendu pour la Souscription) + documents d'accueil
+        statiques configurables (`attachment_ids` du template). Variante
+        choisie par les faits de la demande ; no-op si la Souscription
+        n'existe pas (rien à joindre, rien à notifier)."""
+        self.ensure_one()
+        if not self.souscription_id:
+            return
+        if self.pro:
+            xmlid = self._TEMPLATE_XMLID_BIENVENUE_PRO
+        elif self.tarif_solidaire:
+            xmlid = self._TEMPLATE_XMLID_BIENVENUE_SOLIDAIRE
+        else:
+            xmlid = self._TEMPLATE_XMLID_BIENVENUE_PARTICULIER
+        template = self.env.ref(xmlid, raise_if_not_found=False)
+        if template:
+            template.send_mail(self.souscription_id.id, force_send=False)
 
     def _create_odoo_entries(self):
         """Crée automatiquement les entrées Odoo (contact, banque, souscription)"""

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -5,6 +5,7 @@ from . import (
     test_facturation,
     test_grille_prix,
     test_integration,
+    test_mails_raccordement,
     test_periode_composition,
     test_periode_energie,
     test_periode_facture,

--- a/tests/test_documents_contractuels.py
+++ b/tests/test_documents_contractuels.py
@@ -24,7 +24,7 @@ class TestCaptureConsentement(SouscriptionsTestMixin, TransactionCase):
     def setUpClass(cls):
         super().setUpClass()
         cls.setUpSouscriptionsData()
-        cls.stage_final = cls.env.ref('souscriptions_odoo.stage_souscrit')
+        cls.stage_final = cls.env.ref('souscriptions_odoo.stage_abonnement_valide')
 
     def _demande(self, **kwargs):
         defaults = {
@@ -313,7 +313,7 @@ class TestJournalConsentement(SouscriptionsTestMixin, TransactionCase):
                 'consent_conso_quotidienne': False,
             }
         )
-        demande.stage_id = self.env.ref('souscriptions_odoo.stage_souscrit')
+        demande.stage_id = self.env.ref('souscriptions_odoo.stage_abonnement_valide')
 
         souscription = demande.souscription_id
         self.assertEqual(souscription.etat_consentement('courbe_charge'), 'donne')

--- a/tests/test_documents_contractuels.py
+++ b/tests/test_documents_contractuels.py
@@ -24,7 +24,7 @@ class TestCaptureConsentement(SouscriptionsTestMixin, TransactionCase):
     def setUpClass(cls):
         super().setUpClass()
         cls.setUpSouscriptionsData()
-        cls.stage_final = cls.env.ref('souscriptions_odoo.stage_abonnement_valide')
+        cls.stage_final = cls.env.ref('souscriptions_odoo.stage_accepte_iban_verifie')
 
     def _demande(self, **kwargs):
         defaults = {
@@ -313,7 +313,7 @@ class TestJournalConsentement(SouscriptionsTestMixin, TransactionCase):
                 'consent_conso_quotidienne': False,
             }
         )
-        demande.stage_id = self.env.ref('souscriptions_odoo.stage_abonnement_valide')
+        demande.stage_id = self.env.ref('souscriptions_odoo.stage_accepte_iban_verifie')
 
         souscription = demande.souscription_id
         self.assertEqual(souscription.etat_consentement('courbe_charge'), 'donne')

--- a/tests/test_mails_raccordement.py
+++ b/tests/test_mails_raccordement.py
@@ -1,0 +1,89 @@
+"""Tests #102 — mails de rassurage F120/F130 à l'entrée des branches ⏳
+(ADR 0022 §6) : un template par branche, envoyé à l'entrée effective
+(initiale ou re-routée), jamais à un autre changement d'étape.
+
+Pas de nouvelle couture : assertion directe sur les `mail.mail` générés
+(`send_mail(force_send=False)` crée l'enregistrement sans tenter d'envoi
+SMTP), comme le reste de la suite raccordement.
+"""
+
+from datetime import date, timedelta
+
+from odoo.tests.common import TransactionCase, tagged
+
+from .common import SouscriptionsTestMixin
+
+
+@tagged('souscriptions', 'souscriptions_raccordement_mails', 'post_install', '-at_install')
+class TestMailsRassurageRaccordement(SouscriptionsTestMixin, TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.setUpSouscriptionsData()
+        cls.stage_nouveau = cls.env.ref('souscriptions_odoo.stage_nouveau')
+        cls.stage_pro_a_valider = cls.env.ref('souscriptions_odoo.stage_pro_a_valider')
+        cls.stage_f120_mes = cls.env.ref('souscriptions_odoo.stage_f120_mes')
+        cls.stage_f130_cfne = cls.env.ref('souscriptions_odoo.stage_f130_cfne')
+        cls.template_f120 = cls.env.ref('souscriptions_odoo.mail_template_raccordement_f120')
+        cls.template_f130 = cls.env.ref('souscriptions_odoo.mail_template_raccordement_f130')
+
+    def create_demande(self, email, **kwargs):
+        defaults = {
+            'pdl': 'PDL_MAIL_' + email,
+            'date_debut_souhaitee': date.today() + timedelta(days=30),
+            'puissance_souscrite': '6',
+            'type_tarif': 'base',
+            'provision_mensuelle_kwh': 250.0,
+            'contact_nom': 'Test',
+            'contact_email': email,
+            'contact_street': 'Test Street',
+            'contact_zip': '12345',
+            'contact_city': 'Test City',
+        }
+        defaults.update(kwargs)
+        return self.env['raccordement.demande'].create(defaults)
+
+    def _mails(self, demande):
+        return self.env['mail.mail'].search([('res_id', '=', demande.id), ('model', '=', 'raccordement.demande')])
+
+    def test_entree_f120_envoie_mail_rassurage(self):
+        demande = self.create_demande('mail-f120@example.com')
+        demande.write({'situation_entree': 'mes', 'id_affaire': 'AFF-MAIL-001'})
+
+        self.assertEqual(demande.stage_id, self.stage_f120_mes)
+        mails = self._mails(demande)
+        self.assertEqual(len(mails), 1)
+        self.assertEqual(mails.subject, self.template_f120.subject)
+        self.assertEqual(mails.email_to, demande.contact_email)
+
+    def test_entree_f130_envoie_mail_rassurage_template_distinct(self):
+        demande = self.create_demande('mail-f130@example.com')
+        demande.write({'situation_entree': 'cfne', 'id_affaire': 'AFF-MAIL-002'})
+
+        self.assertEqual(demande.stage_id, self.stage_f130_cfne)
+        mails = self._mails(demande)
+        self.assertEqual(len(mails), 1)
+        self.assertEqual(mails.subject, self.template_f130.subject)
+        self.assertNotEqual(self.template_f120.subject, self.template_f130.subject)
+
+    def test_reroute_f120_vers_f130_envoie_mail_de_la_branche_darrivee(self):
+        demande = self.create_demande('mail-reroute@example.com', situation_entree='mes', id_affaire='AFF-MAIL-003')
+        self.assertEqual(demande.stage_id, self.stage_f120_mes)
+        self.assertEqual(len(self._mails(demande)), 1)
+
+        demande.situation_entree = 'cfne'
+
+        self.assertEqual(demande.stage_id, self.stage_f130_cfne)
+        mails = self._mails(demande)
+        self.assertEqual(len(mails), 2, 'Le re-routage doit envoyer un second mail (celui de la nouvelle branche)')
+        self.assertEqual(mails.sorted('id')[-1].subject, self.template_f130.subject)
+
+    def test_autre_changement_detape_nenvoie_pas_de_rassurage(self):
+        """Un changement d'étape hors branche ⏳ (drag manuel classique)
+        n'envoie aucun rassurage."""
+        demande = self.create_demande('mail-aucun@example.com', pro=True, siret='12345678901234')
+        self.assertEqual(demande.stage_id, self.stage_pro_a_valider)
+
+        demande.stage_id = self.stage_nouveau
+
+        self.assertFalse(self._mails(demande))

--- a/tests/test_mails_raccordement.py
+++ b/tests/test_mails_raccordement.py
@@ -11,7 +11,7 @@ from datetime import date, timedelta
 
 from odoo.tests.common import TransactionCase, tagged
 
-from .common import SouscriptionsTestMixin
+from .common import SouscriptionsTestMixin, build_grille_lignes
 
 
 @tagged('souscriptions', 'souscriptions_raccordement_mails', 'post_install', '-at_install')
@@ -64,6 +64,7 @@ class TestMailsRassurageRaccordement(SouscriptionsTestMixin, TransactionCase):
         mails = self._mails(demande)
         self.assertEqual(len(mails), 1)
         self.assertEqual(mails.subject, self.template_f130.subject)
+        self.assertEqual(mails.email_to, demande.contact_email)
         self.assertNotEqual(self.template_f120.subject, self.template_f130.subject)
 
     def test_reroute_f120_vers_f130_envoie_mail_de_la_branche_darrivee(self):
@@ -76,7 +77,9 @@ class TestMailsRassurageRaccordement(SouscriptionsTestMixin, TransactionCase):
         self.assertEqual(demande.stage_id, self.stage_f130_cfne)
         mails = self._mails(demande)
         self.assertEqual(len(mails), 2, 'Le re-routage doit envoyer un second mail (celui de la nouvelle branche)')
-        self.assertEqual(mails.sorted('id')[-1].subject, self.template_f130.subject)
+        dernier = mails.sorted('id')[-1]
+        self.assertEqual(dernier.subject, self.template_f130.subject)
+        self.assertEqual(dernier.email_to, demande.contact_email)
 
     def test_autre_changement_detape_nenvoie_pas_de_rassurage(self):
         """Un changement d'étape hors branche ⏳ (drag manuel classique)
@@ -106,6 +109,20 @@ class TestPackBienvenueRaccordement(SouscriptionsTestMixin, TransactionCase):
         cls.template_particulier = cls.env.ref('souscriptions_odoo.mail_template_bienvenue_particulier')
         cls.template_pro = cls.env.ref('souscriptions_odoo.mail_template_bienvenue_pro')
         cls.template_solidaire = cls.env.ref('souscriptions_odoo.mail_template_bienvenue_solidaire')
+        # La CP jointe au pack se rend à la date de début de la Souscription
+        # (date_debut_souhaitee = aujourd'hui + 30 j) : grille ouverte à
+        # partir de 2025 pour couvrir cette date quel que soit le jour du
+        # run — la grille 2024 du mixin ne couvre que les fixtures
+        # historiques (pas de chevauchement).
+        grille_courante = cls.env['grille.prix'].create(
+            {
+                'name': 'Grille Test courante',
+                'date_debut': date(2025, 1, 1),
+                'date_fin': False,
+                'active': True,
+            }
+        )
+        build_grille_lignes(cls.env, grille_courante, prix_base=0.15, prix_hp=0.18, prix_hc=0.12)
 
     def create_demande(self, email, **kwargs):
         defaults = {
@@ -143,6 +160,7 @@ class TestPackBienvenueRaccordement(SouscriptionsTestMixin, TransactionCase):
         mails = self._mails(souscription)
         self.assertEqual(len(mails), 1)
         self.assertEqual(mails.subject, self.template_particulier.subject)
+        self.assertEqual(mails.recipient_ids, souscription.partner_id, 'Le pack part au contact de la demande')
         self.assertTrue(mails.attachment_ids, 'La CP devrait partir en pièce jointe (report_template_ids)')
 
     def test_variante_pro(self):

--- a/tests/test_mails_raccordement.py
+++ b/tests/test_mails_raccordement.py
@@ -87,3 +87,114 @@ class TestMailsRassurageRaccordement(SouscriptionsTestMixin, TransactionCase):
         demande.stage_id = self.stage_nouveau
 
         self.assertFalse(self._mails(demande))
+
+
+@tagged('souscriptions', 'souscriptions_raccordement_mails', 'post_install', '-at_install')
+class TestPackBienvenueRaccordement(SouscriptionsTestMixin, TransactionCase):
+    """Tests #103 — pack de bienvenue automatique à « Abonnement Validé »
+    (ADR 0022 §6) : conditions particulières complètes en pièce jointe
+    (report_template_ids, même report que le bouton manuel de la
+    Souscription — pas de nouvelle couture), documents d'accueil statiques
+    configurables, variante par les faits, pas de doublon."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.setUpSouscriptionsData()
+        cls.stage_accepte_iban_verifie = cls.env.ref('souscriptions_odoo.stage_accepte_iban_verifie')
+        cls.stage_abonnement_valide = cls.env.ref('souscriptions_odoo.stage_abonnement_valide')
+        cls.template_particulier = cls.env.ref('souscriptions_odoo.mail_template_bienvenue_particulier')
+        cls.template_pro = cls.env.ref('souscriptions_odoo.mail_template_bienvenue_pro')
+        cls.template_solidaire = cls.env.ref('souscriptions_odoo.mail_template_bienvenue_solidaire')
+
+    def create_demande(self, email, **kwargs):
+        defaults = {
+            'pdl': 'PDL_BIENVENUE_' + email,
+            'date_debut_souhaitee': date.today() + timedelta(days=30),
+            'puissance_souscrite': '6',
+            'type_tarif': 'base',
+            'provision_mensuelle_kwh': 250.0,
+            'contact_nom': 'Test',
+            'contact_email': email,
+            'contact_street': 'Test Street',
+            'contact_zip': '12345',
+            'contact_city': 'Test City',
+            'mode_paiement': 'virement',
+        }
+        defaults.update(kwargs)
+        return self.env['raccordement.demande'].create(defaults)
+
+    def _mails(self, souscription):
+        return self.env['mail.mail'].search(
+            [('res_id', '=', souscription.id), ('model', '=', 'souscription.souscription')]
+        )
+
+    def _accepter_et_valider(self, demande):
+        """Mène la demande jusqu'à « Abonnement Validé » (naissance à
+        l'acceptation, #101, puis clôture du kanban)."""
+        demande.stage_id = self.stage_accepte_iban_verifie
+        demande.stage_id = self.stage_abonnement_valide
+        return demande.souscription_id
+
+    def test_drag_en_abonnement_valide_envoie_pack_bienvenue_avec_cp_en_piece_jointe(self):
+        demande = self.create_demande('bienvenue-particulier@example.com')
+        souscription = self._accepter_et_valider(demande)
+
+        mails = self._mails(souscription)
+        self.assertEqual(len(mails), 1)
+        self.assertEqual(mails.subject, self.template_particulier.subject)
+        self.assertTrue(mails.attachment_ids, 'La CP devrait partir en pièce jointe (report_template_ids)')
+
+    def test_variante_pro(self):
+        demande = self.create_demande('bienvenue-pro@example.com', pro=True, siret='12345678901234', coeff_pro=5.0)
+        souscription = self._accepter_et_valider(demande)
+
+        mails = self._mails(souscription)
+        self.assertEqual(len(mails), 1)
+        self.assertIn('professionnel', mails.body_html)
+
+    def test_variante_solidaire(self):
+        demande = self.create_demande('bienvenue-solidaire@example.com', tarif_solidaire=True)
+        souscription = self._accepter_et_valider(demande)
+
+        mails = self._mails(souscription)
+        self.assertEqual(len(mails), 1)
+        self.assertIn('tarif solidaire', mails.body_html)
+
+    def test_variante_particulier_par_defaut(self):
+        demande = self.create_demande('bienvenue-defaut@example.com')
+        souscription = self._accepter_et_valider(demande)
+
+        mails = self._mails(souscription)
+        self.assertNotIn('professionnel', mails.body_html)
+        self.assertNotIn('tarif solidaire', mails.body_html)
+
+    def test_pas_de_doublon_si_reecriture_sans_changement(self):
+        demande = self.create_demande('bienvenue-nodup@example.com')
+        souscription = self._accepter_et_valider(demande)
+        self.assertEqual(len(self._mails(souscription)), 1)
+
+        # Ré-écriture de la même étape (resync, pas un vrai changement) :
+        # aucun second pack.
+        demande.stage_id = self.stage_abonnement_valide
+
+        self.assertEqual(len(self._mails(souscription)), 1)
+
+    def test_documents_accueil_statiques_partent_avec_le_mail(self):
+        """Les documents d'accueil statiques (attachment_ids du template)
+        sont configurables et partent avec le mail."""
+        piece_jointe = self.env['ir.attachment'].create(
+            {
+                'name': "Guide d'accueil EDN.pdf",
+                'datas': b'ZmFrZSBwZGYgY29udGVudA==',  # 'fake pdf content' en base64
+            }
+        )
+        self.template_particulier.attachment_ids = [(6, 0, [piece_jointe.id])]
+        self.addCleanup(lambda: self.template_particulier.write({'attachment_ids': [(5, 0, 0)]}))
+
+        demande = self.create_demande('bienvenue-doc@example.com')
+        souscription = self._accepter_et_valider(demande)
+
+        mails = self._mails(souscription)
+        noms = mails.attachment_ids.mapped('name')
+        self.assertIn("Guide d'accueil EDN.pdf", noms)

--- a/tests/test_poll_affaires_enedis.py
+++ b/tests/test_poll_affaires_enedis.py
@@ -44,24 +44,25 @@ class TestPollAffairesEnedis(SouscriptionsTestCase):
         return patch.object(_SERVICE, '_appeler', return_value=return_value, side_effect=side_effect)
 
     def create_demande_avec_souscription(self, id_affaire=None, email='poll-rsc@example.com'):
-        """Demande complète menée jusqu'à « Souscrit » : Souscription créée,
-        liée à sa demande via souscription_id."""
-        demande = self.env['raccordement.demande'].create(
-            {
-                'pdl': 'PDL_POLL_' + email,
-                'date_debut_souhaitee': date.today() + timedelta(days=30),
-                'puissance_souscrite': '6',
-                'type_tarif': 'base',
-                'provision_mensuelle_kwh': 250.0,
-                'contact_nom': 'Test',
-                'contact_email': email,
-                'contact_street': 'Test Street',
-                'contact_zip': '12345',
-                'contact_city': 'Test City',
-                'id_affaire': id_affaire,
-            }
-        )
-        demande.stage_id = self.env.ref('souscriptions_odoo.stage_souscrit')
+        """Demande complète menée jusqu'à « Abonnement Validé » : Souscription
+        créée, liée à sa demande via souscription_id."""
+        vals = {
+            'pdl': 'PDL_POLL_' + email,
+            'date_debut_souhaitee': date.today() + timedelta(days=30),
+            'puissance_souscrite': '6',
+            'type_tarif': 'base',
+            'provision_mensuelle_kwh': 250.0,
+            'contact_nom': 'Test',
+            'contact_email': email,
+            'contact_street': 'Test Street',
+            'contact_zip': '12345',
+            'contact_city': 'Test City',
+            'id_affaire': id_affaire,
+        }
+        if id_affaire:
+            vals['situation_entree'] = 'mes'
+        demande = self.env['raccordement.demande'].create(vals)
+        demande.stage_id = self.env.ref('souscriptions_odoo.stage_abonnement_valide')
         return demande
 
     # --- Ciblage du lot ---

--- a/tests/test_poll_affaires_enedis.py
+++ b/tests/test_poll_affaires_enedis.py
@@ -44,8 +44,9 @@ class TestPollAffairesEnedis(SouscriptionsTestCase):
         return patch.object(_SERVICE, '_appeler', return_value=return_value, side_effect=side_effect)
 
     def create_demande_avec_souscription(self, id_affaire=None, email='poll-rsc@example.com'):
-        """Demande complète menée jusqu'à « Abonnement Validé » : Souscription
-        créée, liée à sa demande via souscription_id."""
+        """Demande complète menée jusqu'à « Accepté et IBAN vérifié » (#101 —
+        naissance de la Souscription) : mode virement, pas de garde IBAN à
+        contourner, hors sujet de ces tests de poll RSC."""
         vals = {
             'pdl': 'PDL_POLL_' + email,
             'date_debut_souhaitee': date.today() + timedelta(days=30),
@@ -57,12 +58,13 @@ class TestPollAffairesEnedis(SouscriptionsTestCase):
             'contact_street': 'Test Street',
             'contact_zip': '12345',
             'contact_city': 'Test City',
+            'mode_paiement': 'virement',
             'id_affaire': id_affaire,
         }
         if id_affaire:
             vals['situation_entree'] = 'mes'
         demande = self.env['raccordement.demande'].create(vals)
-        demande.stage_id = self.env.ref('souscriptions_odoo.stage_abonnement_valide')
+        demande.stage_id = self.env.ref('souscriptions_odoo.stage_accepte_iban_verifie')
         return demande
 
     # --- Ciblage du lot ---

--- a/tests/test_pull_meta_periodes.py
+++ b/tests/test_pull_meta_periodes.py
@@ -13,7 +13,7 @@ Fixtures RSC/PDL : identifiants factices (jamais des vrais échantillons).
 
 import unittest
 from contextlib import contextmanager
-from datetime import date
+from datetime import date, timedelta
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
@@ -308,6 +308,37 @@ class TestWizardPullMetaPeriodes(SouscriptionsTestCase):
         wizard = self._lancer_avec_client(_fake_client([]))
         self.assertIn('Sans RSC (ignorées) :', wizard.resultat)
         self.assertNotIn('Sans RSC (ignorées) : 0', wizard.resultat)
+
+    def test_souscription_en_instance_nee_du_raccordement_hors_pull(self):
+        """#101 AC5 : une Souscription *en instance* (née à l'acceptation,
+        sans RSC) reste hors du pull — comportement du pull clé RSC/mois
+        (AC3 ci-dessus), asserté ici sur une Souscription née du
+        Raccordement plutôt que sur une fixture directe."""
+        demande = self.env['raccordement.demande'].create(
+            {
+                'pdl': 'PDL_RACC_HORS_PULL',
+                'date_debut_souhaitee': date.today() + timedelta(days=30),
+                'puissance_souscrite': '6',
+                'type_tarif': 'base',
+                'provision_mensuelle_kwh': 250.0,
+                'contact_nom': 'Test',
+                'contact_email': 'racc-hors-pull@example.com',
+                'contact_street': 'Test Street',
+                'contact_zip': '12345',
+                'contact_city': 'Test City',
+                'mode_paiement': 'virement',
+            }
+        )
+        demande.stage_id = self.env.ref('souscriptions_odoo.stage_accepte_iban_verifie')
+        souscription = demande.souscription_id
+        self.assertTrue(souscription, "La Souscription devrait naître à l'acceptation")
+        self.assertEqual(souscription.etat, 'en_instance')
+
+        wizard = self._lancer_avec_client(_fake_client([]))
+
+        self.assertIn(souscription.name, wizard.resultat)
+        periode = self.env['souscription.periode'].search([('souscription_id', '=', souscription.id)])
+        self.assertFalse(periode, 'Aucune période ne doit être amorcée pour une Souscription en instance')
 
     def test_releves_crees_avec_identifiant_externe_et_origine(self):
         """AC4 : relevés créés avec identifiant externe + origine."""

--- a/tests/test_raccordement.py
+++ b/tests/test_raccordement.py
@@ -486,10 +486,13 @@ class TestRaccordementWorkflow(SouscriptionsTestMixin, TransactionCase):
     @classmethod
     def setUpRaccordementData(cls):
         """Setup des données spécifiques aux tests de raccordement"""
-        # Utiliser les vraies étapes du module (#100 : chaîne cible prod).
+        # Utiliser les vraies étapes du module. La naissance de la
+        # Souscription (is_close) vit sur « Accepté et IBAN vérifié » (#101,
+        # ADR 0022 §2) ; stage_validated sert d'étape intermédiaire distincte
+        # pour le test de non-duplication (bounce non-finale).
         cls.stage_received = cls.env.ref('souscriptions_odoo.stage_nouveau')
-        cls.stage_validated = cls.env.ref('souscriptions_odoo.stage_accepte_iban_verifie')
-        cls.stage_final = cls.env.ref('souscriptions_odoo.stage_abonnement_valide')
+        cls.stage_validated = cls.env.ref('souscriptions_odoo.stage_calcul_mensualites')
+        cls.stage_final = cls.env.ref('souscriptions_odoo.stage_accepte_iban_verifie')
 
     def create_complete_demande(self, **kwargs):
         """Helper pour créer une demande complète"""

--- a/tests/test_raccordement.py
+++ b/tests/test_raccordement.py
@@ -486,10 +486,10 @@ class TestRaccordementWorkflow(SouscriptionsTestMixin, TransactionCase):
     @classmethod
     def setUpRaccordementData(cls):
         """Setup des données spécifiques aux tests de raccordement"""
-        # Utiliser les vraies étapes du module
-        cls.stage_received = cls.env.ref('souscriptions_odoo.stage_demande_recue')
-        cls.stage_validated = cls.env.ref('souscriptions_odoo.stage_iban_valide')
-        cls.stage_final = cls.env.ref('souscriptions_odoo.stage_souscrit')
+        # Utiliser les vraies étapes du module (#100 : chaîne cible prod).
+        cls.stage_received = cls.env.ref('souscriptions_odoo.stage_nouveau')
+        cls.stage_validated = cls.env.ref('souscriptions_odoo.stage_accepte_iban_verifie')
+        cls.stage_final = cls.env.ref('souscriptions_odoo.stage_abonnement_valide')
 
     def create_complete_demande(self, **kwargs):
         """Helper pour créer une demande complète"""
@@ -917,7 +917,7 @@ class TestRaccordementSecurity(SouscriptionsTestMixin, TransactionCase):
         )
 
         # Essayer de passer à l'étape IBAN validé avec un IBAN invalide
-        self.env.ref('souscriptions_odoo.stage_iban_valide')
+        self.env.ref('souscriptions_odoo.stage_accepte_iban_verifie')
 
         # L'onchange devrait générer un warning (pas d'exception)
         # On vérifie juste que l'IBAN est invalide

--- a/tests/test_raccordement_kanban_faits.py
+++ b/tests/test_raccordement_kanban_faits.py
@@ -63,10 +63,16 @@ class TestKanbanPiloteParLesFaits(SouscriptionsTestMixin, TransactionCase):
         self.assertTrue(self.stage_valide_sge.entree_factuelle)
 
     def test_stage_abonnement_valide_finale_repliee(self):
+        """La naissance (is_close) a migré vers « Accepté et IBAN vérifié »
+        (#101) : « Abonnement Validé » reste la terminale repliée, mais ne
+        crée plus rien."""
         self.assertGreater(self.stage_abonnement_valide.sequence, self.stage_valide_sge.sequence)
         self.assertTrue(self.stage_abonnement_valide.fold)
-        self.assertTrue(self.stage_abonnement_valide.is_close)
+        self.assertFalse(self.stage_abonnement_valide.is_close)
         self.assertFalse(self.stage_abonnement_valide.entree_factuelle)
+
+    def test_stage_accepte_iban_verifie_porte_la_naissance(self):
+        self.assertTrue(self.stage_accepte_iban_verifie.is_close)
 
     # --- Situation d'entrée requise à la saisie de l'id_Affaire ---
 
@@ -130,10 +136,12 @@ class TestKanbanPiloteParLesFaits(SouscriptionsTestMixin, TransactionCase):
         self.assertEqual(demande.stage_id, self.stage_calcul_mensualites)
 
     def test_drag_in_manuel_autorise_vers_etape_non_factuelle(self):
-        """Les étapes non pilotées par un fait restent librement draggables."""
+        """Les étapes non pilotées par un fait restent librement draggables
+        (hors « Accepté et IBAN vérifié », qui porte sa propre garde IBAN
+        depuis #101 — testée séparément plus bas)."""
         demande = self.create_demande('faits5@example.com')
-        demande.stage_id = self.stage_accepte_iban_verifie
-        self.assertEqual(demande.stage_id, self.stage_accepte_iban_verifie)
+        demande.stage_id = self.stage_calcul_mensualites
+        self.assertEqual(demande.stage_id, self.stage_calcul_mensualites)
 
     def test_contournement_de_contexte_reserve_aux_automatismes(self):
         demande = self.create_demande('faits6@example.com')
@@ -242,12 +250,80 @@ class TestKanbanPiloteParLesFaits(SouscriptionsTestMixin, TransactionCase):
         souscription.write({'ref_situation_contractuelle': 'RSC-MANUEL'})
         self.assertEqual(souscription.etat, 'en_service')
 
-    # --- Non-régression : « Abonnement Validé » garde son rôle de création ---
-    # (état intérimaire #100 — le déplacement vers « Accepté et IBAN vérifié »
-    # est la tranche #101.)
+    # --- Naissance à l'acceptation (#101, ADR 0022 §2) : la création migre
+    # de « Abonnement Validé » vers « Accepté et IBAN vérifié ». ---
 
-    def test_abonnement_valide_garde_son_role_de_creation(self):
+    def test_naissance_a_laccepte_iban_verifie(self):
         demande = self.create_demande('faits10@example.com', mode_paiement='virement')
-        demande.stage_id = self.stage_abonnement_valide
+        demande.stage_id = self.stage_accepte_iban_verifie
         self.assertTrue(demande.souscription_id)
         self.assertTrue(demande.partner_id)
+
+    def test_abonnement_valide_ne_cree_plus_rien(self):
+        """« Abonnement Validé » ne porte plus le rôle de création (#101) :
+        un drag direct vers cette étape sans être passé par l'acceptation ne
+        crée aucune entrée Odoo."""
+        demande = self.create_demande('faits10b@example.com', mode_paiement='virement')
+        demande.stage_id = self.stage_abonnement_valide
+        self.assertFalse(demande.souscription_id)
+        self.assertFalse(demande.partner_id)
+
+    # --- Garde bloquante IBAN à l'acceptation (#101) ---
+
+    def test_acceptation_refusee_si_prelevement_et_iban_invalide(self):
+        demande = self.create_demande(
+            'faits_iban1@example.com', mode_paiement='prelevement', bank_iban='FR1420041010050500013M02607'
+        )
+        self.assertFalse(demande.iban_valide)
+        with self.assertRaises(UserError) as cm:
+            demande.stage_id = self.stage_accepte_iban_verifie
+        self.assertIn('IBAN', str(cm.exception))
+        self.assertFalse(demande.souscription_id)
+
+    def test_acceptation_autorisee_si_prelevement_et_iban_valide(self):
+        demande = self.create_demande(
+            'faits_iban2@example.com', mode_paiement='prelevement', bank_iban='FR1420041010050500013M02606'
+        )
+        demande.stage_id = self.stage_accepte_iban_verifie
+        self.assertTrue(demande.souscription_id)
+
+    def test_acceptation_autorisee_hors_prelevement_meme_sans_iban(self):
+        demande = self.create_demande('faits_iban3@example.com', mode_paiement='virement', bank_iban='')
+        demande.stage_id = self.stage_accepte_iban_verifie
+        self.assertTrue(demande.souscription_id)
+
+    # --- coeff_pro recopié à la naissance (#101, ADR 0022 §7) ---
+
+    def test_coeff_pro_recopie_sur_la_souscription_nee(self):
+        demande = self.create_demande(
+            'faits_coeffpro@example.com', mode_paiement='virement', pro=True, siret='12345678901234', coeff_pro=12.5
+        )
+        demande.stage_id = self.stage_accepte_iban_verifie
+        self.assertEqual(demande.souscription_id.coeff_pro, 12.5)
+
+    # --- Write-through id_Affaire post-naissance (#101, ADR 0022 §2) ---
+
+    def test_id_affaire_saisi_apres_naissance_se_propage_a_la_souscription(self):
+        demande = self.create_demande('faits_wt1@example.com', mode_paiement='virement')
+        demande.stage_id = self.stage_accepte_iban_verifie
+        souscription = demande.souscription_id
+        self.assertFalse(souscription.id_affaire)
+
+        demande.write({'situation_entree': 'mes', 'id_affaire': 'AFF-WT-001'})
+
+        self.assertEqual(souscription.id_affaire, 'AFF-WT-001')
+        self.assertEqual(souscription.id_affaire_date_saisie, demande.id_affaire_date_saisie)
+
+    def test_id_affaire_corrige_apres_naissance_se_propage_avec_sa_date(self):
+        demande = self.create_demande(
+            'faits_wt2@example.com', mode_paiement='virement', situation_entree='mes', id_affaire='AFF-WT-002'
+        )
+        demande.stage_id = self.stage_accepte_iban_verifie
+        souscription = demande.souscription_id
+        self.assertEqual(souscription.id_affaire, 'AFF-WT-002')
+
+        hier = date.today() - timedelta(days=1)
+        demande.write({'id_affaire': 'AFF-WT-002-CORRIGE', 'id_affaire_date_saisie': hier})
+
+        self.assertEqual(souscription.id_affaire, 'AFF-WT-002-CORRIGE')
+        self.assertEqual(souscription.id_affaire_date_saisie, hier)

--- a/tests/test_raccordement_kanban_faits.py
+++ b/tests/test_raccordement_kanban_faits.py
@@ -1,7 +1,10 @@
-"""Tests #90 — kanban de raccordement piloté par les faits (ADR 0021 §5) :
-auto-move à la saisie de l'id_Affaire et à l'acquisition de la RSC, drag-in
-manuel interdit sur ces deux étapes factuelles, pas de recul, non-régression
-de la création à « Souscrit »."""
+"""Tests #90/#100 — kanban de raccordement piloté par les faits (ADR 0021 §5,
+ADR 0022 §1/§4) : routage à la création (PRO/particulier), situation d'entrée
+requise à la saisie de l'id_Affaire, auto-move vers la branche ⏳ désignée,
+re-routage latéral d'une branche à l'autre à la correction de la situation
+d'entrée, reciblage de l'auto-move RSC vers « Validé sur SGE », drag-in manuel
+interdit sur les étapes factuelles, pas de recul, non-régression de la
+création à « Abonnement Validé »."""
 
 from datetime import date, timedelta
 
@@ -17,11 +20,14 @@ class TestKanbanPiloteParLesFaits(SouscriptionsTestMixin, TransactionCase):
     def setUpClass(cls):
         super().setUpClass()
         cls.setUpSouscriptionsData()
-        cls.stage_recue = cls.env.ref('souscriptions_odoo.stage_demande_recue')
-        cls.stage_iban = cls.env.ref('souscriptions_odoo.stage_iban_valide')
-        cls.stage_demande_sge = cls.env.ref('souscriptions_odoo.stage_demande_sge')
-        cls.stage_souscrit = cls.env.ref('souscriptions_odoo.stage_souscrit')
-        cls.stage_en_service = cls.env.ref('souscriptions_odoo.stage_en_service')
+        cls.stage_nouveau = cls.env.ref('souscriptions_odoo.stage_nouveau')
+        cls.stage_pro_a_valider = cls.env.ref('souscriptions_odoo.stage_pro_a_valider')
+        cls.stage_accepte_iban_verifie = cls.env.ref('souscriptions_odoo.stage_accepte_iban_verifie')
+        cls.stage_f120_mes = cls.env.ref('souscriptions_odoo.stage_f120_mes')
+        cls.stage_f130_cfne = cls.env.ref('souscriptions_odoo.stage_f130_cfne')
+        cls.stage_valide_sge = cls.env.ref('souscriptions_odoo.stage_valide_sge')
+        cls.stage_calcul_mensualites = cls.env.ref('souscriptions_odoo.stage_calcul_mensualites')
+        cls.stage_abonnement_valide = cls.env.ref('souscriptions_odoo.stage_abonnement_valide')
 
     def create_demande(self, email, **kwargs):
         defaults = {
@@ -39,107 +45,187 @@ class TestKanbanPiloteParLesFaits(SouscriptionsTestMixin, TransactionCase):
         defaults.update(kwargs)
         return self.env['raccordement.demande'].create(defaults)
 
-    # --- Stage « En service » : nouvelle étape ---
+    # --- Routage à la création (#100, ADR 0022 §1) ---
 
-    def test_stage_en_service_finale_repliee_sans_role_de_creation(self):
-        self.assertGreater(self.stage_en_service.sequence, self.stage_souscrit.sequence)
-        self.assertTrue(self.stage_en_service.fold)
-        self.assertFalse(self.stage_en_service.is_close)
-        self.assertTrue(self.stage_en_service.entree_factuelle)
-        self.assertTrue(self.stage_demande_sge.entree_factuelle)
+    def test_routage_creation_particulier_vers_nouveau(self):
+        demande = self.create_demande('routage1@example.com')
+        self.assertEqual(demande.stage_id, self.stage_nouveau)
 
-    # --- Auto-move : id_Affaire -> Demande SGE faite ---
+    def test_routage_creation_pro_vers_pro_a_valider(self):
+        demande = self.create_demande('routage2@example.com', pro=True, siret='12345678901234')
+        self.assertEqual(demande.stage_id, self.stage_pro_a_valider)
 
-    def test_auto_move_a_la_saisie_id_affaire(self):
+    # --- Nature des étapes ---
+
+    def test_branches_sge_et_valide_sge_sont_factuelles(self):
+        self.assertTrue(self.stage_f120_mes.entree_factuelle)
+        self.assertTrue(self.stage_f130_cfne.entree_factuelle)
+        self.assertTrue(self.stage_valide_sge.entree_factuelle)
+
+    def test_stage_abonnement_valide_finale_repliee(self):
+        self.assertGreater(self.stage_abonnement_valide.sequence, self.stage_valide_sge.sequence)
+        self.assertTrue(self.stage_abonnement_valide.fold)
+        self.assertTrue(self.stage_abonnement_valide.is_close)
+        self.assertFalse(self.stage_abonnement_valide.entree_factuelle)
+
+    # --- Situation d'entrée requise à la saisie de l'id_Affaire ---
+
+    def test_id_affaire_sans_situation_entree_refuse_a_la_creation(self):
+        with self.assertRaises(UserError) as cm:
+            self.create_demande('faits_refus1@example.com', id_affaire='38233180')
+        self.assertIn("situation d'entrée", str(cm.exception).lower())
+
+    def test_id_affaire_sans_situation_entree_refuse_en_ecriture(self):
+        demande = self.create_demande('faits_refus2@example.com')
+        with self.assertRaises(UserError) as cm:
+            demande.id_affaire = '38233180'
+        self.assertIn("situation d'entrée", str(cm.exception).lower())
+
+    # --- Auto-move : id_Affaire + situation_entree -> branche ⏳ ---
+
+    def test_auto_move_vers_f120_mes(self):
         demande = self.create_demande('faits1@example.com')
-        self.assertEqual(demande.stage_id, self.stage_recue)
+        self.assertEqual(demande.stage_id, self.stage_nouveau)
 
-        demande.id_affaire = '38233180'
+        demande.write({'situation_entree': 'mes', 'id_affaire': '38233180'})
 
-        self.assertEqual(demande.stage_id, self.stage_demande_sge)
+        self.assertEqual(demande.stage_id, self.stage_f120_mes)
+
+    def test_auto_move_vers_f130_cfne(self):
+        demande = self.create_demande('faits1b@example.com')
+
+        demande.write({'situation_entree': 'cfne', 'id_affaire': '38233181'})
+
+        self.assertEqual(demande.stage_id, self.stage_f130_cfne)
 
     def test_auto_move_id_affaire_ne_recule_pas(self):
-        """Une demande déjà en aval (Souscrit) ne recule jamais vers
-        « Demande SGE faite » quand l'id_Affaire est (re)saisi."""
+        """Une demande déjà en aval (Abonnement Validé) ne recule jamais vers
+        une branche ⏳ quand l'id_Affaire est (re)saisi."""
         demande = self.create_demande(
             'faits2@example.com',
             mode_paiement='virement',
         )
-        demande.stage_id = self.stage_souscrit
-        self.assertEqual(demande.stage_id, self.stage_souscrit)
+        demande.stage_id = self.stage_abonnement_valide
+        self.assertEqual(demande.stage_id, self.stage_abonnement_valide)
 
-        demande.id_affaire = '38233181'
+        demande.write({'situation_entree': 'mes', 'id_affaire': '38233182'})
 
-        self.assertEqual(demande.stage_id, self.stage_souscrit)
+        self.assertEqual(demande.stage_id, self.stage_abonnement_valide)
 
     # --- Drag-in manuel interdit ---
 
-    def test_drag_in_manuel_refuse_vers_demande_sge(self):
+    def test_drag_in_manuel_refuse_vers_f120_mes(self):
         demande = self.create_demande('faits3@example.com')
         with self.assertRaises(UserError) as cm:
-            demande.stage_id = self.stage_demande_sge
+            demande.stage_id = self.stage_f120_mes
         self.assertIn('pilotée par un fait', str(cm.exception))
-        self.assertEqual(demande.stage_id, self.stage_recue)
+        self.assertEqual(demande.stage_id, self.stage_nouveau)
 
-    def test_drag_in_manuel_refuse_vers_en_service(self):
+    def test_drag_in_manuel_refuse_vers_valide_sge(self):
         demande = self.create_demande('faits4@example.com', mode_paiement='virement')
-        demande.stage_id = self.stage_souscrit
+        demande.stage_id = self.stage_calcul_mensualites
         with self.assertRaises(UserError) as cm:
-            demande.stage_id = self.stage_en_service
+            demande.stage_id = self.stage_valide_sge
         self.assertIn('pilotée par un fait', str(cm.exception))
-        self.assertEqual(demande.stage_id, self.stage_souscrit)
+        self.assertEqual(demande.stage_id, self.stage_calcul_mensualites)
 
     def test_drag_in_manuel_autorise_vers_etape_non_factuelle(self):
         """Les étapes non pilotées par un fait restent librement draggables."""
         demande = self.create_demande('faits5@example.com')
-        demande.stage_id = self.stage_iban
-        self.assertEqual(demande.stage_id, self.stage_iban)
+        demande.stage_id = self.stage_accepte_iban_verifie
+        self.assertEqual(demande.stage_id, self.stage_accepte_iban_verifie)
 
     def test_contournement_de_contexte_reserve_aux_automatismes(self):
         demande = self.create_demande('faits6@example.com')
-        demande.with_context(raccordement_automove=True).stage_id = self.stage_demande_sge
-        self.assertEqual(demande.stage_id, self.stage_demande_sge)
+        demande.with_context(raccordement_automove=True).stage_id = self.stage_f120_mes
+        self.assertEqual(demande.stage_id, self.stage_f120_mes)
 
-    # --- Auto-move : RSC acquise -> En service ---
+    # --- Re-routage latéral F120 <-> F130 (correction de situation_entree) ---
 
-    def test_auto_move_en_service_a_la_rsc_manuelle(self):
-        demande = self.create_demande('faits7@example.com', mode_paiement='virement', id_affaire='38233182')
-        demande.stage_id = self.stage_souscrit
+    def test_correction_situation_entree_reroute_de_f120_vers_f130(self):
+        demande = self.create_demande('faits_reroute1@example.com', situation_entree='mes', id_affaire='38233190')
+        self.assertEqual(demande.stage_id, self.stage_f120_mes)
+
+        demande.situation_entree = 'cfne'
+
+        self.assertEqual(demande.stage_id, self.stage_f130_cfne)
+
+    def test_correction_situation_entree_reroute_de_f130_vers_f120(self):
+        demande = self.create_demande('faits_reroute2@example.com', situation_entree='cfne', id_affaire='38233191')
+        self.assertEqual(demande.stage_id, self.stage_f130_cfne)
+
+        demande.situation_entree = 'mes'
+
+        self.assertEqual(demande.stage_id, self.stage_f120_mes)
+
+    def test_correction_situation_entree_ne_fait_jamais_reculer_une_carte_en_aval(self):
+        demande = self.create_demande(
+            'faits_reroute3@example.com', mode_paiement='virement', situation_entree='mes', id_affaire='38233192'
+        )
+        self.assertEqual(demande.stage_id, self.stage_f120_mes)
+        # Simule l'avancement à « Validé sur SGE » (poll RSC déjà couvert
+        # plus bas) : contournement de contexte réservé aux automatismes,
+        # étape factuelle.
+        demande.with_context(raccordement_automove=True).stage_id = self.stage_valide_sge
+
+        demande.situation_entree = 'cfne'
+
+        self.assertEqual(demande.stage_id, self.stage_valide_sge)
+
+    # --- Auto-move : RSC acquise -> Validé sur SGE (reciblage #100) ---
+
+    # Ces trois tests exercent l'automove RSC -> Validé sur SGE isolément :
+    # les entrées Odoo sont créées directement (`_create_odoo_entries`, déjà
+    # couvert par les tests de création plus haut) pour lier la Souscription
+    # à sa demande sans déplacer la carte — la demande reste en amont de
+    # « Validé sur SGE » (état intérimaire #100 : la naissance normale
+    # n'intervient qu'à la toute dernière étape, cf. #101).
+
+    def test_auto_move_valide_sge_a_la_rsc_manuelle(self):
+        demande = self.create_demande(
+            'faits7@example.com', mode_paiement='virement', situation_entree='mes', id_affaire='38233182'
+        )
+        self.assertEqual(demande.stage_id, self.stage_f120_mes)
+        demande._create_odoo_entries()
         souscription = demande.souscription_id
         self.assertTrue(souscription)
         self.assertEqual(souscription.id_affaire, '38233182')
 
         souscription.write({'ref_situation_contractuelle': 'RSC-9001'})  # gestionnaire (superuser en test)
 
-        self.assertEqual(demande.stage_id, self.stage_en_service)
+        self.assertEqual(demande.stage_id, self.stage_valide_sge)
         messages = demande.message_ids.mapped('body')
-        self.assertTrue(any('En service' in body for body in messages))
+        self.assertTrue(any('Validé sur SGE' in body for body in messages))
 
-    def test_auto_move_en_service_a_la_rsc_du_poll(self):
+    def test_auto_move_valide_sge_a_la_rsc_du_poll(self):
         """L'automatisme s'accroche au fait, pas au canal : une RSC écrite
         via le contournement `rsc_automatisme` (poll #89) avance la carte
         exactement comme une écriture manuelle."""
-        demande = self.create_demande('faits8@example.com', mode_paiement='virement', id_affaire='38233183')
-        demande.stage_id = self.stage_souscrit
+        demande = self.create_demande(
+            'faits8@example.com', mode_paiement='virement', situation_entree='mes', id_affaire='38233183'
+        )
+        demande._create_odoo_entries()
         souscription = demande.souscription_id
 
         souscription.with_context(rsc_automatisme=True).write({'ref_situation_contractuelle': 'RSC-9002'})
 
-        self.assertEqual(demande.stage_id, self.stage_en_service)
+        self.assertEqual(demande.stage_id, self.stage_valide_sge)
 
-    def test_auto_move_en_service_ne_recule_jamais(self):
+    def test_auto_move_valide_sge_ne_recule_jamais(self):
         """Une nouvelle résolution RSC (re-résolution) sur une demande déjà
-        « En service » ne provoque ni erreur ni recul."""
-        demande = self.create_demande('faits9@example.com', mode_paiement='virement', id_affaire='38233184')
-        demande.stage_id = self.stage_souscrit
+        « Validé sur SGE » ne provoque ni erreur ni recul."""
+        demande = self.create_demande(
+            'faits9@example.com', mode_paiement='virement', situation_entree='mes', id_affaire='38233184'
+        )
+        demande._create_odoo_entries()
         souscription = demande.souscription_id
         souscription.write({'ref_situation_contractuelle': 'RSC-9003'})
-        self.assertEqual(demande.stage_id, self.stage_en_service)
+        self.assertEqual(demande.stage_id, self.stage_valide_sge)
 
         # Ré-écriture (même valeur) : no-op côté auto-move (pas de nouvelle
-        # trace, la demande reste en service).
+        # trace, la demande reste à Validé sur SGE).
         souscription.write({'ref_situation_contractuelle': 'RSC-9003'})
-        self.assertEqual(demande.stage_id, self.stage_en_service)
+        self.assertEqual(demande.stage_id, self.stage_valide_sge)
 
     def test_souscription_sans_demande_liee_ne_leve_pas_derreur(self):
         """Une Souscription sans demande (saisie manuelle) : la RSC s'écrit
@@ -156,10 +242,12 @@ class TestKanbanPiloteParLesFaits(SouscriptionsTestMixin, TransactionCase):
         souscription.write({'ref_situation_contractuelle': 'RSC-MANUEL'})
         self.assertEqual(souscription.etat, 'en_service')
 
-    # --- Non-régression : « Souscrit » garde son rôle de création ---
+    # --- Non-régression : « Abonnement Validé » garde son rôle de création ---
+    # (état intérimaire #100 — le déplacement vers « Accepté et IBAN vérifié »
+    # est la tranche #101.)
 
-    def test_souscrit_garde_son_role_de_creation(self):
+    def test_abonnement_valide_garde_son_role_de_creation(self):
         demande = self.create_demande('faits10@example.com', mode_paiement='virement')
-        demande.stage_id = self.stage_souscrit
+        demande.stage_id = self.stage_abonnement_valide
         self.assertTrue(demande.souscription_id)
         self.assertTrue(demande.partner_id)

--- a/tests/test_souscription_etat.py
+++ b/tests/test_souscription_etat.py
@@ -30,9 +30,12 @@ class TestIdAffaireRaccordement(SouscriptionsTestCase):
             'contact_street': 'Test Street',
             'contact_zip': '12345',
             'contact_city': 'Test City',
-            # Situation d'entrée requise à la saisie de l'id_Affaire (#100),
-            # hors sujet de ces tests (capture/recopie de l'id_Affaire).
+            # Hors sujet de ces tests (capture/recopie de l'id_Affaire) :
+            # situation d'entrée posée (#100, requise à la saisie de
+            # l'id_Affaire) et mode virement (#101, pas de garde IBAN à
+            # contourner).
             'situation_entree': 'mes',
+            'mode_paiement': 'virement',
         }
         defaults.update(kwargs)
         return self.env['raccordement.demande'].create(defaults)
@@ -60,7 +63,7 @@ class TestIdAffaireRaccordement(SouscriptionsTestCase):
         hier = date.today() - timedelta(days=2)
         demande.write({'id_affaire': '38233180', 'id_affaire_date_saisie': hier})
 
-        stage_final = self.env.ref('souscriptions_odoo.stage_abonnement_valide')
+        stage_final = self.env.ref('souscriptions_odoo.stage_accepte_iban_verifie')
         demande.stage_id = stage_final
 
         souscription = demande.souscription_id

--- a/tests/test_souscription_etat.py
+++ b/tests/test_souscription_etat.py
@@ -30,6 +30,9 @@ class TestIdAffaireRaccordement(SouscriptionsTestCase):
             'contact_street': 'Test Street',
             'contact_zip': '12345',
             'contact_city': 'Test City',
+            # Situation d'entrée requise à la saisie de l'id_Affaire (#100),
+            # hors sujet de ces tests (capture/recopie de l'id_Affaire).
+            'situation_entree': 'mes',
         }
         defaults.update(kwargs)
         return self.env['raccordement.demande'].create(defaults)
@@ -57,7 +60,7 @@ class TestIdAffaireRaccordement(SouscriptionsTestCase):
         hier = date.today() - timedelta(days=2)
         demande.write({'id_affaire': '38233180', 'id_affaire_date_saisie': hier})
 
-        stage_final = self.env.ref('souscriptions_odoo.stage_souscrit')
+        stage_final = self.env.ref('souscriptions_odoo.stage_abonnement_valide')
         demande.stage_id = stage_final
 
         souscription = demande.souscription_id

--- a/views/raccordement/raccordement_demande_views.xml
+++ b/views/raccordement/raccordement_demande_views.xml
@@ -38,6 +38,7 @@
                             <field name="mode_paiement" />
                         </group>
                         <group name="dates_suivi" string="Suivi">
+                            <field name="situation_entree" />
                             <field name="date_demande_sge" />
                             <field name="date_demande_mesures" />
                             <field name="date_estimation" />

--- a/views/raccordement/raccordement_demande_views.xml
+++ b/views/raccordement/raccordement_demande_views.xml
@@ -30,6 +30,7 @@
                         <group name="souscription_info" string="Informations Souscription">
                             <field name="pro" />
                             <field name="siret" invisible="pro == False" />
+                            <field name="coeff_pro" invisible="pro == False" />
                             <field name="pdl" />
                             <field name="date_debut_souhaitee" />
                             <field name="puissance_souscrite" />


### PR DESCRIPTION
Closes #100
Closes #101
Closes #102
Closes #103

Aligne le raccordement sur la chaîne prod (ADR 0022) : 8 étapes cibles avec routage PRO/situation d'entrée, naissance de la Souscription avancée à l'acceptation (garde IBAN bloquante, coeff_pro, write-through de l'id_Affaire), et les deux mails automatiques qui manquaient encore (rassurage F120/F130 à l'entrée des branches ⏳, pack de bienvenue complet à « Abonnement Validé »). Pas de migration : le module n'existe pas en prod, data/démo/tests réécrits dans la même PR.

- **#100 — chaîne kanban** : `data/raccordement_stages.xml` refondu (8 étapes, trichotomie 🔴/⏳/✓), routage à la création, champ `situation_entree`, auto-move vers la bonne branche (et re-routage latéral sans jamais reculer), RSC reciblée vers « Validé sur SGE », heuristique de nom obsolète retirée.
- **#101 — naissance à l'acceptation** : `is_close` déplacé sur « Accepté et IBAN vérifié », garde IBAN bloquante, `coeff_pro` recopié, write-through `id_Affaire` post-naissance, exclusion du pull assertée.
- **#102 — mails de rassurage** : F120/F130 à l'entrée effective des branches ⏳, y compris au re-routage.
- **#103 — pack de bienvenue** : automatique à « Abonnement Validé » (CP en pièce jointe via `report_template_ids`, variantes particulier/pro/solidaire, documents d'accueil configurables, garde anti-doublon).

Piège Odoo 19 rencontré : `mail.template.use_default_to` vaut True par défaut et ignore silencieusement `email_to`/`partner_to` — posé explicitement à False sur les 5 templates.

Suite Docker Odoo 19 : `0 failed, 0 error(s) of 289 tests`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
