### PR TITLE
fix(grille): retire tracking=True inerte sur regime_prix

### DIFF
--- a/models/core/grille_prix.py
+++ b/models/core/grille_prix.py
@@ -37,7 +37,6 @@ class GrillePrix(models.Model):
         string='Régime de prix',
         default='standard',
         required=True,
-        tracking=True,
         help='Barème appliqué par cette grille. Chaque régime versionne ses '
         'grilles indépendamment : une grille Moulin ouverte coexiste avec une '
         'grille standard ouverte (anti-chevauchement et fermeture automatique '


### PR DESCRIPTION
grille.prix n'hérite pas de `mail.thread` : le `tracking=True` posé sur `regime_prix` (#116) était ignoré par l'ORM et produisait un WARNING `unknown parameter 'tracking'` à chaque chargement du registre.

Suppression du paramètre — aucun changement fonctionnel, le champ n'a jamais été tracké. Vérifié : `-u souscriptions_odoo` charge sans warning ni erreur.

🤖 Generated with [Claude Code](https://claude.com/claude-code)