### PR TITLE
feat(periode): Périodes d'ouverture backfillées liées à des factures legacy

### DIFF
--- a/demo/souscriptions_demo.xml
+++ b/demo/souscriptions_demo.xml
@@ -200,6 +200,61 @@
         </record>
 
         <!-- ================================ -->
+        <!-- PÉRIODES D'OUVERTURE (BACKFILL MIGRATION — #107, ADR 0023 §3) -->
+        <!-- ================================ -->
+        <!-- Client migré depuis la prod (Odoo 17) : contrat lissé dont les mois
+             antérieurs à la bascule ne sont pas régularisés. Démontre le
+             backfill : les Périodes d'ouverture portent le facturé prod
+             (provision, jours) et référencent une facture LEGACY plutôt qu'un
+             account.move (ADR 0004/0023) — aucune facture n'est créée dans ce
+             système pour ces mois. -->
+        <record id="demo_client_migre_lisse" model="res.partner">
+            <field name="name">Amélie Rousseau</field>
+            <field name="is_company">False</field>
+            <field name="street">27 rue de la Bascule</field>
+            <field name="city">Nantes</field>
+            <field name="zip">44100</field>
+            <field name="country_id" ref="base.fr"/>
+            <field name="email">amelie.rousseau@email.fr</field>
+        </record>
+
+        <record id="demo_souscription_migree_lissee" model="souscription.souscription">
+            <field name="partner_id" ref="demo_client_migre_lisse"/>
+            <field name="pdl">PDL22516914077777</field>
+            <field name="puissance_souscrite">9</field>
+            <field name="type_tarif">hphc</field>
+            <field name="date_debut">2022-10-01</field>
+            <field name="provision_hp_kwh">210</field>
+            <field name="provision_hc_kwh">130</field>
+            <field name="lisse">True</field>
+            <field name="mode_paiement">prelevement</field>
+            <field name="etat_facturation_id" ref="etat_a_facturer"/>
+            <field name="ref_compteur">85445566</field>
+        </record>
+
+        <!-- Novembre et décembre 2023 : mois non régularisés au moment de la
+             bascule, backfillés depuis la facture legacy correspondante. -->
+        <record id="demo_periode_ouverture_novembre_2023" model="souscription.periode">
+            <field name="souscription_id" ref="demo_souscription_migree_lissee"/>
+            <field name="date_debut">2023-11-01</field>
+            <field name="date_fin">2023-12-01</field>
+            <field name="type_periode">mensuelle</field>
+            <field name="provision_hp_kwh">210</field>
+            <field name="provision_hc_kwh">130</field>
+            <field name="facture_legacy_ref">FACT-PROD-2023-11-004521</field>
+        </record>
+
+        <record id="demo_periode_ouverture_decembre_2023" model="souscription.periode">
+            <field name="souscription_id" ref="demo_souscription_migree_lissee"/>
+            <field name="date_debut">2023-12-01</field>
+            <field name="date_fin">2024-01-01</field>
+            <field name="type_periode">mensuelle</field>
+            <field name="provision_hp_kwh">210</field>
+            <field name="provision_hc_kwh">130</field>
+            <field name="facture_legacy_ref">FACT-PROD-2023-12-004890</field>
+        </record>
+
+        <!-- ================================ -->
         <!-- PÉRIODES ADMIN (PORTAL TESTING) -->
         <!-- ================================ -->
 

--- a/models/core/souscription.py
+++ b/models/core/souscription.py
@@ -567,6 +567,11 @@ class Souscription(models.Model):
         facture (garde anti-doublon) et délègue l'émission à la période
         (``periode._creer_facture``). La composition des lignes et la création du
         ``account.move`` vivent désormais sur la Période (ADR 0006).
+
+        Une Période d'ouverture (#107) est déjà facturée côté legacy
+        (``facture_legacy_ref``) même si elle n'a pas de ``facture_id`` (pas de
+        move dans ce système) : l'anti-doublon l'exclut aussi, pour ne jamais
+        émettre une seconde facture sur un mois déjà réglé en prod.
         """
         _logger.info(f'Créer factures appelé pour {len(self)} souscriptions')
 
@@ -576,7 +581,8 @@ class Souscription(models.Model):
                 continue
 
             premiere_facture = self.env['account.move']
-            for periode in souscription.periode_ids.filtered(lambda p: not p.facture_id):
+            a_facturer = souscription.periode_ids.filtered(lambda p: not p.facture_id and not p.facture_legacy_ref)
+            for periode in a_facturer:
                 try:
                     facture = periode._creer_facture()
                     premiere_facture = premiere_facture or facture

--- a/models/core/souscription_periode.py
+++ b/models/core/souscription_periode.py
@@ -204,6 +204,21 @@ class SouscriptionPeriode(models.Model):
     # une facture est remise en brouillon par le·la facturiste.
     facture_state = fields.Selection(related='facture_id.state', string='État facture', readonly=True)
 
+    # Période d'ouverture (#107, ADR 0023 décision 3) : Période légitime
+    # backfillée par la migration pour un mois non régularisé d'un contrat
+    # lissé, portant du facturé (provision, jours — champs existants) mais
+    # liée à une facture PROD (Odoo 17), hors du système — donc sans
+    # account.move (facture_id/move_ids restent vides, pas de move fictif). Ce
+    # champ est le seul marqueur : sa présence identifie la Période d'ouverture,
+    # aucun type_periode dédié — elle reste 'mensuelle', pour rester dans le
+    # même périmètre qu'une Période facturée normale (régularisation #20).
+    facture_legacy_ref = fields.Char(
+        string='Facture legacy (référence)',
+        readonly=True,
+        help='Référence de la facture prod (Odoo 17) dont cette Période est le backfill. '
+        "Marque la Période comme « d'ouverture » : pas d'account.move dans ce système.",
+    )
+
     @api.depends('move_ids.move_type')
     def _compute_facture_id(self):
         for periode in self:
@@ -315,19 +330,24 @@ class SouscriptionPeriode(models.Model):
             'cta_eur',
             'taux_accise_eur_mwh',
             'puissance_moyenne_kva',
+            # Référence de la facture legacy (#107) : au même titre que
+            # facture_id, sa présence fige la période — l'écraser romprait le
+            # lien vers la facture prod sans passer par le verrou.
+            'facture_legacy_ref',
         }
     )
 
     def write(self, vals):
         """Verrou de facturation (#14) : la période est le brouillon de travail
-        éditable *avant* facturation ; dès qu'une facture la référence (facturée,
-        brouillon de facture compris), ses champs facturables sont figés et toute
-        réécriture est rejetée (UserError, y compris via RPC). Pour corriger :
-        supprimer la facture (ce qui dé-fige la période) ou émettre une
-        régularisation."""
+        éditable *avant* facturation ; dès qu'une facture la référence — un
+        account.move (facture_id, #14) ou une facture legacy (facture_legacy_ref,
+        #107, Période d'ouverture sans move) —, ses champs facturables sont
+        figés et toute réécriture est rejetée (UserError, y compris via RPC).
+        Pour corriger : supprimer la facture (ce qui dé-fige la période) ou
+        émettre une régularisation."""
         if self._LOCKED_FIELDS.intersection(vals):
             for periode in self:
-                if periode.facture_id:
+                if periode.facture_id or periode.facture_legacy_ref:
                     raise UserError(
                         f'Période {periode.mois_annee} : déjà facturée, modification interdite. '
                         'Supprimez la facture pour corriger, ou créez une régularisation.'

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -10,6 +10,7 @@ from . import (
     test_periode_energie,
     test_periode_facture,
     test_periode_form,
+    test_periode_ouverture,
     test_periode_snapshot,
     test_poll_affaires_enedis,
     test_portal,

--- a/tests/test_periode_ouverture.py
+++ b/tests/test_periode_ouverture.py
@@ -1,0 +1,154 @@
+"""
+Tests des Périodes d'ouverture backfillées (issue #107, ADR 0023 décision 3).
+
+Une Période d'ouverture est une Période **légitime** créée par la migration
+pour les mois non régularisés des contrats lissés : amorcée depuis le facturé
+prod (provision, jours, prix appliqué — résolu via la grille comme toute
+Période, ADR 0002), liée à une facture **legacy** (prod Odoo 17, hors du
+système) plutôt qu'à un `account.move` du nouveau système (`facture_id` reste
+dérivé de `move_ids`, ADR 0004 — pas de move fictif).
+
+Rien ne doit l'exclure du périmètre de la future régularisation (#20) : elle
+reste `type_periode='mensuelle'`, elle sied dans le même domaine qu'une
+Période facturée normale.
+"""
+
+from datetime import date
+
+from odoo.exceptions import UserError
+from odoo.tests.common import tagged
+
+from .common import SouscriptionsTestCase
+
+
+@tagged('souscriptions', 'souscriptions_periode_ouverture', 'post_install', '-at_install')
+class TestPeriodeOuverture(SouscriptionsTestCase):
+    def _periode_ouverture(self, souscription, **vals):
+        base = {
+            'souscription_id': souscription.id,
+            'date_debut': date(2023, 6, 1),
+            'date_fin': date(2023, 7, 1),
+            'type_periode': 'mensuelle',
+            'facture_legacy_ref': 'FACT-PROD-2023-0456',
+        }
+        base.update(vals)
+        return self.env['souscription.periode'].create(base)
+
+    def test_reference_facture_legacy_sans_account_move(self):
+        """AC1 : une Période peut porter une référence de facture legacy, sans
+        account.move du nouveau système — facture_id (dérivé de move_ids)
+        reste vide, pas de move fictif (ADR 0004)."""
+        periode = self._periode_ouverture(self.souscription_hphc, provision_hp_kwh=200.0, provision_hc_kwh=120.0)
+
+        self.assertEqual(periode.facture_legacy_ref, 'FACT-PROD-2023-0456')
+        self.assertFalse(periode.facture_id, 'Pas de account.move : facture_id doit rester vide')
+        self.assertFalse(periode.move_ids)
+
+    def test_porte_provision_base_jours_et_prix_via_grille(self):
+        """AC2 (Base) : provision facturée et jours sont portés par la Période ;
+        le prix appliqué reste résolvable par la même mécanique que toute
+        Période (grille sélectionnée par régime + date de fin, ADR 0002/0006 —
+        jamais recopié sur la Période)."""
+        self.souscription_base.lisse = True
+        periode = self._periode_ouverture(
+            self.souscription_base,
+            provision_base_kwh=280.0,
+            date_debut=date(2024, 1, 1),
+            date_fin=date(2024, 1, 31),
+        )
+
+        self.assertEqual(periode.provision_base_kwh, 280.0)
+        self.assertEqual(periode.jours, 30)
+
+        grille = self.env['grille.prix'].get_grille_active(periode.date_fin, regime=periode.regime_prix_periode)
+        prix = grille.get_prix_dict()
+        produit_base = self.env['souscription.produit'].produit_energie('base', periode.tarif_solidaire_periode)
+        self.assertIn(produit_base.id, prix, 'Le prix appliqué se résout via la grille, comme toute Période')
+
+    def test_porte_provision_hp_hc(self):
+        """AC2 (HP/HC) : provision facturée par cadran, HP et HC."""
+        periode = self._periode_ouverture(self.souscription_hphc, provision_hp_kwh=200.0, provision_hc_kwh=120.0)
+
+        self.assertEqual(periode.provision_hp_kwh, 200.0)
+        self.assertEqual(periode.provision_hc_kwh, 120.0)
+
+    def test_identifiable_en_liste_et_formulaire(self):
+        """AC3 : le champ facture_legacy_ref (identifiant de la Période
+        d'ouverture) est exposé sur les vues liste et formulaire de la
+        Période."""
+        form_view = self.env['souscription.periode'].get_view(view_type='form')
+        self.assertIn('facture_legacy_ref', form_view['arch'])
+
+        list_view = self.env['souscription.periode'].get_view(view_type='list')
+        self.assertIn('facture_legacy_ref', list_view['arch'])
+
+    def test_expose_memes_donnees_qu_une_periode_facturee_normale(self):
+        """AC4 : une Période d'ouverture reste `type_periode='mensuelle'` —
+        rien ne l'exclut d'un domaine plausible de la future régularisation
+        (#20) : périodes mensuelles lissées de la souscription, mêmes champs
+        (snapshot, jours, écart) qu'une Période facturée normale."""
+        sous = self.souscription_hphc
+        periode = self._periode_ouverture(sous, provision_hp_kwh=200.0, provision_hc_kwh=120.0)
+
+        perimetre = self.env['souscription.periode'].search(
+            [
+                ('souscription_id', '=', sous.id),
+                ('type_periode', '=', 'mensuelle'),
+                ('lisse_periode', '=', True),
+            ]
+        )
+        self.assertIn(periode, perimetre)
+        self.assertEqual(periode.type_tarif_periode, 'hphc')
+        self.assertTrue(periode.jours)
+        self.assertEqual(periode.ecart_hp_kwh, periode.energie_hp_kwh - periode.provision_hp_kwh)
+
+    def test_figee_par_le_verrou_de_facturation_sans_account_move(self):
+        """Le verrou de facturation (#14) protège aussi la Période
+        d'ouverture : dès que `facture_legacy_ref` est posé, ses champs
+        facturables sont figés — même sans account.move (pas de trou dans le
+        verrou)."""
+        periode = self._periode_ouverture(self.souscription_base, provision_base_kwh=280.0)
+
+        with self.assertRaises(UserError):
+            periode.write({'provision_base_kwh': 999.0})
+
+    def test_creer_factures_ne_refacture_pas_une_periode_d_ouverture(self):
+        """creer_factures() ne doit jamais émettre un second account.move sur
+        une Période déjà facturée côté legacy (double facturation évitée) : le
+        filtre anti-doublon (#23) tient compte de facture_legacy_ref, pas
+        seulement de facture_id."""
+        sous = self.souscription_base
+        self._periode_ouverture(sous, provision_base_kwh=280.0, date_debut=date(2023, 6, 1), date_fin=date(2023, 7, 1))
+
+        sous.creer_factures()
+
+        self.assertFalse(sous.facture_ids, "Aucune facture ne doit être créée pour une Période d'ouverture")
+
+
+@tagged('souscriptions', 'souscriptions_periode_ouverture', 'post_install', '-at_install')
+class TestPeriodeOuvertureDemoLive(SouscriptionsTestCase):
+    """Contrôles sur la démo « backfill migration » (#107), skippés si la démo
+    n'est pas chargée sur cette base — même convention que
+    `test_releve_demo.TestReleveDemoLive` (démontrable en dev, non chargée en
+    CI standard)."""
+
+    def _ref(self, xmlid):
+        return self.env.ref(f'souscriptions_odoo.{xmlid}', raise_if_not_found=False)
+
+    def setUp(self):
+        super().setUp()
+        if not self._ref('demo_periode_ouverture_novembre_2023'):
+            self.skipTest('Données de démo non chargées sur cette base')
+
+    def test_periode_ouverture_demo_liee_a_une_facture_legacy(self):
+        periode = self._ref('demo_periode_ouverture_novembre_2023')
+        self.assertTrue(periode.facture_legacy_ref)
+        self.assertFalse(periode.facture_id)
+
+    def test_periode_ouverture_demo_dans_l_historique_de_la_souscription(self):
+        sous = self._ref('demo_souscription_migree_lissee')
+        periodes_ouverture = self._ref('demo_periode_ouverture_novembre_2023') | self._ref(
+            'demo_periode_ouverture_decembre_2023'
+        )
+        self.assertTrue(sous.lisse)
+        self.assertTrue(periodes_ouverture <= sous.periode_ids, "Périodes d'ouverture absentes de l'historique")

--- a/views/core/souscription_views.xml
+++ b/views/core/souscription_views.xml
@@ -75,7 +75,7 @@
                     <notebook>
                         <page string="Périodes de facturation">
                             <field name="periode_ids">
-                                <list editable="bottom">
+                                <list editable="bottom" decoration-info="facture_legacy_ref and not facture_id">
                                     <field name="mois_annee"/>
                                     <field name="type_periode"/>
                                     <field name="type_tarif_periode"/>
@@ -89,6 +89,9 @@
                                     <field name="turpe_fixe"/>
                                     <field name="turpe_variable"/>
                                     <field name="facture_id"/>
+                                    <!-- Période d'ouverture (#107) : backfill lié à une
+                                         facture legacy plutôt qu'à un account.move. -->
+                                    <field name="facture_legacy_ref"/>
                                 </list>
                             </field>
                         </page>

--- a/views/core/souscriptions_periode_views.xml
+++ b/views/core/souscriptions_periode_views.xml
@@ -4,7 +4,7 @@
         <field name="name">souscription.periode.list</field>
         <field name="model">souscription.periode</field>
         <field name="arch" type="xml">
-            <list>
+            <list decoration-info="facture_legacy_ref and not facture_id">
                 <field name="souscription_id"/>
                 <field name="pdl"/>
                 <field name="mois_annee"/>
@@ -20,6 +20,10 @@
                 <field name="facture_state" widget="badge"
                        decoration-success="facture_state == 'posted'"
                        decoration-warning="facture_state == 'draft'"/>
+                <!-- Période d'ouverture (#107) : facturée côté legacy, pas
+                     d'account.move — la référence prod est le marqueur
+                     d'identification, mise en évidence par la couleur de ligne. -->
+                <field name="facture_legacy_ref"/>
             </list>
         </field>
     </record>
@@ -136,6 +140,11 @@
                     <group string="Documents">
                         <field name="facture_id"/>
                         <field name="facture_state"/>
+                        <!-- Période d'ouverture (#107, ADR 0023) : backfill lié
+                             à une facture PROD (Odoo 17), hors du système —
+                             pas d'account.move ; ce champ est le marqueur
+                             d'identification de la Période d'ouverture. -->
+                        <field name="facture_legacy_ref"/>
                     </group>
                     <!-- Tous les documents liés (factures, avoirs…), brouillons
                          compris : une facture remise en brouillon reste visible ici. -->


### PR DESCRIPTION
Closes #107

Ajoute le support modèle des Périodes d'ouverture (ADR 0023 §3) : une Période peut désormais référencer une facture legacy (prod Odoo 17) via `facture_legacy_ref`, au lieu d'un account.move — le verrou de facturation et l'anti-doublon de `creer_factures()` en tiennent compte pour ne jamais la réécrire ni la refacturer. Elle reste `type_periode='mensuelle'`, donc dans le même périmètre qu'une Période facturée normale pour la future régularisation (#20). Démo : une souscription lissée avec deux Périodes d'ouverture sur des mois passés.

🤖 Generated with [Claude Code](https://claude.com/claude-code)