### PR TITLE
refactor(electricore): fabrique de client unique — souscription.electricore.client (ADR 0024)

### DIFF
--- a/docs/adr/0024-electricore-dependance-molle-garde-import-fabrique-client-unique.md
+++ b/docs/adr/0024-electricore-dependance-molle-garde-import-fabrique-client-unique.md
@@ -1,0 +1,32 @@
+# electricore-client : dépendance *molle* (garde d'import), jamais `external_dependencies` — une fabrique de client unique
+
+*Statut : accepté. Formalise une décision déjà prise mais éparse — comment (#77 AC1), requirements.txt, docstring du manifeste — au moment où les deux gardes d'import dupliquées (service RSC #88 ; wizard de pull #77) fusionnent en une couture de construction unique, `souscription.electricore.client`. Ne re-décide pas [ADR-0019](0019-consommation-electricore-client-fin-contrat-type-versionne.md) (quel paquet, quel contrat) : elle en fixe la **posture de dépendance** et le **point de construction**.*
+
+Odoo consomme electricore via le paquet fin `electricore-client` ([ADR-0019](0019-consommation-electricore-client-fin-contrat-type-versionne.md)). Deux fonctionnalités l'appellent : la **résolution RSC** (poll de raccordement, [ADR-0021](0021-chaine-raccordement-pilotee-faits-naissance-instance-rsc-poll.md)) et le **pull des méta-périodes** (wizard facturiste, [ADR-0011](0011-contrat-pull-facturation-electricore-cle-rsc-mois.md)). Odoo offre la clé de manifeste `external_dependencies` : il vérifie l'importabilité des paquets Python **au chargement** et **refuse de charger le module entier** si l'un manque (échec fermé, en amont). L'AC de #77 exige au contraire un module **installable sur toute instance**, même sans le paquet — avec un message clair *au clic* si absent. Avant cet ADR, chaque fonctionnalité portait sa **propre** garde d'import + sa propre méthode `_client()` (bloc `try/import`, lecture des paramètres système, deux `UserError` — le tout **copié à l'identique**).
+
+## Décision
+
+1. **Dépendance molle, jamais `external_dependencies`.** `electricore-client` est **épinglé** dans `requirements.txt` (préoccupation de déploiement) et **gardé** par un `try/import` (préoccupation runtime), mais **n'est pas déclaré** en `external_dependencies`. Son absence n'empêche ni l'installation ni le chargement du module ; seules les deux fonctionnalités qui appellent electricore échouent, et seulement **à l'usage**.
+2. **Détection au démarrage, levée à l'usage.** La garde d'import s'évalue **une fois** au chargement (drapeau de disponibilité). L'erreur actionnable (`UserError`) **ne peut pas** être levée à l'import — cela casserait le chargement du registre, précisément ce que ferait `external_dependencies` — elle est donc levée au moment de l'appel.
+3. **Deux « disponibilités » distinctes.** (a) *paquet présent* = un **fait de démarrage** (drapeau d'import) ; (b) *URL + api_key configurés* = une **donnée runtime** (`ir.config_parameter`, éditable à chaud, sans redémarrage) — donc vérifiée à l'usage. Aucune des deux ne peut être un contrôle d'installation.
+4. **Une fabrique de client unique.** Un `AbstractModel` `souscription.electricore.client` (méthode publique `client()`) porte **la** garde d'import, **le** drapeau, **la** lecture de config et **la** construction du client — les deux `UserError` (*paquet manquant* / *config manquante*) comprises. Le service RSC et le wizard de pull l'appellent ; **aucun** ne reconstruit de client. Chaque appelant conserve son **appel d'endpoint** (`resoudre_rsc` en **lot** ↔ `meta_periodes` en **flux**/context-manager) et sa **propre** correspondance d'exceptions.
+5. **Échec rapide et déterministe.** Chaque action acquiert le client **en tête** (`client()`), avant tout travail dépendant des données : un même clic produit toujours la même classe de résultat. La construction **n'ouvre aucune socket** (le HTTP n'a lieu qu'à l'ouverture du flux / à l'appel batch), donc l'échec précoce est gratuit.
+6. **Couture de test par endpoint.** Chaque appelant patche **sa** méthode de transport nommée (`_appeler` côté RSC — inchangée ; `_ouvrir_flux` côté pull) et retourne une réponse en boîte, sans construire de client. La **fabrique** a son propre petit test (paquet manquant / config manquante / construction), là où ces gardes se testaient auparavant **en double**.
+
+## Conséquences
+
+- Le module reste **installable partout** ; le déploiement doit `pip install electricore-client` (odoo.sh / Docker) — une **étape de build**, pas une dépendance de manifeste.
+- La garde de disponibilité **vit et se teste une seule fois** (dans la fabrique) ; les `setUp` des tests d'endpoint cessent de patcher le drapeau `ELECTRICORE_CLIENT_DISPONIBLE`.
+- **Garde-fou pour un futur audit** : voir « import gardé + `UserError` au clic » et vouloir le *corriger* en `external_dependencies` **régresse l'AC #77** — relire cet ADR d'abord.
+- Le nom du service RSC cesse de mentir : il reste *pour la résolution RSC*, et n'est plus le point de construction de facto du client de pull.
+
+## Options écartées
+
+- **`external_dependencies` dans le manifeste** (idiome Odoo standard, échec fermé à l'install) : ferait échouer le module **entier** — y compris contrats, factures, portail — sur toute instance sans le paquet. Contredit « module installable » (#77).
+- **Statu quo : deux gardes d'import dupliquées.** Même bloc `try/import`, même `_client()`, mêmes deux `UserError` copiés dans le service RSC et le wizard — deux endroits à patcher, deux jeux de tests du même garde.
+- **Router le pull *à travers* le service RSC** (`souscription.rsc.service._client()`) : réutilise une **méthode privée** d'un modèle **nommé pour un autre endpoint** ; le nom du service devient trompeur dès que le pull s'en sert.
+- **Fabrique de *transport complète*** (appels d'endpoint inclus) : les sémantiques diffèrent (lot ↔ flux/context-manager) et les vocabulaires d'exception aussi (`ContractVersionError` seul ↔ `+ IngestionEnCours`, `PreconditionNonRemplie`) — chaque endpoint deviendrait un **passe-plat mince** à signature différente. La fabrique s'arrête donc à « rends-moi un client configuré ».
+
+## Raison
+
+electricore est **optionnel à l'installation** mais **requis à l'usage** des deux features qui l'appellent. La seule forme qui respecte cela : *détecter au démarrage, lever à l'usage, lire la config à l'usage* — et concentrer ces trois gestes dans **une** couture, pour que l'invariant « dépendance molle, message actionnable » ait **un seul gardien, testé une fois**. C'est aussi la frontière voulue par [ADR-0001](0001-odoo-systeme-ecriture-electricore-api-read-only.md)/[ADR-0019](0019-consommation-electricore-client-fin-contrat-type-versionne.md) : tout ce qui parle réseau vers electricore passe par un point nommé et unique.

--- a/models/core/__init__.py
+++ b/models/core/__init__.py
@@ -1,5 +1,6 @@
 from . import (
     account_move,
+    electricore_client_fabrique,
     electricore_rsc_service,
     grille_prix,
     res_partner,

--- a/models/core/electricore_client_fabrique.py
+++ b/models/core/electricore_client_fabrique.py
@@ -1,0 +1,65 @@
+"""Fabrique unique du client electricore (#88/#77, ADR 0024).
+
+Avant cet ADR, le service RSC (#88) et le wizard de pull des méta-périodes
+(#77) portaient chacun leur propre garde d'import, leur propre drapeau de
+disponibilité, leur propre lecture de config et leur propre `_client()` —
+le tout copié à l'identique. Ce module concentre les quatre dans une unique
+couture : un `AbstractModel` (`souscription.electricore.client`, méthode
+publique `client()`) que les deux appelants utilisent via `self.env`, sans
+jamais construire leur propre client.
+
+Dépendance molle (#77 AC1) : `electricore-client` reste épinglé dans
+requirements.txt et gardé par un `try/import`, mais n'est **jamais** déclaré
+en `external_dependencies` — son absence n'empêche ni l'installation ni le
+chargement du module, seul l'appel à `client()` échoue, avec un message
+actionnable.
+
+Chaque appelant garde son propre appel d'endpoint (`resoudre_rsc` en lot ↔
+`meta_periodes` en flux) et son propre mapping d'exceptions : cette fabrique
+s'arrête à « rends-moi un client configuré » (ADR 0024 §4, option écartée
+« fabrique de transport complète »).
+"""
+
+from __future__ import annotations
+
+from odoo import models
+from odoo.exceptions import UserError
+
+try:
+    from electricore_client import ElectricoreClient
+
+    ELECTRICORE_CLIENT_DISPONIBLE = True
+except ImportError:  # pragma: no cover - exercé par test_electricore_client_fabrique
+    ELECTRICORE_CLIENT_DISPONIBLE = False
+
+
+class SouscriptionElectricoreClient(models.AbstractModel):
+    _name = 'souscription.electricore.client'
+    _description = 'Fabrique unique du client electricore (ADR 0024)'
+
+    def client(self):
+        """Construit un client electricore configuré.
+
+        Acquis en tête de chaque action appelante (échec rapide et
+        déterministe, ADR 0024 §5) : la construction n'ouvre aucune socket,
+        seule l'ouverture du flux / l'appel batch parle réseau.
+
+        Raises:
+            UserError: le paquet `electricore_client` est absent (fait de
+                démarrage), ou la configuration système est manquante
+                (donnée runtime, éditable à chaud).
+        """
+        if not ELECTRICORE_CLIENT_DISPONIBLE:
+            raise UserError(
+                "Le paquet 'electricore_client' n'est pas installé sur ce serveur. "
+                'Installez la dépendance épinglée dans requirements.txt puis réessayez.'
+            )
+        ICP = self.env['ir.config_parameter'].sudo()
+        url = ICP.get_param('souscriptions.electricore_url')
+        api_key = ICP.get_param('souscriptions.electricore_api_key')
+        if not url or not api_key:
+            raise UserError(
+                'Configuration electricore manquante : renseignez les paramètres système '
+                "'souscriptions.electricore_url' et 'souscriptions.electricore_api_key'."
+            )
+        return ElectricoreClient(url=url, api_key=api_key)

--- a/models/core/electricore_rsc_service.py
+++ b/models/core/electricore_rsc_service.py
@@ -1,11 +1,11 @@
 """Service transport unique vers l'endpoint de résolution RSC d'electricore
 (#88, ADR 0021 §3, contrat figé `docs/contrat-rsc.md` côté electricore).
 
-Enveloppe le paquet PyPI épinglé `electricore-client` (requirements.txt),
-même garde d'import et mêmes paramètres système que le wizard de pull des
-méta-périodes (#84, `souscriptions.electricore_url` /
-`souscriptions.electricore_api_key`) — dépendance déclarée par le pin +
-la garde, pas par `external_dependencies` (cf. requirements.txt).
+Le client electricore est acquis auprès de la fabrique unique
+`souscription.electricore.client` (ADR 0024) : ce module ne porte plus ni
+garde d'import, ni drapeau de disponibilité, ni lecture de config — seul son
+propre appel d'endpoint (`resoudre_rsc` en lot) et son mapping d'exception
+(`ContractVersionError`).
 
 C'est l'unique point du module qui parle réseau pour la résolution RSC ; le
 pull des périodes (#12) s'y branchera plus tard.
@@ -17,11 +17,12 @@ from odoo import models
 from odoo.exceptions import UserError
 
 try:
-    from electricore_client import ContractVersionError, ElectricoreClient
+    from electricore_client import ContractVersionError
+except ImportError:  # pragma: no cover - paquet optionnel (ADR 0024) ; la fabrique lève avant tout mapping
 
-    ELECTRICORE_CLIENT_DISPONIBLE = True
-except ImportError:  # pragma: no cover - exercé par test_paquet_manquant_leve_userror_actionnable
-    ELECTRICORE_CLIENT_DISPONIBLE = False
+    class ContractVersionError(Exception):
+        """Repli si `electricore_client` est absent : jamais levée en pratique — la fabrique
+        (`souscription.electricore.client`) échoue avant tout appel qui pourrait la lever."""
 
 
 class SouscriptionRscService(models.AbstractModel):
@@ -41,19 +42,14 @@ class SouscriptionRscService(models.AbstractModel):
             désordre de la réponse.
 
         Raises:
-            UserError: paquet absent, configuration manquante, ou version de
-                contrat inattendue — dans tous les cas, aucune donnée n'est
-                écrite par l'appelant puisque l'exception interrompt l'appel
-                avant tout accès au résultat.
+            UserError: paquet absent, configuration manquante (fabrique,
+                ADR 0024), ou version de contrat inattendue — dans tous les
+                cas, aucune donnée n'est écrite par l'appelant puisque
+                l'exception interrompt l'appel avant tout accès au résultat.
         """
         ids = list(ids)
         if not ids:
             return {}
-        if not ELECTRICORE_CLIENT_DISPONIBLE:
-            raise UserError(
-                "Le paquet 'electricore_client' n'est pas installé sur ce serveur. "
-                'Installez la dépendance épinglée dans requirements.txt puis réessayez.'
-            )
         try:
             resultats = self._appeler(ids)
         except ContractVersionError as exc:
@@ -61,20 +57,8 @@ class SouscriptionRscService(models.AbstractModel):
         return {r.id_affaire: r for r in resultats}
 
     def _appeler(self, ids):
-        """Point de transport unique : construit le client et appelle
+        """Point de transport unique : acquiert le client via la fabrique
+        (`souscription.electricore.client`, ADR 0024) et appelle
         `resoudre_rsc`. Seul endroit qui parle réseau — c'est la couture
         patchée en tests (réponses en boîte, rien d'autre n'est mocké)."""
-        return self._client().resoudre_rsc(ids)
-
-    def _client(self):
-        """Client electricore depuis `ir.config_parameter` — mêmes clés que
-        le wizard de pull des méta-périodes (#84)."""
-        ICP = self.env['ir.config_parameter'].sudo()
-        url = ICP.get_param('souscriptions.electricore_url')
-        api_key = ICP.get_param('souscriptions.electricore_api_key')
-        if not url or not api_key:
-            raise UserError(
-                'Configuration electricore manquante : renseignez les paramètres système '
-                "'souscriptions.electricore_url' et 'souscriptions.electricore_api_key'."
-            )
-        return ElectricoreClient(url=url, api_key=api_key)
+        return self.env['souscription.electricore.client'].client().resoudre_rsc(ids)

--- a/models/wizard/souscription_pull_meta_periodes_wizard.py
+++ b/models/wizard/souscription_pull_meta_periodes_wizard.py
@@ -2,10 +2,11 @@
 
 Brancher le seam décidé : l'addon consomme le paquet `electricore-client`
 (httpx + pydantic) et n'implémente que le mapping vers ses propres modèles
-(`souscription.periode._amorcer_depuis_meta`). Le paquet n'est pas une
-dépendance dure d'installation (cf. `requirements.txt` + garde d'import
-ci-dessous) : un déploiement sans le paquet installe le module, le bouton du
-wizard échoue avec un message actionnable.
+(`souscription.periode._amorcer_depuis_meta`). Le client est acquis auprès de
+la fabrique unique `souscription.electricore.client` (ADR 0024) : ce module
+ne porte plus ni garde d'import du client, ni drapeau de disponibilité, ni
+lecture de config — seuls son propre appel d'endpoint (`meta_periodes` en
+flux) et son mapping d'exceptions.
 """
 
 from __future__ import annotations
@@ -15,21 +16,23 @@ from datetime import timedelta
 from odoo import api, fields, models
 from odoo.exceptions import UserError
 
-# Garde d'import (#77 AC1) : `electricore_client` est un paquet PyPI épinglé
-# (requirements.txt), pas une dépendance dure Odoo — `external_dependencies`
-# ferait échouer l'installation du module sur toute instance qui ne l'a pas
-# encore, ce qui contredit « module installable » (cf. rapport de la PR).
+# Garde d'import minimale (ADR 0024) : seules les exceptions du mapping de ce
+# wizard sont importées ici — la construction du client (garde + drapeau +
+# config) vit dans la fabrique. Si le paquet est absent, la fabrique lève
+# avant qu'aucune de ces exceptions ne puisse être levée.
 try:
-    from electricore_client import (
-        ContractVersionError,
-        ElectricoreClient,
-        IngestionEnCours,
-    )
+    from electricore_client import ContractVersionError, IngestionEnCours
     from electricore_client.exceptions import PreconditionNonRemplie
+except ImportError:  # pragma: no cover - paquet optionnel ; la fabrique lève avant tout mapping
 
-    ELECTRICORE_CLIENT_DISPONIBLE = True
-except ImportError:  # pragma: no cover - exercé par test_paquet_manquant_leve_userror_actionnable
-    ELECTRICORE_CLIENT_DISPONIBLE = False
+    class ContractVersionError(Exception):
+        """Repli si `electricore_client` est absent : jamais levée en pratique."""
+
+    class IngestionEnCours(Exception):
+        """Repli si `electricore_client` est absent : jamais levée en pratique."""
+
+    class PreconditionNonRemplie(Exception):
+        """Repli si `electricore_client` est absent : jamais levée en pratique."""
 
 
 class SouscriptionPullMetaPeriodesWizard(models.TransientModel):
@@ -55,13 +58,13 @@ class SouscriptionPullMetaPeriodesWizard(models.TransientModel):
     def action_lancer(self):
         """Récupère les méta-périodes du mois pour toutes les souscriptions à
         RSC, crée les périodes manquantes (create-missing-only), résume le
-        résultat (créées / déjà existantes / sans RSC / erreurs)."""
+        résultat (créées / déjà existantes / sans RSC / erreurs).
+
+        Le client est acquis en tête, avant toute recherche (échec rapide et
+        déterministe, ADR 0024 §5) : un même clic produit toujours la même
+        classe de résultat, que des souscriptions à RSC existent ou non."""
         self.ensure_one()
-        if not ELECTRICORE_CLIENT_DISPONIBLE:
-            raise UserError(
-                "Le paquet 'electricore_client' n'est pas installé sur ce serveur. "
-                'Installez la dépendance épinglée dans requirements.txt puis réessayez.'
-            )
+        client = self.env['souscription.electricore.client'].client()
 
         Souscription = self.env['souscription.souscription']
         Periode = self.env['souscription.periode']
@@ -73,10 +76,9 @@ class SouscriptionPullMetaPeriodesWizard(models.TransientModel):
         creees, existantes, erreurs = [], [], []
 
         if par_rsc:
-            client = self._client()
             mois_str = fields.Date.to_string(self.mois)
             try:
-                with client.meta_periodes(mois=mois_str, rsc=list(par_rsc)) as stream:
+                with self._ouvrir_flux(client, mois_str, list(par_rsc)) as stream:
                     for meta in stream:
                         souscription = par_rsc.get(meta.ref_situation_contractuelle)
                         if souscription is None:
@@ -148,15 +150,8 @@ class SouscriptionPullMetaPeriodesWizard(models.TransientModel):
             lignes += ['Erreurs :'] + [f'  - {ligne}' for ligne in erreurs]
         return '\n'.join(lignes)
 
-    def _client(self):
-        """Construit le client electricore depuis `ir.config_parameter`
-        (`souscriptions.electricore_url` / `souscriptions.electricore_api_key`)."""
-        ICP = self.env['ir.config_parameter'].sudo()
-        url = ICP.get_param('souscriptions.electricore_url')
-        api_key = ICP.get_param('souscriptions.electricore_api_key')
-        if not url or not api_key:
-            raise UserError(
-                'Configuration electricore manquante : renseignez les paramètres système '
-                "'souscriptions.electricore_url' et 'souscriptions.electricore_api_key'."
-            )
-        return ElectricoreClient(url=url, api_key=api_key)
+    def _ouvrir_flux(self, client, mois_str, rsc):
+        """Point de transport unique : ouvre le flux `meta_periodes` (context
+        manager). Seul endroit qui parle réseau — c'est la couture patchée en
+        tests (réponses en boîte, rien d'autre n'est mocké)."""
+        return client.meta_periodes(mois=mois_str, rsc=rsc)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -2,6 +2,7 @@ from . import (
     test_basic,
     test_catalogue,
     test_documents_contractuels,
+    test_electricore_client_fabrique,
     test_facturation,
     test_grille_prix,
     test_integration,

--- a/tests/test_electricore_client_fabrique.py
+++ b/tests/test_electricore_client_fabrique.py
@@ -1,0 +1,53 @@
+"""Tests de la fabrique unique de client electricore (#88/#77, ADR 0024).
+
+Teste **une seule fois** la garde partagée par le service RSC (#88) et le
+wizard de pull des méta-périodes (#77) : paquet absent, configuration
+manquante, construction. Ces deux appelants ne testent plus que leur propre
+couture de transport (`_appeler` / `_ouvrir_flux`), plus jamais cette garde
+(cf. tests/test_rsc_service.py, tests/test_pull_meta_periodes.py).
+"""
+
+from unittest.mock import patch
+
+from odoo.addons.souscriptions_odoo.models.core import electricore_client_fabrique as fabrique_module
+from odoo.exceptions import UserError
+from odoo.tests.common import tagged
+
+from .common import SouscriptionsTestCase
+
+_MODEL = 'souscription.electricore.client'
+
+
+@tagged('souscriptions', 'souscriptions_electricore_client_fabrique', 'post_install', '-at_install')
+class TestElectricoreClientFabrique(SouscriptionsTestCase):
+    def setUp(self):
+        super().setUp()
+        patcher = patch.object(fabrique_module, 'ELECTRICORE_CLIENT_DISPONIBLE', True)
+        patcher.start()
+        self.addCleanup(patcher.stop)
+        ICP = self.env['ir.config_parameter'].sudo()
+        ICP.set_param('souscriptions.electricore_url', 'https://electricore.example.test')
+        ICP.set_param('souscriptions.electricore_api_key', 'fake-api-key')
+
+    def test_paquet_manquant_leve_userror_actionnable(self):
+        with patch.object(fabrique_module, 'ELECTRICORE_CLIENT_DISPONIBLE', False):
+            with self.assertRaises(UserError) as cm:
+                self.env[_MODEL].client()
+        self.assertIn('electricore_client', str(cm.exception))
+
+    def test_url_manquante_leve_userror(self):
+        self.env['ir.config_parameter'].sudo().set_param('souscriptions.electricore_url', False)
+        with self.assertRaises(UserError):
+            self.env[_MODEL].client()
+
+    def test_api_key_manquante_leve_userror(self):
+        self.env['ir.config_parameter'].sudo().set_param('souscriptions.electricore_api_key', False)
+        with self.assertRaises(UserError):
+            self.env[_MODEL].client()
+
+    def test_construit_le_client_configure(self):
+        """La fabrique construit bien `ElectricoreClient` avec la config lue
+        (`ir.config_parameter`), sans autre traduction."""
+        with patch.object(fabrique_module, 'ElectricoreClient') as MockClient:
+            self.env[_MODEL].client()
+        MockClient.assert_called_once_with(url='https://electricore.example.test', api_key='fake-api-key')

--- a/tests/test_poll_affaires_enedis.py
+++ b/tests/test_poll_affaires_enedis.py
@@ -29,17 +29,6 @@ def _resultat(id_affaire, rsc=None, error=None):
 
 @tagged('souscriptions', 'souscriptions_poll_rsc', 'post_install', '-at_install')
 class TestPollAffairesEnedis(SouscriptionsTestCase):
-    def setUp(self):
-        super().setUp()
-        # Le paquet peut être absent du sandbox d'exécution des tests : forcé
-        # disponible (même garde que le wizard #84 et le service #88).
-        patcher = patch.object(service_module, 'ELECTRICORE_CLIENT_DISPONIBLE', True)
-        patcher.start()
-        self.addCleanup(patcher.stop)
-        ICP = self.env['ir.config_parameter'].sudo()
-        ICP.set_param('souscriptions.electricore_url', 'https://electricore.example.test')
-        ICP.set_param('souscriptions.electricore_api_key', 'fake-api-key')
-
     def _patch_appeler(self, return_value=None, side_effect=None):
         return patch.object(_SERVICE, '_appeler', return_value=return_value, side_effect=side_effect)
 

--- a/tests/test_pull_meta_periodes.py
+++ b/tests/test_pull_meta_periodes.py
@@ -17,16 +17,12 @@ from datetime import date, timedelta
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
+from odoo.addons.souscriptions_odoo.models.core import electricore_client_fabrique as fabrique_module
 from odoo.addons.souscriptions_odoo.models.wizard import souscription_pull_meta_periodes_wizard as wizard_module
 from odoo.exceptions import UserError
 from odoo.tests.common import tagged
 
 from .common import SouscriptionsTestCase
-
-# Cible de patch en toutes lettres (mock.patch résout par import string) : on
-# tape sur les noms importés *dans le module wizard*, jamais sur le paquet
-# electricore_client lui-même (qui peut être absent du sandbox de tests).
-_WIZARD = 'odoo.addons.souscriptions_odoo.models.wizard.souscription_pull_meta_periodes_wizard'
 
 
 def _objet_releve(**kwargs):
@@ -217,16 +213,6 @@ def _fake_client(metas=(), *, leve=None):
 class TestWizardPullMetaPeriodes(SouscriptionsTestCase):
     def setUp(self):
         super().setUp()
-        # Le wizard résout ses paramètres via ir.config_parameter : posés une
-        # fois pour tous les tests de cette classe (pas de vrai réseau).
-        ICP = self.env['ir.config_parameter'].sudo()
-        ICP.set_param('souscriptions.electricore_url', 'https://electricore.example.test')
-        ICP.set_param('souscriptions.electricore_api_key', 'fake-api-key')
-
-        patcher_dispo = patch(f'{_WIZARD}.ELECTRICORE_CLIENT_DISPONIBLE', True)
-        patcher_dispo.start()
-        self.addCleanup(patcher_dispo.stop)
-
         patcher_exc = patch.multiple(
             wizard_module,
             IngestionEnCours=_FakeIngestionEnCours,
@@ -240,25 +226,13 @@ class TestWizardPullMetaPeriodes(SouscriptionsTestCase):
         return self.env['souscription.pull.meta.periodes.wizard'].create({'mois': mois})
 
     def _lancer_avec_client(self, client, mois=date(2024, 1, 1)):
+        """Lance le wizard avec un client factice fourni directement par la
+        fabrique (ADR 0024) : la garde paquet/config de la fabrique est
+        testée une fois dans test_electricore_client_fabrique.py, pas ici."""
         wizard = self._wizard(mois)
-        with patch.object(wizard_module, 'ElectricoreClient', return_value=client):
+        with patch.object(fabrique_module.SouscriptionElectricoreClient, 'client', return_value=client):
             wizard.action_lancer()
         return wizard
-
-    def test_paquet_manquant_leve_userror_actionnable(self):
-        """AC1 : message clair si le paquet manque — pas d'appel réseau."""
-        with patch(f'{_WIZARD}.ELECTRICORE_CLIENT_DISPONIBLE', False):
-            wizard = self._wizard()
-            with self.assertRaises(UserError) as cm:
-                wizard.action_lancer()
-        self.assertIn('electricore_client', str(cm.exception))
-
-    def test_config_manquante_leve_userror(self):
-        self.souscription_base.ref_situation_contractuelle = 'RSC-00000000000001'
-        self.env['ir.config_parameter'].sudo().set_param('souscriptions.electricore_api_key', False)
-        wizard = self._wizard()
-        with self.assertRaises(UserError):
-            wizard.action_lancer()
 
     def test_cree_les_periodes_manquantes_pour_les_souscriptions_a_rsc(self):
         """AC2 : le wizard crée les périodes manquantes du mois pour les
@@ -391,18 +365,18 @@ class TestWizardPullMetaPeriodes(SouscriptionsTestCase):
             self._lancer_avec_client(client)
         self.assertIn('v2', str(cm.exception))
 
-    def test_aucune_souscription_a_rsc_naboutit_pas_a_un_appel_client(self):
-        """Aucune RSC facturable -> le client n'est même pas construit (pas de
-        round-trip réseau inutile)."""
-        with patch.object(wizard_module, 'ElectricoreClient') as MockClient:
-            wizard = self._wizard()
-            wizard.action_lancer()
-            MockClient.assert_not_called()
+    def test_aucune_souscription_a_rsc_naboutit_pas_a_un_appel_de_flux(self):
+        """Aucune RSC facturable -> aucun flux n'est ouvert (pas de round-trip
+        réseau inutile), même si le client est acquis en tête (fast-fail,
+        ADR 0024 §5 : la construction elle-même n'ouvre aucune socket)."""
+        client = _fake_client([])
+        wizard = self._lancer_avec_client(client)
+        client.meta_periodes.assert_not_called()
         self.assertIn('Sans RSC', wizard.resultat)
 
 
 @unittest.skipIf(
-    not wizard_module.ELECTRICORE_CLIENT_DISPONIBLE,
+    not fabrique_module.ELECTRICORE_CLIENT_DISPONIBLE,
     'electricore_client non installé : test exercé uniquement là où le paquet réel est présent (CI Docker).',
 )
 @tagged('souscriptions', 'souscriptions_pull_meta', 'post_install', '-at_install')

--- a/tests/test_rsc_service.py
+++ b/tests/test_rsc_service.py
@@ -33,19 +33,8 @@ def _resultat(id_affaire, rsc=None, error=None):
 @tagged('souscriptions', 'souscriptions_rsc_service', 'post_install', '-at_install')
 class TestServiceRscTransport(SouscriptionsTestCase):
     """Le service (`souscription.rsc.service`) isolément : appariement,
-    lot vide, garde d'import, config manquante, version de contrat."""
-
-    def setUp(self):
-        super().setUp()
-        # Le paquet peut être absent du sandbox d'exécution des tests : forcé
-        # disponible par défaut (même garde que le wizard #84), sauf test
-        # dédié qui le repatche localement à False.
-        patcher = patch.object(service_module, 'ELECTRICORE_CLIENT_DISPONIBLE', True)
-        patcher.start()
-        self.addCleanup(patcher.stop)
-        ICP = self.env['ir.config_parameter'].sudo()
-        ICP.set_param('souscriptions.electricore_url', 'https://electricore.example.test')
-        ICP.set_param('souscriptions.electricore_api_key', 'fake-api-key')
+    lot vide, version de contrat. La garde d'import/config de la fabrique
+    (ADR 0024) est testée une fois dans test_electricore_client_fabrique.py."""
 
     def _patch_appeler(self, return_value=None, side_effect=None):
         return patch.object(
@@ -94,17 +83,6 @@ class TestServiceRscTransport(SouscriptionsTestCase):
         self.assertTrue(resultat['SANS-C15'].error.startswith('Affaire connue'))
         self.assertTrue(resultat['AMBIGUE'].error.startswith('Résolution ambiguë'))
 
-    def test_paquet_manquant_leve_userror_actionnable(self):
-        with patch.object(service_module, 'ELECTRICORE_CLIENT_DISPONIBLE', False):
-            with self.assertRaises(UserError) as cm:
-                self.env[_SERVICE_MODEL].resoudre(['A'])
-        self.assertIn('electricore_client', str(cm.exception))
-
-    def test_config_manquante_leve_userror(self):
-        self.env['ir.config_parameter'].sudo().set_param('souscriptions.electricore_api_key', False)
-        with self.assertRaises(UserError):
-            self.env[_SERVICE_MODEL].resoudre(['A'])
-
     def test_version_de_contrat_inattendue_signalee_sans_ecriture(self):
         """AC2 : version de contrat inattendue -> signalée (UserError), le
         service n'écrit jamais de donnée (l'exception interrompt l'appel
@@ -119,15 +97,6 @@ class TestServiceRscTransport(SouscriptionsTestCase):
 @tagged('souscriptions', 'souscriptions_rsc_service', 'post_install', '-at_install')
 class TestActionResoudreRscMaintenant(SouscriptionsTestCase):
     """Le bouton « résoudre la RSC maintenant » sur la Souscription."""
-
-    def setUp(self):
-        super().setUp()
-        patcher = patch.object(service_module, 'ELECTRICORE_CLIENT_DISPONIBLE', True)
-        patcher.start()
-        self.addCleanup(patcher.stop)
-        ICP = self.env['ir.config_parameter'].sudo()
-        ICP.set_param('souscriptions.electricore_url', 'https://electricore.example.test')
-        ICP.set_param('souscriptions.electricore_api_key', 'fake-api-key')
 
     def _patch_appeler(self, return_value=None, side_effect=None):
         return patch.object(


### PR DESCRIPTION
Consolide les deux gardes d'import + `_client()` dupliquées du service RSC (#88) et du wizard de pull des méta-périodes (#77) en un seul AbstractModel `souscription.electricore.client` (ADR 0024), méthode `client()`. Chaque appelant garde son appel d'endpoint propre (`resoudre_rsc` en lot / `meta_periodes` en flux via la nouvelle couture `_ouvrir_flux`) et son mapping d'exceptions ; le wizard acquiert `client()` en tête de `action_lancer` (fast-fail avant tout search). `electricore-client` reste absent de `external_dependencies` (module toujours installable sans le paquet).

Les tests « paquet manquant » / « config manquante », dupliqués dans les deux suites (+ un troisième point de duplication trouvé dans `test_poll_affaires_enedis.py`), sont désormais testés une seule fois dans `tests/test_electricore_client_fabrique.py`.

Suite complète : **312 tests, 0 failed, 0 error** (docker, odoo:19.0).

Closes #119

🤖 Generated with [Claude Code](https://claude.com/claude-code)