### PR TITLE
feat(raccordement): estimation des provisions à l'étape « Calcul de mensualités »

### DIFF
--- a/models/raccordement/raccordement_demande.py
+++ b/models/raccordement/raccordement_demande.py
@@ -1,6 +1,7 @@
 import logging
 import re
 
+import requests
 from odoo import api, fields, models
 from odoo.exceptions import UserError, ValidationError
 
@@ -31,6 +32,15 @@ class RaccordementDemande(models.Model):
     color = fields.Integer(string='Couleur', related='stage_id.color')
     kanban_state = fields.Selection(
         [('normal', 'En cours'), ('blocked', 'Bloqué'), ('done', 'Prêt')], string='État kanban', default='normal'
+    )
+    # Visibilité du bouton « Estimer les provisions » (#121) : calculée plutôt
+    # que comparée en XML (un many2one ne se compare pas à un xmlid dans une
+    # expression de vue) — même idiome que les autres gardes par étape
+    # (env.ref) du module, cf. _avancer_demande_valide_sge.
+    en_calcul_mensualites = fields.Boolean(
+        string="À l'étape « Calcul de mensualités »",
+        compute='_compute_en_calcul_mensualites',
+        help="Vrai à l'étape « Calcul de mensualités en cours » (#121).",
     )
 
     # Informations souscription
@@ -252,6 +262,14 @@ class RaccordementDemande(models.Model):
         """Retourne toutes les étapes pour la vue kanban"""
         # Retourne toutes les étapes dans l'ordre défini
         return stages.search([], order='sequence')
+
+    @api.depends('stage_id')
+    def _compute_en_calcul_mensualites(self):
+        """Vrai à l'étape « Calcul de mensualités en cours » (#121) — pilote
+        la visibilité du bouton « Estimer les provisions »."""
+        stage = self.env.ref('souscriptions_odoo.stage_calcul_mensualites', raise_if_not_found=False)
+        for record in self:
+            record.en_calcul_mensualites = bool(stage) and record.stage_id == stage
 
     @api.depends('bank_iban')
     def _compute_iban_valide(self):
@@ -694,3 +712,133 @@ class RaccordementDemande(models.Model):
             souscription.enregistrer_consentement('courbe_charge', source=source)
 
         return souscription
+
+    # --- Estimation des provisions (#121, GET /provision/estimation) ---
+    #
+    # Bouton seulement, pas d'auto-déclenchement au drag kanban : un appel
+    # réseau dans write() bloquerait la transaction du drag-and-drop — le
+    # bouton suffit (l'AC de l'issue accepte « bouton, et/ou auto »).
+
+    _CONTRACT_VERSION_ESTIMATION_ATTENDU = 1
+
+    def action_estimer_provisions(self):
+        """Bouton « Estimer les provisions » (visible à l'étape « Calcul de
+        mensualités en cours ») : interroge electricore
+        (GET /provision/estimation) et pré-remplit les provisions selon le
+        tarif. L'humain garde la main — les champs restent éditables — et
+        l'absence de données (trouve=False, 503 flux R67) n'empêche jamais la
+        saisie manuelle : c'est le chemin normal."""
+        self.ensure_one()
+        client = self.env['souscription.electricore.client'].client()  # fast-fail paquet+config (ADR 0024)
+        try:
+            reponse = self._appeler_estimation(client, self.pdl)
+        except requests.exceptions.HTTPError as exc:
+            if exc.response is not None and exc.response.status_code == 503:
+                return self._notifier_estimation_indisponible(exc.response)
+            raise UserError(f"Erreur electricore lors de l'estimation des provisions : {exc}") from exc
+        except requests.exceptions.RequestException as exc:
+            raise UserError(f"Erreur electricore lors de l'estimation des provisions : {exc}") from exc
+
+        contract_version = reponse.get('contract_version')
+        if contract_version is None or contract_version < self._CONTRACT_VERSION_ESTIMATION_ATTENDU:
+            raise UserError(
+                "Version de contrat electricore inattendue pour l'estimation des provisions : "
+                f'{contract_version!r} (attendu >= {self._CONTRACT_VERSION_ESTIMATION_ATTENDU}).'
+            )
+
+        if not reponse.get('trouve'):
+            self.message_post(
+                body='Aucune mesure R67 dans la fenêtre de 12 mois : estimation impossible, saisie manuelle.'
+            )
+            return
+
+        self._appliquer_estimation(reponse['estimation'])
+
+    def _appeler_estimation(self, client, pdl):
+        """Point de transport unique : GET /provision/estimation?pdl=<pdl>
+        (couture patchée en tests, réponse en boîte — rien d'autre n'est
+        mocké).
+
+        TODO: electricore-client 0.2.0 n'expose pas encore
+        `/provision/estimation` (seuls meta_periodes, chronologie,
+        turpe_variable, resoudre_rsc existent) : basculer sur la méthode du
+        client quand elle existera."""
+        response = requests.get(
+            f'{client.url}/provision/estimation',
+            params={'pdl': pdl},
+            headers={'X-API-Key': client.api_key},
+            timeout=30,
+        )
+        response.raise_for_status()
+        return response.json()
+
+    def _notifier_estimation_indisponible(self, response):
+        """503 = état opérationnel attendu (flux R67 non matérialisé — M023
+        pas encore ingérée sur le portail SGE — ou ingestion en cours) :
+        jamais une UserError. Tracé au chatter comme information
+        opérationnelle, et notification non bloquante côté utilisateur."""
+        self.ensure_one()
+        try:
+            detail = response.json().get('detail')
+        except ValueError:
+            detail = None
+        message = detail or (
+            'Flux R67 non disponible pour ce PDL (mesures pas encore ingérées, ou ingestion en cours) : '
+            'réessayez plus tard, ou saisissez les provisions à la main.'
+        )
+        self.message_post(body=f'Estimation des provisions indisponible : {message}')
+        return {
+            'type': 'ir.actions.client',
+            'tag': 'display_notification',
+            'params': {
+                'title': 'Estimation des provisions indisponible',
+                'message': message,
+                'type': 'warning',
+                'sticky': False,
+            },
+        }
+
+    def _appliquer_estimation(self, estimation):
+        """Pré-remplit les provisions selon le tarif à partir de l'estimation
+        electricore — en kWh, zéro € (la valorisation reste côté grille de
+        prix) — puis trace un unique message chatter récapitulatif (pas de
+        spam). Profondeur HP/HC insuffisante (champs null, ou
+        `profondeur_cadran == 'base'`) sur un tarif HP/HC : ne remplit rien,
+        repli manuel signalé au chatter."""
+        self.ensure_one()
+        if self.type_tarif == 'base':
+            vals = {'provision_mensuelle_kwh': estimation.get('energie_base_mensuel_kwh') or 0.0}
+        else:  # hphc
+            hp = estimation.get('energie_hp_mensuel_kwh')
+            hc = estimation.get('energie_hc_mensuel_kwh')
+            if hp is None or hc is None or estimation.get('profondeur_cadran') == 'base':
+                self.message_post(
+                    body='Estimation electricore insuffisamment détaillée (profondeur HP/HC absente) : '
+                    'aucune provision pré-remplie, saisie manuelle nécessaire.'
+                )
+                return
+            vals = {'provision_hp_kwh': hp, 'provision_hc_kwh': hc}
+
+        self.write(vals)
+        self.message_post(body=self._message_recapitulatif_estimation(estimation, vals))
+
+    @staticmethod
+    def _message_recapitulatif_estimation(estimation, vals):
+        """Résumé chatter (un seul post par clic, pas de spam) : valeurs
+        pré-remplies, couverture, profondeur, qualité, alerte éventuelle."""
+        lignes = ['Estimation des provisions (electricore) :']
+        if 'provision_mensuelle_kwh' in vals:
+            lignes.append(f'- Provision mensuelle (Base) : {vals["provision_mensuelle_kwh"]:.1f} kWh')
+        if 'provision_hp_kwh' in vals:
+            lignes.append(f'- Provision HP mensuelle : {vals["provision_hp_kwh"]:.1f} kWh')
+            lignes.append(f'- Provision HC mensuelle : {vals["provision_hc_kwh"]:.1f} kWh')
+        suffisante = 'suffisante' if estimation.get('couverture_suffisante') else 'insuffisante'
+        lignes.append(
+            f'- Couverture : {estimation.get("couverture_mois")} mois, '
+            f'{estimation.get("couverture_debut")} → {estimation.get("couverture_fin")} ({suffisante})'
+        )
+        lignes.append(f'- Profondeur : {estimation.get("profondeur_cadran")}')
+        lignes.append(f'- Qualité : {estimation.get("qualite")}')
+        if estimation.get('signal_alertable'):
+            lignes.append('⚠️ Signal alertable : estimation à vérifier avant validation.')
+        return '\n'.join(lignes)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -3,6 +3,7 @@ from . import (
     test_catalogue,
     test_documents_contractuels,
     test_electricore_client_fabrique,
+    test_estimation_provisions,
     test_facturation,
     test_grille_prix,
     test_integration,

--- a/tests/test_estimation_provisions.py
+++ b/tests/test_estimation_provisions.py
@@ -1,0 +1,196 @@
+"""Tests #121 — estimation des provisions à l'étape « Calcul de mensualités »
+(GET /provision/estimation).
+
+Couture de test : on patche `_appeler_estimation`, la méthode transport de
+`raccordement.demande`, avec des réponses en boîte. Le client lui-même est
+fourni directement par la fabrique patchée (`souscription.electricore.client`,
+ADR 0024) — sa garde paquet/config est testée une fois dans
+test_electricore_client_fabrique.py, pas ici. Aucun HTTP réel.
+"""
+
+from datetime import date, timedelta
+from unittest.mock import MagicMock, patch
+
+import requests
+from odoo.addons.souscriptions_odoo.models.core import electricore_client_fabrique as fabrique_module
+from odoo.addons.souscriptions_odoo.models.raccordement import raccordement_demande as demande_module
+from odoo.tests.common import tagged
+
+from .common import SouscriptionsTestCase
+
+
+def _estimation(**kwargs):
+    """Stub de l'enveloppe `estimation` (dict plat, contrat electricore)."""
+    base = dict(
+        energie_base_kwh=3360.0,
+        energie_hp_kwh=None,
+        energie_hc_kwh=None,
+        energie_base_mensuel_kwh=280.0,
+        energie_hp_mensuel_kwh=None,
+        energie_hc_mensuel_kwh=None,
+        profondeur_cadran='base',
+        couverture_mois=12.0,
+        couverture_debut='2023-01-01',
+        couverture_fin='2024-01-01',
+        couverture_suffisante=True,
+        qualite='bonne',
+        presence_regularisation=False,
+        signal_alertable=False,
+    )
+    base.update(kwargs)
+    return base
+
+
+def _reponse(trouve=True, estimation=None, contract_version=1):
+    """Stub de l'enveloppe JSON de `GET /provision/estimation`."""
+    return {
+        'contract_version': contract_version,
+        'pdl': 'PDL_ESTIMATION_TEST',
+        'as_of': '2024-01-01',
+        'trouve': trouve,
+        'estimation': estimation,
+    }
+
+
+def _http_error_503(detail=None):
+    """Stub de `requests.exceptions.HTTPError` (503), avec ou sans `detail`
+    JSON — mime `response.raise_for_status()`."""
+    response = MagicMock()
+    response.status_code = 503
+    response.json.return_value = {'detail': detail} if detail else {}
+    return requests.exceptions.HTTPError(response=response)
+
+
+@tagged('souscriptions', 'souscriptions_estimation_provisions', 'post_install', '-at_install')
+class TestEstimationProvisions(SouscriptionsTestCase):
+    def setUp(self):
+        super().setUp()
+        # Le client est fourni directement par la fabrique patchée : la garde
+        # paquet/config (ADR 0024) est hors sujet ici (cf.
+        # test_electricore_client_fabrique.py).
+        self.fake_client = MagicMock(url='https://electricore.example.test', api_key='fake-api-key')
+        patcher = patch.object(fabrique_module.SouscriptionElectricoreClient, 'client', return_value=self.fake_client)
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+    def _patch_appeler_estimation(self, return_value=None, side_effect=None):
+        return patch.object(
+            demande_module.RaccordementDemande,
+            '_appeler_estimation',
+            return_value=return_value,
+            side_effect=side_effect,
+        )
+
+    def _creer_demande(self, **kwargs):
+        vals = dict(
+            pdl='PDL_ESTIMATION_TEST',
+            date_debut_souhaitee=date.today() + timedelta(days=30),
+            puissance_souscrite='6',
+            type_tarif='base',
+            contact_nom='Test',
+            contact_email='estimation-provisions@example.com',
+            contact_street='Test Street',
+            contact_zip='12345',
+            contact_city='Test City',
+            mode_paiement='virement',
+        )
+        vals.update(kwargs)
+        return self.env['raccordement.demande'].create(vals)
+
+    def _demande_calcul_mensualites(self, **kwargs):
+        demande = self._creer_demande(**kwargs)
+        demande.stage_id = self.env.ref('souscriptions_odoo.stage_calcul_mensualites')
+        return demande
+
+    # --- Pré-remplissage selon le tarif ---
+
+    def test_base_pre_rempli(self):
+        demande = self._demande_calcul_mensualites(type_tarif='base')
+        avant = len(demande.message_ids)
+        estimation = _estimation(energie_base_mensuel_kwh=312.5)
+
+        with self._patch_appeler_estimation(return_value=_reponse(estimation=estimation)):
+            demande.action_estimer_provisions()
+
+        self.assertEqual(demande.provision_mensuelle_kwh, 312.5)
+        # Un seul post par clic (pas de spam).
+        self.assertEqual(len(demande.message_ids) - avant, 1)
+
+    def test_hphc_pre_rempli(self):
+        demande = self._demande_calcul_mensualites(type_tarif='hphc')
+        estimation = _estimation(
+            profondeur_cadran='hp_hc',
+            energie_hp_mensuel_kwh=210.0,
+            energie_hc_mensuel_kwh=95.0,
+        )
+
+        with self._patch_appeler_estimation(return_value=_reponse(estimation=estimation)):
+            demande.action_estimer_provisions()
+
+        self.assertEqual(demande.provision_hp_kwh, 210.0)
+        self.assertEqual(demande.provision_hc_kwh, 95.0)
+
+    def test_hphc_profondeur_insuffisante_ne_remplit_rien(self):
+        """profondeur_cadran == 'base' (ou champs hp/hc null) sur un tarif
+        HP/HC -> repli manuel, aucun champ pré-rempli."""
+        demande = self._demande_calcul_mensualites(type_tarif='hphc')
+        avant_hp, avant_hc = demande.provision_hp_kwh, demande.provision_hc_kwh
+        avant_msgs = len(demande.message_ids)
+        estimation = _estimation(profondeur_cadran='base', energie_hp_mensuel_kwh=None, energie_hc_mensuel_kwh=None)
+
+        with self._patch_appeler_estimation(return_value=_reponse(estimation=estimation)):
+            demande.action_estimer_provisions()
+
+        self.assertEqual(demande.provision_hp_kwh, avant_hp)
+        self.assertEqual(demande.provision_hc_kwh, avant_hc)
+        self.assertEqual(len(demande.message_ids) - avant_msgs, 1)
+        self.assertIn('profondeur', demande.message_ids[0].body.lower())
+
+    # --- trouve=False / 503 : jamais bloquant ---
+
+    def test_trouve_false_necrit_rien(self):
+        demande = self._demande_calcul_mensualites(type_tarif='base')
+        avant = demande.provision_mensuelle_kwh
+        avant_msgs = len(demande.message_ids)
+
+        with self._patch_appeler_estimation(return_value=_reponse(trouve=False, estimation=None)):
+            demande.action_estimer_provisions()  # ne doit pas lever
+
+        self.assertEqual(demande.provision_mensuelle_kwh, avant)
+        self.assertEqual(len(demande.message_ids) - avant_msgs, 1)
+
+    def test_503_ne_leve_pas_userror(self):
+        """503 = état opérationnel attendu (flux R67 pas encore matérialisé) :
+        chatter + notification non bloquante, jamais une UserError."""
+        demande = self._demande_calcul_mensualites(type_tarif='base')
+        avant_msgs = len(demande.message_ids)
+
+        with self._patch_appeler_estimation(side_effect=_http_error_503('flux R67 non matérialisé')):
+            resultat = demande.action_estimer_provisions()  # ne doit pas lever
+
+        self.assertEqual(resultat['type'], 'ir.actions.client')
+        self.assertEqual(resultat['tag'], 'display_notification')
+        self.assertEqual(resultat['params']['type'], 'warning')
+        self.assertFalse(resultat['params']['sticky'])
+        self.assertEqual(len(demande.message_ids) - avant_msgs, 1)
+
+    # --- Éditabilité + recopie vers la Souscription ---
+
+    def test_valeurs_restent_editables_apres_estimation(self):
+        demande = self._demande_calcul_mensualites(type_tarif='base')
+        with self._patch_appeler_estimation(return_value=_reponse(estimation=_estimation())):
+            demande.action_estimer_provisions()
+
+        demande.write({'provision_mensuelle_kwh': 999.0})
+        self.assertEqual(demande.provision_mensuelle_kwh, 999.0)
+
+    def test_recopie_vers_souscription_inchangee(self):
+        """La recopie des provisions vers la Souscription à la validation
+        (`_create_souscription`, ~ligne 673) reste inchangée par #121."""
+        demande = self._creer_demande(type_tarif='hphc', provision_hp_kwh=210.0, provision_hc_kwh=95.0)
+        demande.stage_id = self.env.ref('souscriptions_odoo.stage_accepte_iban_verifie')
+
+        souscription = demande.souscription_id
+        self.assertTrue(souscription, "La Souscription devrait naître à l'acceptation")
+        self.assertEqual(souscription.provision_hp_kwh, 210.0)
+        self.assertEqual(souscription.provision_hc_kwh, 95.0)

--- a/views/raccordement/raccordement_demande_views.xml
+++ b/views/raccordement/raccordement_demande_views.xml
@@ -7,6 +7,11 @@
         <field name="arch" type="xml">
             <form>
                 <header>
+                    <button name="action_estimer_provisions"
+                            string="Estimer les provisions"
+                            type="object"
+                            icon="fa-calculator"
+                            invisible="not en_calcul_mensualites" />
                     <field name="stage_id" widget="statusbar" options="{'clickable': '1'}" />
                 </header>
                 <sheet>


### PR DESCRIPTION
Bouton « Estimer les provisions » sur `raccordement.demande`, visible à l'étape « Calcul de mensualités en cours » : acquiert le client via la fabrique (ADR 0024, fast-fail paquet+config), interroge `GET /provision/estimation` via une couture de transport dédiée, et pré-remplit les provisions selon le tarif (Base, ou HP/HC si la profondeur du cadran le permet). `trouve=False` et 503 (flux R67 non matérialisé) ne bloquent jamais la saisie manuelle : chatter informatif, jamais de `UserError` pour ces deux cas.

Pas d'auto-déclenchement au drag kanban (un appel réseau dans `write()` bloquerait la transaction) : le bouton suffit, conforme à l'AC « bouton, et/ou auto ».

Transport temporaire via `requests` en attendant que `electricore-client` expose `/provision/estimation` (0.2.0 ne l'expose pas encore ; TODO laissé dans le code). **Suivi côté electricore** : ajouter `provision_estimation(pdl)` au paquet fin, puis re-pin ici.

**Empilée sur #123** (base `refactor/119-fabrique-client-electricore`) — à merger après elle, en re-basant la base sur `main`.

Suite complète : **312 tests, 0 failed, 0 error** (docker, odoo:19.0).

Closes #121

🤖 Generated with [Claude Code](https://claude.com/claude-code)