### PR TITLE
fix(periode): qualite porte les valeurs du contrat electricore (réelle/estimée, accents compris)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -105,6 +105,18 @@ _Éviter_ : confondre **index** (la valeur cumulée d'un registre) et **relevé*
 en porte plusieurs) ; confondre avec `energie_*` (la *consommation* dérivée des relevés) ; cadran
 facturé.
 
+**Qualité (verdict)** :
+Verdict electricore sur l'énergie d'une *Période* : **réelle**, **estimée** ou **incalculable** —
+les termes du glossaire electricore, portés **tels quels** (accents compris) sur la Période
+(ADR 0020 : noms *et valeurs* du contrat). Concept **amont** : le rollup depuis la nature des
+relevés bornants (pire-gagne) appartient à electricore (son ADR-0033) ; côté addon le·la
+*facturiste* le **lit**, ne le calcule ni le modifie. Une période *incalculable* est créée quand
+même (brouillon facturable, cf. *Période*). Jumeau : **statut de communication**
+(communicante / non communicante), même provenance, même statut readonly.
+_Éviter_ : `data_complete` (l'ancien drapeau binaire qu'il remplace) ; confondre avec la **nature**
+d'un *Relevé* (réel/estimé au grain relevé — la qualité est le verdict au grain *période*) ;
+désaccentuer les valeurs (`reelle` n'existe pas sur le fil — bug S0001).
+
 **Grille de prix** :
 Barème **fournisseur** daté (`grille.prix`), **tout-compris** : le TURPE y est **absorbé**, jamais
 refacturé ligne à ligne (ADR 0002). Porte le prix d'abonnement **affine** — prix de base 3 kVA +

--- a/docs/adr/0020-alignement-contrat-meta-periodes-v3.md
+++ b/docs/adr/0020-alignement-contrat-meta-periodes-v3.md
@@ -1,5 +1,14 @@
 # Alignement sur le contrat méta-périodes v3 : noms du contrat, `mois` canonique, atterrissage des verdicts et montants, provenance des relevés
 
+*Note (juillet 2026) : le §1 s'étend des **noms** aux **valeurs** du contrat. Le fil sert les
+verdicts avec les termes du glossaire electricore — `qualite ∈ {réelle, estimée, incalculable}`,
+**accentués** (son ADR-0033) — et les clés de sélection Odoo les reprennent **telles quelles** ;
+les clés désaccentuées (`reelle`, `estimee`) du premier atterrissage étaient une traduction
+involontaire, révélée en prod par le rejet du pull S0001 (`Wrong value ... 'réelle'`). Même
+raison que pour les noms : toute couche de traduction est une classe de bugs. Une valeur de fil
+hors sélection reste un **échec bruyant** skip-and-report (savepoint, ADR-0011) — pas de repli
+silencieux : hors bump de `contract_version`, c'est une violation de contrat qui doit se voir.*
+
 [ADR-0011](0011-contrat-pull-facturation-electricore-cle-rsc-mois.md) a fixé le pull
 facturiste sur un payload *supposé* ; depuis, electricore a versionné son contrat **réel** :
 `PeriodeMeta` **v3** (`electricore_client.models.meta_periodes`, servi en `response_model`,

--- a/models/core/souscription_periode.py
+++ b/models/core/souscription_periode.py
@@ -87,7 +87,7 @@ class SouscriptionPeriode(models.Model):
     # data_complete d'ADR 0011 ; une période incalculable est créée quand même
     # (le brouillon facturable reste la règle, CONTEXT.md).
     qualite = fields.Selection(
-        [('reelle', 'Réelle'), ('estimee', 'Estimée'), ('incalculable', 'Incalculable')],
+        [('réelle', 'Réelle'), ('estimée', 'Estimée'), ('incalculable', 'Incalculable')],
         string='Qualité',
         readonly=True,
         help="Verdict electricore sur la qualité de l'énergie de cette période.",

--- a/tests/test_periode_atterrissage.py
+++ b/tests/test_periode_atterrissage.py
@@ -33,7 +33,7 @@ class TestPeriodeAtterrissage(SouscriptionsTestCase):
         """Les champs d'atterrissage v3 se créent et se lisent tels quels."""
         periode = self._periode(
             self.souscription_base,
-            qualite='estimee',
+            qualite='estimée',
             statut_communication='non_communicante',
             has_changement=True,
             source_hash='abc123',
@@ -42,7 +42,7 @@ class TestPeriodeAtterrissage(SouscriptionsTestCase):
             puissance_moyenne_kva=5.8,
         )
 
-        self.assertEqual(periode.qualite, 'estimee')
+        self.assertEqual(periode.qualite, 'estimée')
         self.assertEqual(periode.statut_communication, 'non_communicante')
         self.assertTrue(periode.has_changement)
         self.assertEqual(periode.source_hash, 'abc123')
@@ -65,7 +65,7 @@ class TestPeriodeAtterrissage(SouscriptionsTestCase):
         with self.assertRaises(UserError):
             periode.write({'cta_eur': 999.0})
         with self.assertRaises(UserError):
-            periode.write({'qualite': 'reelle'})
+            periode.write({'qualite': 'réelle'})
         with self.assertRaises(UserError):
             periode.write({'puissance_moyenne_kva': 12.0})
 

--- a/tests/test_pull_meta_periodes.py
+++ b/tests/test_pull_meta_periodes.py
@@ -66,7 +66,7 @@ def _periode_meta(**kwargs):
         cta_eur=1.1,
         taux_accise_eur_mwh=21.0,
         has_changement=False,
-        qualite='reelle',
+        qualite='réelle',
         statut_communication='communicante',
         releves_utilises=[],
         source_hash='hash-abc123',
@@ -91,7 +91,7 @@ class TestAmorcerDepuisMeta(SouscriptionsTestCase):
         self.assertEqual(periode.turpe_variable, 4.2)
         self.assertEqual(periode.cta_eur, 1.1)
         self.assertEqual(periode.taux_accise_eur_mwh, 21.0)
-        self.assertEqual(periode.qualite, 'reelle')
+        self.assertEqual(periode.qualite, 'réelle')
         self.assertEqual(periode.statut_communication, 'communicante')
         self.assertEqual(periode.source_hash, 'hash-abc123')
         self.assertFalse(periode.has_changement)
@@ -403,7 +403,7 @@ class TestAmorcerDepuisMetaAvecPaquetReel(SouscriptionsTestCase):
             cta_eur=1.1,
             taux_accise_eur_mwh=21.0,
             has_changement=False,
-            qualite='reelle',
+            qualite='réelle',
             statut_communication='communicante',
             releves_utilises=[
                 ObjetReleve(
@@ -421,7 +421,7 @@ class TestAmorcerDepuisMetaAvecPaquetReel(SouscriptionsTestCase):
 
         self.assertEqual(periode.date_debut, date(2024, 1, 1))
         self.assertEqual(periode.energie_base_kwh, 280.0)
-        self.assertEqual(periode.qualite, 'reelle')
+        self.assertEqual(periode.qualite, 'réelle')
         self.assertEqual(len(periode.releve_ids), 1)
         self.assertEqual(periode.releve_ids.releve_externe_id, 'ELC-RELEVE-100')
         self.assertEqual(periode.releve_ids.index_base, 1000.0)


### PR DESCRIPTION
Closes #125

La sélection `qualite` de la *Période* attendait des clés désaccentuées
(`reelle`/`estimee`) alors qu'electricore sert les termes accentués de son
glossaire (`réelle`/`estimée`/`incalculable`, ADR-0033 amont). En prod, ça
faisait échouer le pull facturiste sur S0001 (`Wrong value for
souscription.periode.qualite: 'réelle'`), période non créée.

Correction : les clés de sélection reprennent les valeurs du fil telles
quelles, accents compris (ADR 0020 §1 étendu aux valeurs) — aucune couche de
traduction, mapping d'amorçage inchangé. Les réponses en boîte des tests
(`test_periode_atterrissage.py`, `test_pull_meta_periodes.py`) encodaient un
fil imaginaire désaccentué ; corrigées vers les valeurs réelles.

Aucune migration de données : zéro période en base avec les valeurs
désaccentuées, le wizard étant le seul écrivain et ayant toujours échoué
dessus.

**Déploiement (post-merge) :** mise à jour du module requise (`-u`, les
valeurs de sélection sont matérialisées en base), puis re-run du wizard sur
le même mois pour que la période S0001 se crée sans erreur.

Suite complète : `0 failed, 0 error(s) of 321 tests` (docker, image odoo:19.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)