### PR TITLE
Docker dev — crons off : --max-cron-threads=0 sur odoo et odoo-dev

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       retries: 5
 
   odoo:
-    build: 
+    build:
       context: ../
       dockerfile: docker/Dockerfile
     depends_on:
@@ -39,9 +39,10 @@ services:
       --db_password=odoo
       --addons-path=/usr/lib/python3/dist-packages/odoo/addons,/mnt/extra-addons
       --load-language=fr_FR
+      --max-cron-threads=0
 
   odoo-dev:
-    build: 
+    build:
       context: ../
       dockerfile: docker/Dockerfile
     depends_on:
@@ -63,6 +64,7 @@ services:
       --db_password=odoo
       --addons-path=/usr/lib/python3/dist-packages/odoo/addons,/mnt/extra-addons
       --load-language=fr_FR
+      --max-cron-threads=0
       --dev=reload,xml,qweb
     profiles:
       - dev


### PR DESCRIPTION
Closes #127

Tient le garde-fou charter migration « SMTP neutralisé, crons off » (user story 25) sur la compose dev : `workers = 0` ne coupe pas le cron Odoo, or l'addon embarque un cron de poll Enedis et des templates de mails automatiques qui se déclencheraient sur données réelles pendant un battle-test.

- `--max-cron-threads=0` ajouté à la commande des services `odoo` et `odoo-dev` de `docker/docker-compose.yml`
- Aucune configuration SMTP sortante introduite (le diff n'ajoute que le flag cron + fixes whitespace du hook pre-commit)
- `docker-compose.demo.yml` et `docker-compose.prod.yml` non modifiées

🤖 Generated with [Claude Code](https://claude.com/claude-code)