### PR TITLE
Sync electricore : pull-tout des prestations F15, dédup par référence Enedis

### DIFF
--- a/models/core/souscription_refacturation.py
+++ b/models/core/souscription_refacturation.py
@@ -1,4 +1,8 @@
-from odoo import api, fields, models
+import logging
+
+from odoo import _, api, fields, models
+
+_logger = logging.getLogger(__name__)
 
 
 class SouscriptionRefacturation(models.Model):
@@ -104,3 +108,107 @@ class SouscriptionRefacturation(models.Model):
                 'price_unit': self.prix,
             },
         )
+
+    # --- Sync electricore : pull-tout des prestations F15 (#37, ADR 0009 §2) ---
+
+    def synchroniser_depuis_electricore(self):
+        """Tire TOUTES les prestations F15 d'electricore et upsert par référence Enedis.
+
+        Pas de fenêtre temporelle : les lignes F15 arrivent en retard, datées dans
+        le passé — un curseur de date les manquerait (ADR 0009 §2) ; l'idempotence
+        vient de la contrainte UNIQUE sur `reference_enedis`. Le client est acquis
+        en tête, avant tout travail (échec rapide et déterministe, ADR 0024 §5).
+        """
+        client = self.env['souscription.electricore.client'].client()
+        compte = self._upserter_prestations(self._tirer_prestations(client))
+        message = _(
+            'Prestations : %(creees)s créée(s), %(maj)s mise(s) à jour, %(facturees)s facturée(s) '
+            'inchangée(s), %(ignorees)s sans souscription, %(erreurs)s en erreur (voir logs).',
+            **compte,
+        )
+        return {
+            'type': 'ir.actions.client',
+            'tag': 'display_notification',
+            'params': {
+                'title': _('Sync prestations electricore'),
+                'message': message,
+                'type': 'warning' if compte['erreurs'] else 'success',
+                'sticky': False,
+            },
+        }
+
+    def _tirer_prestations(self, client):
+        """Couture transport (patchée par les tests) : consomme le flux JSONL typé
+        (`PrestationF15`, contrat v1) et rend des dicts plats."""
+        with client.prestations() as flux:
+            return [presta.model_dump() for presta in flux]
+
+    def _upserter_prestations(self, lignes):
+        """Upsert par `reference_enedis` après résolution de la souscription.
+
+        Savepoint par ligne (skip-and-report, ADR 0011) : une contrainte sur une
+        ligne n'emporte pas le lot. Une prestation déjà FACTURÉE n'est jamais
+        réécrite — `facture_id` est la source de vérité du « facturé » (ADR 0009
+        §4), la refacturer suivrait la facture, pas le flux.
+        """
+        existantes = {
+            p.reference_enedis: p
+            for p in self.search([('reference_enedis', 'in', [ligne['reference'] for ligne in lignes])])
+        }
+        compte = {'creees': 0, 'maj': 0, 'facturees': 0, 'ignorees': 0, 'erreurs': 0}
+        for ligne in lignes:
+            souscription = self._resoudre_souscription(ligne)
+            if not souscription:
+                compte['ignorees'] += 1
+                continue
+            existante = existantes.get(ligne['reference'])
+            if existante and existante.facture_id:
+                compte['facturees'] += 1
+                continue
+            try:
+                with self.env.cr.savepoint():
+                    vals = self._vals_prestation(ligne, souscription)
+                    if existante:
+                        existante.write(vals)
+                        compte['maj'] += 1
+                    else:
+                        self.create(vals)
+                        compte['creees'] += 1
+            except Exception:
+                _logger.warning('Sync prestation %s : échec, ligne sautée.', ligne.get('reference'), exc_info=True)
+                compte['erreurs'] += 1
+        return compte
+
+    def _resoudre_souscription(self, ligne):
+        """RSC d'abord (une RSC identifie LE contrat — vrai même pour une prestation
+        d'un ancien contrat sur le même PDL), PDL non résilié en repli et seulement
+        s'il est sans ambiguïté. Sans résolution : recordset vide (ligne ignorée, v1)."""
+        Souscription = self.env['souscription.souscription']
+        rsc = ligne.get('ref_situation_contractuelle')
+        if rsc:
+            par_rsc = Souscription.search([('ref_situation_contractuelle', '=', rsc)], limit=1)
+            if par_rsc:
+                return par_rsc
+        pdl = ligne.get('pdl')
+        if pdl:
+            candidates = Souscription.search([('pdl', '=', pdl), ('etat', '!=', 'resiliee')])
+            if len(candidates) == 1:
+                return candidates
+        return Souscription.browse()
+
+    @api.model
+    def _vals_prestation(self, ligne, souscription):
+        # 'NS' (non soumis) = indemnité hors champ TVA (pénalité due par Enedis) ;
+        # tout taux numérique = prestation taxée. La TVA elle-même suit le PRODUIT
+        # choisi par la nature (ADR 0009 §5) — jamais un taux recopié par ligne.
+        non_soumis = (ligne.get('taux_tva_applicable') or '').strip().upper() == 'NS'
+        return {
+            'reference_enedis': ligne['reference'],
+            'souscription_id': souscription.id,
+            'pdl': ligne.get('pdl') or False,
+            'code_enedis': ligne.get('id_ev') or False,
+            'libelle': ligne.get('libelle_ev') or ligne.get('id_ev') or 'Prestation Enedis',
+            'prix': ligne.get('prix_unitaire') or 0.0,
+            'quantite': ligne.get('quantite') or 1.0,
+            'nature': 'indemnite' if non_soumis else 'prestation',
+        }

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,5 @@
 # manifeste : l'absence du paquet ne doit pas empêcher l'installation du
 # module (garde d'import dans models/wizard/souscription_pull_meta_periodes_wizard.py,
 # UserError explicite au clic si absent).
-electricore-client==0.2.0
+# 0.3.0 : méthode prestations() — sync de la file « à refacturer » (#37).
+electricore-client==0.3.0

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -27,4 +27,5 @@ from . import (
     test_security,
     test_souscription,
     test_souscription_etat,
+    test_sync_prestations,
 )

--- a/tests/test_sync_prestations.py
+++ b/tests/test_sync_prestations.py
@@ -1,0 +1,160 @@
+"""Tests #37 — sync electricore des prestations : pull-tout, dédup par référence Enedis.
+
+Couture de test : `_tirer_prestations` (transport JSONL) est patchée avec des
+lignes en boîte (contrat v1 `PrestationF15`, dicts plats) ; la fabrique client
+est patchée pour rendre un MagicMock (sa garde paquet/config est testée dans
+test_electricore_client_fabrique.py). Résolution RSC/PDL, mapping nature et
+upsert restent réels. Aucun HTTP.
+"""
+
+from unittest.mock import MagicMock, patch
+
+from odoo.addons.souscriptions_odoo.models.core import electricore_client_fabrique as fabrique_module
+from odoo.addons.souscriptions_odoo.models.core import souscription_refacturation as refacturation_module
+from odoo.tests.common import tagged
+
+from .common import SouscriptionsTestCase
+
+
+def _ligne(**overrides):
+    """Stub d'une ligne du contrat v1 `PrestationF15` (dict plat)."""
+    base = dict(
+        reference='ref-0001',
+        pdl='PDL_TEST_STANDARD',
+        ref_situation_contractuelle=None,
+        id_ev='F180B',
+        nature_ev='01',
+        libelle_ev='Mise en service',
+        taux_tva_applicable='20.00',
+        prix_unitaire=30.37,
+        quantite=1.0,
+        montant_ht=30.37,
+        date_debut='2025-02-03',
+        date_fin='2025-02-03',
+        num_facture='3210619182010',
+        date_facture='2025-02-05',
+    )
+    base.update(overrides)
+    return base
+
+
+@tagged('souscriptions', 'souscriptions_sync_prestations', 'post_install', '-at_install')
+class TestSyncPrestations(SouscriptionsTestCase):
+    def setUp(self):
+        super().setUp()
+        self.fake_client = MagicMock(url='https://electricore.example.test', api_key='fake-api-key')
+        patcher = patch.object(fabrique_module.SouscriptionElectricoreClient, 'client', return_value=self.fake_client)
+        patcher.start()
+        self.addCleanup(patcher.stop)
+        self.Refacturation = self.env['souscription.refacturation']
+
+    def _sync(self, lignes):
+        with patch.object(refacturation_module.SouscriptionRefacturation, '_tirer_prestations', return_value=lignes):
+            return self.Refacturation.synchroniser_depuis_electricore()
+
+    def _prestas(self, reference):
+        return self.Refacturation.search([('reference_enedis', '=', reference)])
+
+    def test_pull_cree_et_classe_la_nature(self):
+        """Taux 'NS' -> indemnité (hors champ TVA) ; taux numérique -> prestation taxée.
+        La TVA suit le produit choisi par la nature (ADR 0009 §5), jamais la ligne."""
+        self._sync(
+            [
+                _ligne(reference='ref-mes', taux_tva_applicable='20.00'),
+                _ligne(
+                    reference='ref-pen',
+                    id_ev='DCOUP_PEN',
+                    libelle_ev='Pénalité pour coupure réseau',
+                    taux_tva_applicable='NS',
+                    prix_unitaire=-24.0,
+                    quantite=2.0,
+                ),
+            ]
+        )
+
+        mes = self._prestas('ref-mes')
+        pen = self._prestas('ref-pen')
+        self.assertEqual(mes.nature, 'prestation')
+        self.assertEqual(pen.nature, 'indemnite')
+        self.assertEqual(pen.prix, -24.0)
+        self.assertEqual(pen.quantite, 2.0)
+        self.assertEqual(pen.code_enedis, 'DCOUP_PEN')
+        self.assertEqual(mes.souscription_id, self.souscription_base)  # résolu par PDL
+
+    def test_rerun_idempotent_par_reference(self):
+        """Deux runs identiques : aucun doublon (dédup par contrainte UNIQUE + upsert)."""
+        lignes = [_ligne(reference='ref-idem')]
+        self._sync(lignes)
+        self._sync(lignes)
+
+        self.assertEqual(len(self._prestas('ref-idem')), 1)
+
+    def test_resolution_rsc_prioritaire_sur_pdl(self):
+        """La RSC identifie LE contrat : une prestation d'un ancien contrat sur le
+        même PDL ne doit pas atterrir sur le contrat courant."""
+        ancien = (
+            self.env['souscription.souscription']
+            .with_context(rsc_automatisme=True)
+            .create(
+                {
+                    'partner_id': self.partner_test.id,
+                    'pdl': 'PDL_TEST_STANDARD',  # même PDL que souscription_base
+                    'puissance_souscrite': '6',
+                    'type_tarif': 'base',
+                    'etat_facturation_id': self.etat_facturation.id,
+                    'ref_situation_contractuelle': 'RSC_SYNC_ANCIEN',
+                }
+            )
+        )
+
+        self._sync([_ligne(reference='ref-rsc', ref_situation_contractuelle='RSC_SYNC_ANCIEN')])
+
+        self.assertEqual(self._prestas('ref-rsc').souscription_id, ancien)
+
+    def test_pdl_ambigu_ou_inconnu_ignore(self):
+        """Sans RSC : PDL porté par deux souscriptions non résiliées = ambigu, ignoré ;
+        PDL inconnu = ignoré. Rien n'est matérialisé (v1, skip-and-report)."""
+        self.env['souscription.souscription'].create(
+            {
+                'partner_id': self.partner_test.id,
+                'pdl': 'PDL_TEST_STANDARD',  # doublon de PDL avec souscription_base
+                'puissance_souscrite': '6',
+                'type_tarif': 'base',
+                'etat_facturation_id': self.etat_facturation.id,
+            }
+        )
+
+        self._sync(
+            [
+                _ligne(reference='ref-ambigu'),  # PDL_TEST_STANDARD, désormais porté 2×
+                _ligne(reference='ref-orphelin', pdl='PDL_INCONNU'),
+            ]
+        )
+
+        self.assertFalse(self._prestas('ref-ambigu'))
+        self.assertFalse(self._prestas('ref-orphelin'))
+
+    def test_arrivee_tardive_materialisee(self):
+        """Pull-tout sans curseur : une ligne F15 datée dans le passé, absente du
+        premier run, est matérialisée au run suivant."""
+        self._sync([_ligne(reference='ref-t1')])
+        self._sync(
+            [
+                _ligne(reference='ref-t1'),
+                _ligne(reference='ref-tardive', date_debut='2024-01-05', date_facture='2024-02-05'),
+            ]
+        )
+
+        self.assertEqual(len(self._prestas('ref-tardive')), 1)
+
+    def test_facturee_jamais_reecrite(self):
+        """`facture_id` posé = prestation gelée : un changement amont ne la réécrit
+        pas (la source de vérité du facturé est la facture, ADR 0009 §4)."""
+        self._sync([_ligne(reference='ref-gelee', prix_unitaire=30.37)])
+        presta = self._prestas('ref-gelee')
+        _periode, facture = self.create_test_invoice(self.souscription_base)
+        presta.facture_id = facture
+
+        self._sync([_ligne(reference='ref-gelee', prix_unitaire=999.99)])
+
+        self.assertEqual(presta.prix, 30.37)

--- a/views/core/souscription_refacturation_views.xml
+++ b/views/core/souscription_refacturation_views.xml
@@ -9,6 +9,12 @@
         <field name="model">souscription.refacturation</field>
         <field name="arch" type="xml">
             <list string="Refacturations" default_order="prix desc">
+                <!-- Pull-tout depuis electricore, dédup par référence Enedis (#37) :
+                     manuel (les crons sont off en dev, garde-fou migration). -->
+                <header>
+                    <button name="synchroniser_depuis_electricore" type="object"
+                            string="Tirer d'electricore" class="btn-primary" display="always"/>
+                </header>
                 <field name="souscription_id"/>
                 <field name="pdl"/>
                 <field name="reference_enedis"/>


### PR DESCRIPTION
Closes #37

Alimente la file « à refacturer » depuis electricore : bouton **« Tirer d'electricore »** sur la liste des refacturations (déclencheur manuel — les crons sont off en dev, garde-fou migration). 6 tests, verts via `./scripts/run-tests.sh`.

**Critères d'acceptation :**
- ✅ Contrat d'endpoint épinglé et documenté — `GET /facturation/prestations` (JSONL, contrat v1), cf. Energie-De-Nantes/electricore#590
- ✅ Pull-tout + upsert par `reference_enedis`, aucun doublon au re-run (testé)
- ✅ Orphelines ignorées, non matérialisées (testé) — **révision v1** : résolution **RSC d'abord** (une RSC identifie LE contrat, correct pour une prestation d'un ancien contrat sur le même PDL), PDL non résilié *et non ambigu* en repli
- ✅ Ligne tardive datée dans le passé matérialisée au run suivant (pas de curseur, testé)
- ✅ TVA F15 : le taux (`'NS'` = non soumis) **classe la nature** indemnité/prestation — la TVA elle-même suit le produit choisi par la nature, conformément à l'ADR 0009 §5 qui a révisé ce critère
- ✅ Tests : idempotence, orphelines, arrivée tardive, dédup, + nature et gel des facturées (`facture_id` = source de vérité, ADR 0009 §4)

**Décisions (validées en séance du 2026-07-05) :** `reference` = hash de contenu calculé par l'endpoint (le F15 n'a pas d'id de ligne — libellé exclu de l'assiette) ; résolution RSC-d'abord.

⚠️ **Dépendance de déploiement** : nécessite Energie-De-Nantes/electricore#590 fusionnée, edn.electricore.fr redéployé et `electricore-client` **0.3.0** publié (épinglé dans requirements.txt). Les tests unitaires n'en dépendent pas (transport mocké).

🤖 Generated with [Claude Code](https://claude.com/claude-code)