### PR TITLE
docs: track agent cookbook registry

### DIFF
--- a/COOKBOOK.md
+++ b/COOKBOOK.md
@@ -1,0 +1,45 @@
+# Cookbook
+
+Routines registry for this repo. Each recipe is a way to reach a state or
+exercise a change. `mode: afk` = an agent can run it headless; `mode: human` =
+a present person runs it (usually needs eyeballs). `how-to` selects the fitting
+recipe(s) for a change and fills the `{placeholders}`.
+
+## bring-up
+mode: afk
+when: you need a live instance to exercise a change end to end
+do: `./scripts/run-app.sh` (runs a server — background it; `--reset` rebuilds the demo DB from scratch)
+observe: startup logs — ready when it prints `Odoo démarre sur http://localhost:8069` (login admin / admin, DB souscriptions_demo)
+
+## tests
+mode: afk
+when: a change to models/, controllers/, reports/, security/, or data/
+do: `./scripts/run-tests.sh` (whole suite) — or `TEST_TAGS={tag} ./scripts/run-tests.sh` to narrow (Odoo 19 in Docker; needs sandbox bypass)
+observe: exit code + test summary; a real failure is timestamp-prefixed (`2026-… ERROR test_db …`), docutils `<string>:N:` noise is filtered
+
+## page-render
+mode: human
+when: a change to a view (views/), the portal (controllers/), or a menu/action
+do: start the app (see `bring-up`), log in admin / admin
+look: http://localhost:8069/   # TODO(you): the route to the changed view/record
+expect: the page renders your change
+
+## report-render
+mode: human
+when: a change to a QWeb report in reports/
+do: start the app (see `bring-up`), log in admin / admin, open the report PDF URL
+look: http://localhost:8069/report/pdf/{report_name}/{record_id}
+  # report_name is one of:
+  #   souscriptions_odoo.report_facture_energie                    (record model: account.move)
+  #   souscriptions_odoo.souscription_attestation_document         (record model: souscription.souscription)
+  #   souscriptions_odoo.souscription_conditions_particulieres_document  (record model: souscription.souscription)
+  # TODO(you): the {record_id} to print
+expect: the PDF renders your change (company layout borders all tables — see report-rendering notes)
+
+## inspect-data
+mode: afk
+when: you need to check records/fields in the running instance, not just the code
+do: use the odoo MCP tools (search_records, read_record, get_model_fields…) against instance `dev`
+  # `dev`     = http://localhost:8069, db souscriptions_demo — the local docker; HAS the souscriptions module
+  # `default` = energie-de-nantes.odoo.com SaaS — does NOT carry the souscriptions module
+observe: the returned records/fields


### PR DESCRIPTION
Persist the how-to/run recipe registry that was living untracked on disk (`COOKBOOK.md`, `?? COOKBOOK.md`).

**Janitor pass result:** all 5 recipes verified fresh against the current repo — 0 dead, 0 drifted, 0 added.

| recipe | mode | verified |
|---|---|---|
| `bring-up` | afk | `scripts/run-app.sh`, port 8069, DB souscriptions_demo |
| `tests` | afk | `scripts/run-tests.sh`, TEST_TAGS narrowing |
| `page-render` | human | port 8069, admin/admin |
| `report-render` | human | 3 report names match `reports/` |
| `inspect-data` | afk | `dev`/`default` MCP instances match |

No métier logic — agent tooling/docs only. Two pre-existing `# TODO(you)` gaps remain in the human recipes (a view route, a record id); neither is a structural fact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)