### PR TITLE
Renommage : reference_enedis → reference (« Référence de contenu ») (#146)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -220,8 +220,8 @@ comme distinct de la réalité *physique* mesurée par electricore.
 
 **Refacturation (Enedis)** :
 En-cours refacturable d'origine **Enedis** que le fournisseur **refacture** au·à la
-*souscripteur·rice* (`souscription.refacturation`). Porte un *Code Enedis*, un libellé, un prix et une
-quantité. **Indépendante de la _Période_** : ce n'est pas un fait mensuel mais un en-cours rattaché à
+*souscripteur·rice* (`souscription.refacturation`). Porte une *Référence de contenu*, un *Code
+Enedis*, un libellé, un prix et une quantité. **Indépendante de la _Période_** : ce n'est pas un fait mensuel mais un en-cours rattaché à
 un·e *souscripteur·rice*, qu'une *Facture* **rassemble** au moment de la facturation (plusieurs
 *Refacturations* par *Facture*).
 Deux **natures** :
@@ -240,6 +240,16 @@ factures : il n'y a pas de garde-fou bloquant.
 _Éviter_ : **« prestation » pour désigner l'ensemble** (c'est une *nature*, pas l'umbrella — dire
 *Refacturation*) ; « presta » seule ; *service* ; confondre avec un *Geste commercial* ; **« en attente »
 pour la file par défaut** (c'est *à refacturer*).
+
+**Référence de contenu** :
+La clé d'identité d'une *Refacturation* (champ `reference`, libellé « Référence (electricore) »),
+**fabriquée par electricore** à partir du contenu de la ligne (contrat `prestations` v1, cf.
+Energie-De-Nantes/electricore#590 et `docs/contrat-prestations.md` côté electricore). Ce n'est
+**pas** une référence Enedis : le flux F15 n'a **aucun identifiant de ligne**. Le champ porte le
+nom exact du payload du contrat (`reference` — symétrie producteur/consommateur) et une contrainte
+UNIQUE : c'est elle qui rend le sync pull-tout-et-dédup **idempotent** (ADR 0009 §2).
+_Éviter_ : « référence Enedis » (le F15 n'en fournit pas) ; confondre avec le *Code Enedis* (qui
+identifie le **type** de prestation au catalogue Enedis, pas une ligne précise).
 
 **Facturiste** :
 Rôle métier qui conduit la facturation mensuelle depuis Odoo et **vérifie les données avant

--- a/demo/prestations_demo.xml
+++ b/demo/prestations_demo.xml
@@ -13,7 +13,7 @@
         <record id="demo_presta_mise_en_service" model="souscription.refacturation">
             <field name="souscription_id" ref="demo_souscription_admin"/>
             <field name="pdl">PDL22516914099999</field>
-            <field name="reference_enedis">F15-DEMO-0001</field>
+            <field name="reference">F15-DEMO-0001</field>
             <field name="code_enedis">MES</field>
             <field name="libelle">Mise en service</field>
             <field name="prix">45.85</field>
@@ -24,7 +24,7 @@
         <record id="demo_presta_penalite_coupure" model="souscription.refacturation">
             <field name="souscription_id" ref="demo_souscription_admin"/>
             <field name="pdl">PDL22516914099999</field>
-            <field name="reference_enedis">F15-DEMO-0002</field>
+            <field name="reference">F15-DEMO-0002</field>
             <field name="code_enedis">PENA</field>
             <field name="libelle">Pénalité de coupure (due par Enedis)</field>
             <field name="prix">-30.00</field>
@@ -37,7 +37,7 @@
         <record id="demo_presta_deplacement" model="souscription.refacturation">
             <field name="souscription_id" ref="demo_souscription_admin"/>
             <field name="pdl">PDL22516914099999</field>
-            <field name="reference_enedis">F15-DEMO-0003</field>
+            <field name="reference">F15-DEMO-0003</field>
             <field name="code_enedis">DEPL</field>
             <field name="libelle">Déplacement</field>
             <field name="prix">19.66</field>

--- a/docs/adr/0009-prestation-refacturer-modele-independant-rassemble-sur-facture.md
+++ b/docs/adr/0009-prestation-refacturer-modele-independant-rassemble-sur-facture.md
@@ -14,9 +14,10 @@ fait mensuel mais un **en-cours refacturable** à cadence Enedis.
    `prix`, `quantite`, sa **nature** (`prestation` taxée / `indemnite` hors champ TVA, cf. §5),
    un `souscription_id` (M2o) et un `facture_id` (M2o). Aucun lien vers `souscription.periode`.
 
-2. **Alimenté par electricore, dédupliqué par référence Enedis.** Les prestations sont
+2. **Alimenté par electricore, dédupliqué par référence de contenu.** Les prestations sont
    **tirées en totalité** d'un endpoint electricore dédié (le volume est faible — ~une par PDL),
-   puis **upsert** sur une **référence Enedis unique** (contrainte d'unicité). Pas de fenêtre
+   puis **upsert** sur une **référence de contenu unique** (contrainte d'unicité ; terme corrigé
+   par #146 — le F15 n'a pas d'identifiant de ligne, la clé est fabriquée par electricore). Pas de fenêtre
    temporelle : pull-tout-et-dédup est plus robuste qu'un curseur de date (les lignes F15
    arrivent en retard, datées dans le passé — un curseur les manquerait). Le PDL est résolu en
    *Souscription* au moment du sync ; les PDL **sans souscription active sont ignorés** (v1).
@@ -65,7 +66,7 @@ porté comme **ligne signée** qui se nette dans la facture mensuelle.
   prestations-seules (souscription sans période ce mois-là, ex. après résiliation) reste un
   **follow-up** assumé, pas du v1.
 - **Curseur temporel `[dernière facturée → maintenant]`** : fragile (prestations en retard datées
-  avant le curseur → perdues ; relances → double-facturation). La dédup par référence Enedis
+  avant le curseur → perdues ; relances → double-facturation). La dédup par référence de contenu
   supprime les deux risques.
 - **Booléen `facturee`** au lieu du M2o : deux champs à désynchroniser, et perd le « où ».
 

--- a/models/core/souscription_refacturation.py
+++ b/models/core/souscription_refacturation.py
@@ -18,7 +18,7 @@ class SouscriptionRefacturation(models.Model):
         'souscription.souscription', required=True, ondelete='cascade', string='Souscription'
     )
     pdl = fields.Char(string='PDL')
-    reference_enedis = fields.Char(string='Référence Enedis', required=True)
+    reference = fields.Char(string='Référence (electricore)', required=True)
     code_enedis = fields.Char(string='Code Enedis')
     libelle = fields.Char(string='Libellé', required=True)
     prix = fields.Float(string='Prix (€)', help='Prix de refacturation ; peut être négatif (avoir/pénalité).')
@@ -76,10 +76,12 @@ class SouscriptionRefacturation(models.Model):
     facture_id = fields.Many2one('account.move', string='Facture', readonly=True, ondelete='set null', copy=False)
 
     # Clé de dédup du sync electricore (ADR 0009) : une prestation = une référence
-    # Enedis. Pull-tout-et-dédup s'appuie dessus pour rester idempotent.
-    _unique_reference_enedis = models.Constraint(
-        'UNIQUE(reference_enedis)',
-        'Une prestation existe déjà pour cette référence Enedis.',
+    # de contenu fabriquée par electricore (contrat `prestations` v1 — le F15 n'a
+    # pas d'identifiant de ligne). Pull-tout-et-dédup s'appuie dessus pour rester
+    # idempotent.
+    _unique_reference = models.Constraint(
+        'UNIQUE(reference)',
+        'Une prestation existe déjà pour cette référence.',
     )
 
     def _composer_ligne(self):

--- a/tests/test_refacturation.py
+++ b/tests/test_refacturation.py
@@ -21,7 +21,7 @@ class TestRefacturation(SouscriptionsTestCase):
     def _presta(self, souscription, **vals):
         base = {
             'souscription_id': souscription.id,
-            'reference_enedis': 'F15-001',
+            'reference': 'F15-001',
             'libelle': 'Déplacement technicien',
             'prix': 45.0,
             'quantite': 1.0,
@@ -46,7 +46,7 @@ class TestRefacturation(SouscriptionsTestCase):
         """Opt-out (ADR 0012) : une prestation mise en attente par le·la
         facturiste n'est PAS ramassée par creer_factures() — elle reste dans
         la file, facture_id NULL."""
-        presta = self._presta(self.souscription_base, reference_enedis='F15-HOLD', en_attente=True)
+        presta = self._presta(self.souscription_base, reference='F15-HOLD', en_attente=True)
         self.create_test_periode(self.souscription_base, provision_base_kwh=100.0)
 
         self.souscription_base.creer_factures()
@@ -55,17 +55,17 @@ class TestRefacturation(SouscriptionsTestCase):
 
     def test_etat_a_refacturer_par_defaut(self):
         """Sans facture ni mise en attente, l'état dérivé est « à refacturer »."""
-        presta = self._presta(self.souscription_base, reference_enedis='F15-ETAT-AR')
+        presta = self._presta(self.souscription_base, reference='F15-ETAT-AR')
         self.assertEqual(presta.etat, 'a_refacturer')
 
     def test_etat_en_attente_quand_mise_en_attente(self):
         """Mise en attente par le·la facturiste, pas encore facturée → « en attente »."""
-        presta = self._presta(self.souscription_base, reference_enedis='F15-ETAT-EA', en_attente=True)
+        presta = self._presta(self.souscription_base, reference='F15-ETAT-EA', en_attente=True)
         self.assertEqual(presta.etat, 'en_attente')
 
     def test_etat_facturee_sur_facture_brouillon(self):
         """Ramassée sur une facture encore en brouillon → « facturée »."""
-        presta = self._presta(self.souscription_base, reference_enedis='F15-ETAT-FACT')
+        presta = self._presta(self.souscription_base, reference='F15-ETAT-FACT')
         self.create_test_periode(self.souscription_base, provision_base_kwh=100.0)
         self.souscription_base.creer_factures()
         self.assertEqual(presta.facture_id.state, 'draft')
@@ -74,7 +74,7 @@ class TestRefacturation(SouscriptionsTestCase):
     def test_etat_emise_apres_emission_facture(self):
         """Émission de la facture (brouillon → posted) : l'état dérivé passe
         « facturée » → « émise » automatiquement (recalcul, pas de cron)."""
-        presta = self._presta(self.souscription_base, reference_enedis='F15-ETAT-EMISE')
+        presta = self._presta(self.souscription_base, reference='F15-ETAT-EMISE')
         self.create_test_periode(self.souscription_base, provision_base_kwh=100.0)
         self.souscription_base.creer_factures()
         self.assertEqual(presta.etat, 'facturee')
@@ -102,7 +102,7 @@ class TestRefacturation(SouscriptionsTestCase):
         Même sur une souscription PRO, la ligne refacturée garde son prix brut.
         """
         self.souscription_base.coeff_pro = 30.0
-        presta = self._presta(self.souscription_base, reference_enedis='F15-PRO', prix=45.0)
+        presta = self._presta(self.souscription_base, reference='F15-PRO', prix=45.0)
 
         _cmd, _id, vals = presta._composer_ligne()
         self.assertEqual(vals['price_unit'], 45.0)
@@ -112,7 +112,7 @@ class TestRefacturation(SouscriptionsTestCase):
         sa ligne avec le produit Indemnité dédié, pas le produit Prestation
         (TVA). La TVA suit le produit choisi par la nature (ADR 0009), jamais un
         override de ligne."""
-        presta = self._presta(self.souscription_base, reference_enedis='F15-IND', nature='indemnite')
+        presta = self._presta(self.souscription_base, reference='F15-IND', nature='indemnite')
         _cmd, _id, vals = presta._composer_ligne()
 
         produit_indemnite = self.env.ref('souscriptions_odoo.souscriptions_product_indemnite_enedis')
@@ -128,10 +128,10 @@ class TestRefacturation(SouscriptionsTestCase):
         )
         self.env.ref('souscriptions_odoo.souscriptions_product_prestation_enedis').taxes_id = tva
 
-        self._presta(self.souscription_base, reference_enedis='F15-TVA', libelle='Déplacement', prix=50.0)
+        self._presta(self.souscription_base, reference='F15-TVA', libelle='Déplacement', prix=50.0)
         self._presta(
             self.souscription_base,
-            reference_enedis='F15-IND2',
+            reference='F15-IND2',
             libelle='Pénalité coupure',
             prix=-30.0,
             nature='indemnite',
@@ -139,9 +139,7 @@ class TestRefacturation(SouscriptionsTestCase):
         self.create_test_periode(self.souscription_base, provision_base_kwh=100.0)
 
         self.souscription_base.creer_factures()
-        facture = self.souscription_base.refacturation_ids.filtered(
-            lambda p: p.reference_enedis == 'F15-TVA'
-        ).facture_id
+        facture = self.souscription_base.refacturation_ids.filtered(lambda p: p.reference == 'F15-TVA').facture_id
         facture.action_post()
 
         self.assertEqual(facture.state, 'posted', 'la facture avec lignes prestation + indemnité se pose')
@@ -154,7 +152,7 @@ class TestRefacturation(SouscriptionsTestCase):
         """Une prestation négative (pénalité de coupure due par Enedis) atterrit
         comme ligne négative sur la facture mensuelle."""
         periode = self.create_test_periode(self.souscription_base, provision_base_kwh=100.0)
-        self._presta(self.souscription_base, reference_enedis='F15-NEG', libelle='Pénalité coupure', prix=-30.0)
+        self._presta(self.souscription_base, reference='F15-NEG', libelle='Pénalité coupure', prix=-30.0)
 
         self.souscription_base.creer_factures()
 
@@ -166,7 +164,7 @@ class TestRefacturation(SouscriptionsTestCase):
     def test_presta_facturee_une_seule_fois_sur_plusieurs_periodes(self):
         """Deux périodes facturées en un run : la presta n'atterrit que sur UNE
         facture, jamais dupliquée (pas de double facturation)."""
-        self._presta(self.souscription_base, reference_enedis='F15-UNIQ')
+        self._presta(self.souscription_base, reference='F15-UNIQ')
         p1 = self.create_test_periode(
             self.souscription_base, date_debut=date(2024, 1, 1), date_fin=date(2024, 1, 31), provision_base_kwh=100.0
         )
@@ -182,7 +180,7 @@ class TestRefacturation(SouscriptionsTestCase):
     def test_supprimer_facture_remet_presta_dans_la_file(self):
         """Supprimer la facture (échappatoire de correction, ADR 0007) re-met la
         prestation dans la file « à refacturer » (ondelete=set null)."""
-        presta = self._presta(self.souscription_base, reference_enedis='F15-DEL')
+        presta = self._presta(self.souscription_base, reference='F15-DEL')
         self.create_test_periode(self.souscription_base, provision_base_kwh=100.0)
         self.souscription_base.creer_factures()
         facture = presta.facture_id
@@ -208,12 +206,12 @@ class TestRefacturation(SouscriptionsTestCase):
         self.assertEqual(menu.parent_id, self.env.ref('souscriptions_odoo.menu_souscription_root'))
 
     @mute_logger('odoo.sql_db')
-    def test_reference_enedis_unique(self):
-        """Deux prestations ne peuvent partager la même référence Enedis : c'est
-        la clé de dédup du sync electricore (ADR 0009)."""
-        self._presta(self.souscription_base, reference_enedis='F15-DUP')
+    def test_reference_unique(self):
+        """Deux prestations ne peuvent partager la même référence de contenu :
+        c'est la clé de dédup du sync electricore (ADR 0009)."""
+        self._presta(self.souscription_base, reference='F15-DUP')
         with self.assertRaises(IntegrityError), self.env.cr.savepoint():
-            self._presta(self.souscription_base, reference_enedis='F15-DUP')
+            self._presta(self.souscription_base, reference='F15-DUP')
             self.env.flush_all()
 
 

--- a/views/core/souscription_refacturation_views.xml
+++ b/views/core/souscription_refacturation_views.xml
@@ -11,7 +11,7 @@
             <list string="Refacturations" default_order="prix desc">
                 <field name="souscription_id"/>
                 <field name="pdl"/>
-                <field name="reference_enedis"/>
+                <field name="reference"/>
                 <field name="code_enedis"/>
                 <field name="libelle"/>
                 <field name="nature"/>
@@ -38,7 +38,7 @@
                         <group string="Prestation">
                             <field name="souscription_id"/>
                             <field name="pdl"/>
-                            <field name="reference_enedis"/>
+                            <field name="reference"/>
                             <field name="code_enedis"/>
                             <field name="libelle"/>
                         </group>
@@ -61,7 +61,7 @@
         <field name="model">souscription.refacturation</field>
         <field name="arch" type="xml">
             <search>
-                <field name="reference_enedis"/>
+                <field name="reference"/>
                 <field name="libelle"/>
                 <field name="souscription_id"/>
                 <field name="pdl"/>

--- a/views/core/souscription_views.xml
+++ b/views/core/souscription_views.xml
@@ -98,7 +98,7 @@
                         <page string="Refacturations">
                             <field name="refacturation_ids">
                                 <list editable="bottom">
-                                    <field name="reference_enedis"/>
+                                    <field name="reference"/>
                                     <field name="code_enedis"/>
                                     <field name="libelle"/>
                                     <field name="quantite"/>


### PR DESCRIPTION
Closes #146

## Résumé

Prefactoring mécanique avant la réécriture du sync (#37) : le champ `reference_enedis` de la *Refacturation* n'est pas une référence Enedis (le F15 n'a aucun identifiant de ligne) mais une **référence de contenu** fabriquée par electricore (contrat `prestations` v1, cf. Energie-De-Nantes/electricore#590).

- Champ renommé `reference`, libellé « Référence (electricore) » — modèle, contrainte UNIQUE (`_unique_reference`), vues, démo, tests. Zéro occurrence restante de `reference_enedis` ni de « référence Enedis » (prose ADR 0009 corrigée, décision inchangée).
- Entrée glossaire **Référence de contenu** dans CONTEXT.md (texte arbitré en grill du 2026-07-08), avec l'_Éviter_ « référence Enedis » et la distinction d'avec le *Code Enedis* ; l'entrée *Refacturation* mentionne désormais la référence parmi ce qu'elle porte.
- Aucune migration de données : la refonte n'a pas de prod réelle.

Suite de tests : `0 failed, 0 error(s) of 326 tests` (docker, odoo:19.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)