### PR TITLE
feat(refacturation): sync electricore des prestations F15 — RSC seule, insert-si-absente (#147)

### DIFF
--- a/docs/adr/0009-prestation-refacturer-modele-independant-rassemble-sur-facture.md
+++ b/docs/adr/0009-prestation-refacturer-modele-independant-rassemble-sur-facture.md
@@ -19,8 +19,10 @@ fait mensuel mais un **en-cours refacturable** à cadence Enedis.
    puis **upsert** sur une **référence de contenu unique** (contrainte d'unicité ; terme corrigé
    par #146 — le F15 n'a pas d'identifiant de ligne, la clé est fabriquée par electricore). Pas de fenêtre
    temporelle : pull-tout-et-dédup est plus robuste qu'un curseur de date (les lignes F15
-   arrivent en retard, datées dans le passé — un curseur les manquerait). Le PDL est résolu en
-   *Souscription* au moment du sync ; les PDL **sans souscription active sont ignorés** (v1).
+   arrivent en retard, datées dans le passé — un curseur les manquerait). ~~Le PDL est résolu en
+   *Souscription* au moment du sync ; les PDL **sans souscription active sont ignorés** (v1).~~
+   *(Amendé par #147, cf. ci-dessous : résolution par **RSC seule** — pas de repli PDL — et
+   **insert-si-absente** plutôt qu'upsert.)*
 
 3. **Rassemblée sur la facture de la Période, orchestrée par la Souscription.** Une *Prestation*
    ne fabrique **pas** sa propre facture. Au moment de `souscription.creer_factures()`, après que
@@ -102,3 +104,26 @@ prestations taxées — d'où deux produits. Le module les livre tous deux **san
 
 Bénéfices : plus de mapping taux→enregistrement, positions fiscales respectées, et la « TVA pas
 depuis le défaut produit » d'origine devient « TVA *depuis* le bon produit, choisi par nature ».
+
+## Amendement (#147) — résolution par RSC seule, insert-si-absente
+
+Décisions re-instruites en séance de grill du 2026-07-08 (contre le contrat mergé
+Energie-De-Nantes/electricore#590), amendant le §2 :
+
+1. **Résolution par RSC seule, pas de repli PDL.** Cohérent avec
+   [ADR-0010](0010-identite-souscription-rsc-cle-id-affaire-amorce.md) §4 : aucun repli flou sur le
+   flux vif (vérifié en spike : 0 RSC nulle dans le F15). Une ligne dont la RSC ne matche aucune
+   *Souscription* est **ignorée et comptée au rapport** — c'est un signal de backfill RSC, la ligne
+   est rattrapée gratuitement au run suivant (pull-tout).
+
+2. **Insert-si-absente, pas d'upsert.** La *Référence de contenu* EST le contenu (hash fabriqué par
+   electricore) : même référence = même prestation **par construction** ; une vraie correction
+   Enedis arrive comme nouvelle ligne sur une nouvelle facture (nouvelle référence). Le gel des
+   facturées (§4) devient **automatique** : une ligne existante n'est jamais touchée. Limite
+   assumée : une retouche rétroactive de libellé/taux à référence constante ne se propage pas —
+   échappatoire : supprimer la ligne non facturée et resynchroniser.
+
+3. **Nature depuis le taux F15.** `taux_tva_applicable = 'NS'` (non soumis) → *indemnité* hors
+   champ TVA ; taux numérique → *prestation* taxée. La TVA suit le produit choisi par la nature
+   (§5), jamais un taux recopié par ligne. `montant_ht` est **ignoré** (vérifié en spike : 0 écart
+   avec prix × quantité sur toutes les lignes UNITE).

--- a/models/core/souscription_refacturation.py
+++ b/models/core/souscription_refacturation.py
@@ -1,4 +1,28 @@
-from odoo import api, fields, models
+import logging
+
+from odoo import _, api, fields, models
+from odoo.exceptions import UserError
+
+# Garde d'import minimale (ADR 0024) : seules les exceptions du mapping de ce
+# module sont importées ici — la construction du client (garde + drapeau +
+# config) vit dans la fabrique. Si le paquet est absent, la fabrique lève
+# avant qu'aucune de ces exceptions ne puisse être levée.
+try:
+    from electricore_client import ContractVersionError, IngestionEnCours
+    from electricore_client.exceptions import PreconditionNonRemplie
+except ImportError:  # pragma: no cover - paquet optionnel ; la fabrique lève avant tout mapping
+
+    class ContractVersionError(Exception):
+        """Repli si `electricore_client` est absent : jamais levée en pratique."""
+
+    class IngestionEnCours(Exception):
+        """Repli si `electricore_client` est absent : jamais levée en pratique."""
+
+    class PreconditionNonRemplie(Exception):
+        """Repli si `electricore_client` est absent : jamais levée en pratique."""
+
+
+_logger = logging.getLogger(__name__)
 
 
 class SouscriptionRefacturation(models.Model):
@@ -83,6 +107,105 @@ class SouscriptionRefacturation(models.Model):
         'UNIQUE(reference)',
         'Une prestation existe déjà pour cette référence.',
     )
+
+    # --- Sync electricore : pull-tout des prestations F15 (#147, ADR 0009 §2 amendé) ---
+
+    def synchroniser_depuis_electricore(self):
+        """Tire TOUTES les prestations F15 d'electricore, insert-si-absente par `reference`.
+
+        Pas de fenêtre temporelle : les lignes F15 arrivent en retard, datées dans
+        le passé — un curseur de date les manquerait (ADR 0009 §2) ; l'idempotence
+        vient de l'insert-si-absente sur la *Référence de contenu* (même référence
+        = même contenu par construction, cf. CONTEXT.md) — aucun chemin d'update,
+        le gel des facturées (ADR 0009 §4) est donc automatique. Le client est
+        acquis en tête, avant tout travail (échec rapide et déterministe, ADR 0024 §5).
+        """
+        client = self.env['souscription.electricore.client'].client()
+        try:
+            lignes = self._tirer_prestations(client)
+        except IngestionEnCours:
+            raise UserError(_("L'ingestion electricore est en cours (verrou base) : réessayez plus tard."))
+        except PreconditionNonRemplie as exc:
+            raise UserError(_('Précondition non remplie côté electricore : %s', exc))
+        except ContractVersionError as exc:
+            raise UserError(_('Contrat electricore obsolète : %s', exc))
+        compte = self._inserer_prestations(lignes)
+        message = _(
+            'Prestations : %(creees)s créée(s), %(ignorees)s sans souscription (RSC inconnue), '
+            '%(erreurs)s en erreur (voir logs).',
+            **compte,
+        )
+        return {
+            'type': 'ir.actions.client',
+            'tag': 'display_notification',
+            'params': {
+                'title': _('Sync prestations electricore'),
+                'message': message,
+                'type': 'warning' if compte['erreurs'] or compte['ignorees'] else 'success',
+                'sticky': False,
+            },
+        }
+
+    def _tirer_prestations(self, client):
+        """Couture transport (patchée par les tests) : consomme le flux JSONL typé
+        (`PrestationF15`, contrat v1) et rend des dicts plats. Seul endroit qui
+        parle réseau."""
+        with client.prestations() as flux:
+            return [presta.model_dump() for presta in flux]
+
+    def _inserer_prestations(self, lignes):
+        """Insert-si-absente par `reference`, résolution par RSC seule.
+
+        Résolution par RSC, sans repli PDL (ADR 0010 §4 : aucun repli flou sur le
+        flux vif) : une RSC qui ne matche aucune *Souscription* est ignorée et
+        comptée — signal de backfill RSC, la ligne est rattrapée gratuitement au
+        run suivant. Une référence déjà présente n'est jamais touchée (pas de
+        chemin d'update). Savepoint par ligne (skip-and-report, ADR 0011) : une
+        contrainte sur une ligne n'emporte pas le lot.
+        """
+        existantes = set(
+            self.search([('reference', 'in', [ligne['reference'] for ligne in lignes])]).mapped('reference')
+        )
+        rscs = {ligne['ref_situation_contractuelle'] for ligne in lignes if ligne.get('ref_situation_contractuelle')}
+        par_rsc = {
+            s.ref_situation_contractuelle: s
+            for s in self.env['souscription.souscription'].search([('ref_situation_contractuelle', 'in', list(rscs))])
+        }
+        compte = {'creees': 0, 'ignorees': 0, 'erreurs': 0}
+        for ligne in lignes:
+            if ligne['reference'] in existantes:
+                continue
+            souscription = par_rsc.get(ligne.get('ref_situation_contractuelle'))
+            if souscription is None:
+                compte['ignorees'] += 1
+                continue
+            try:
+                with self.env.cr.savepoint():
+                    self.create(self._vals_prestation(ligne, souscription))
+                compte['creees'] += 1
+            except Exception:
+                _logger.warning('Sync prestation %s : échec, ligne sautée.', ligne.get('reference'), exc_info=True)
+                compte['erreurs'] += 1
+        return compte
+
+    @api.model
+    def _vals_prestation(self, ligne, souscription):
+        # 'NS' (non soumis) = indemnité hors champ TVA (pénalité due par Enedis) ;
+        # tout taux numérique = prestation taxée. La TVA elle-même suit le PRODUIT
+        # choisi par la nature (ADR 0009 §5) — jamais un taux recopié par ligne.
+        # `montant_ht` est ignoré : prix × quantité fait foi (vérifié en spike,
+        # 0 écart sur toutes les lignes UNITE).
+        non_soumis = (ligne.get('taux_tva_applicable') or '').strip().upper() == 'NS'
+        return {
+            'reference': ligne['reference'],
+            'souscription_id': souscription.id,
+            'pdl': ligne.get('pdl') or False,
+            'code_enedis': ligne.get('id_ev') or False,
+            'libelle': ligne.get('libelle_ev') or ligne.get('id_ev') or 'Prestation Enedis',
+            'prix': ligne.get('prix_unitaire') or 0.0,
+            'quantite': ligne.get('quantite') or 1.0,
+            'nature': 'indemnite' if non_soumis else 'prestation',
+        }
 
     def _composer_ligne(self):
         """Compose la ligne de facture (`(0, 0, vals)`) de cette prestation.

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,8 @@
 # manifeste : l'absence du paquet ne doit pas empêcher l'installation du
 # module (garde d'import dans models/wizard/souscription_pull_meta_periodes_wizard.py,
 # UserError explicite au clic si absent).
+# TODO(#147 gate) : bump à 0.3.0 (méthode prestations(), sync de la file « à
+# refacturer ») dès sa publication sur PyPI — le pin est installé par le build
+# Docker de la CI, bumper avant publication casserait le build. D'ici là le
+# bouton « Tirer d'electricore » échoue en réel (gate de déploiement, pas de merge).
 electricore-client==0.2.0

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -27,4 +27,5 @@ from . import (
     test_security,
     test_souscription,
     test_souscription_etat,
+    test_sync_prestations,
 )

--- a/tests/test_sync_prestations.py
+++ b/tests/test_sync_prestations.py
@@ -1,0 +1,190 @@
+"""Tests #147 — sync electricore des prestations : pull-tout, insert-si-absente.
+
+Couture de test : `_tirer_prestations` (transport JSONL) est patchée avec des
+lignes en boîte (contrat v1 `PrestationF15`, dicts plats) ; la fabrique client
+est patchée pour rendre un MagicMock (sa garde paquet/config est testée dans
+test_electricore_client_fabrique.py). Résolution RSC, mapping nature et
+insert-si-absente restent réels. Aucun HTTP.
+
+Décisions du grill 2026-07-08 (cf. issue #147) : résolution par RSC seule
+(pas de repli PDL, ADR 0010 §4), insert-si-absente (pas de chemin d'update —
+la *Référence de contenu* EST le contenu), `montant_ht` ignoré.
+"""
+
+from unittest.mock import MagicMock, patch
+
+from odoo.addons.souscriptions_odoo.models.core import electricore_client_fabrique as fabrique_module
+from odoo.addons.souscriptions_odoo.models.core import souscription_refacturation as refacturation_module
+from odoo.exceptions import UserError
+from odoo.tests.common import tagged
+
+from .common import SouscriptionsTestCase
+
+
+def _ligne(**overrides):
+    """Stub d'une ligne du contrat v1 `PrestationF15` (dict plat)."""
+    base = dict(
+        reference='ref-0001',
+        pdl='PDL_TEST_STANDARD',
+        ref_situation_contractuelle='RSC_SYNC_BASE',
+        id_ev='F180B',
+        nature_ev='01',
+        libelle_ev='Mise en service',
+        taux_tva_applicable='20.00',
+        prix_unitaire=30.37,
+        quantite=1.0,
+        montant_ht=30.37,
+        date_debut='2025-02-03',
+        date_fin='2025-02-03',
+        num_facture='3210619182010',
+        date_facture='2025-02-05',
+    )
+    base.update(overrides)
+    return base
+
+
+@tagged('souscriptions', 'souscriptions_sync_prestations', 'post_install', '-at_install')
+class TestSyncPrestations(SouscriptionsTestCase):
+    def setUp(self):
+        super().setUp()
+        self.fake_client = MagicMock(url='https://electricore.example.test', api_key='fake-api-key')
+        patcher = patch.object(fabrique_module.SouscriptionElectricoreClient, 'client', return_value=self.fake_client)
+        patcher.start()
+        self.addCleanup(patcher.stop)
+        self.souscription_base.with_context(rsc_automatisme=True).write(
+            {'ref_situation_contractuelle': 'RSC_SYNC_BASE'}
+        )
+        self.Refacturation = self.env['souscription.refacturation']
+
+    def _sync(self, lignes):
+        with patch.object(refacturation_module.SouscriptionRefacturation, '_tirer_prestations', return_value=lignes):
+            return self.Refacturation.synchroniser_depuis_electricore()
+
+    def _prestas(self, reference):
+        return self.Refacturation.search([('reference', '=', reference)])
+
+    def test_pull_cree_et_classe_la_nature(self):
+        """Taux 'NS' -> indemnité (hors champ TVA) ; taux numérique -> prestation taxée.
+        La TVA suit le produit choisi par la nature (ADR 0009 §5), jamais la ligne."""
+        action = self._sync(
+            [
+                _ligne(reference='ref-mes', taux_tva_applicable='20.00'),
+                _ligne(
+                    reference='ref-pen',
+                    id_ev='DCOUP_PEN',
+                    libelle_ev='Pénalité pour coupure réseau',
+                    taux_tva_applicable='NS',
+                    prix_unitaire=-24.0,
+                    quantite=2.0,
+                ),
+            ]
+        )
+
+        mes = self._prestas('ref-mes')
+        pen = self._prestas('ref-pen')
+        self.assertEqual(mes.nature, 'prestation')
+        self.assertEqual(mes.souscription_id, self.souscription_base)  # résolu par RSC
+        self.assertEqual(pen.nature, 'indemnite')
+        self.assertEqual(pen.prix, -24.0)
+        self.assertEqual(pen.quantite, 2.0)
+        self.assertEqual(pen.code_enedis, 'DCOUP_PEN')
+        self.assertIn('2 créée(s)', action['params']['message'])
+
+    def test_rerun_idempotent_zero_creation_zero_write(self):
+        """AC1 : 2ᵉ run = 0 création, 0 write — insert-si-absente, aucun chemin
+        d'update. Même un payload amont différent à référence constante ne touche
+        pas la ligne existante (même référence = même contenu par construction ;
+        l'échappatoire est de supprimer la ligne non facturée et resynchroniser)."""
+        self._sync([_ligne(reference='ref-idem', prix_unitaire=30.37)])
+        action = self._sync([_ligne(reference='ref-idem', prix_unitaire=999.99)])
+
+        presta = self._prestas('ref-idem')
+        self.assertEqual(len(presta), 1)
+        self.assertEqual(presta.prix, 30.37)
+        self.assertIn('0 créée(s)', action['params']['message'])
+
+    def test_resolution_rsc_seule_pas_de_repli_pdl(self):
+        """RSC inconnue -> ignorée et comptée, même si le PDL matcherait une
+        souscription (aucun repli flou sur le flux vif, ADR 0010 §4). Signal de
+        backfill RSC : la ligne est rattrapée gratuitement au run suivant."""
+        action = self._sync(
+            [
+                _ligne(
+                    reference='ref-orpheline',
+                    pdl='PDL_TEST_STANDARD',  # PDL de souscription_base — ne doit PAS servir
+                    ref_situation_contractuelle='RSC_INCONNUE',
+                ),
+                _ligne(reference='ref-sans-rsc', ref_situation_contractuelle=None),
+            ]
+        )
+
+        self.assertFalse(self._prestas('ref-orpheline'))
+        self.assertFalse(self._prestas('ref-sans-rsc'))
+        self.assertIn('2 sans souscription', action['params']['message'])
+
+    def test_rsc_backfillee_rattrapee_au_run_suivant(self):
+        """Une ligne ignorée (RSC inconnue) est matérialisée au run suivant une
+        fois la RSC posée sur la souscription — le pull-tout la représente."""
+        self._sync([_ligne(reference='ref-backfill', ref_situation_contractuelle='RSC_SYNC_HPHC')])
+        self.assertFalse(self._prestas('ref-backfill'))
+
+        self.souscription_hphc.with_context(rsc_automatisme=True).write(
+            {'ref_situation_contractuelle': 'RSC_SYNC_HPHC'}
+        )
+        self._sync([_ligne(reference='ref-backfill', ref_situation_contractuelle='RSC_SYNC_HPHC')])
+
+        self.assertEqual(self._prestas('ref-backfill').souscription_id, self.souscription_hphc)
+
+    def test_arrivee_tardive_materialisee(self):
+        """Pull-tout sans curseur (ADR 0009 §2) : une ligne F15 datée dans le
+        passé, absente du premier run, est matérialisée au run suivant."""
+        self._sync([_ligne(reference='ref-t1')])
+        self._sync(
+            [
+                _ligne(reference='ref-t1'),
+                _ligne(reference='ref-tardive', date_debut='2024-01-05', date_facture='2024-02-05'),
+            ]
+        )
+
+        self.assertEqual(len(self._prestas('ref-tardive')), 1)
+
+    def test_facturee_jamais_touchee(self):
+        """Gel des facturées automatique (ADR 0009 §4) : une référence existante
+        n'est jamais réécrite, facture posée ou non."""
+        self._sync([_ligne(reference='ref-gelee', prix_unitaire=30.37)])
+        presta = self._prestas('ref-gelee')
+        _periode, facture = self.create_test_invoice(self.souscription_base)
+        presta.facture_id = facture
+
+        self._sync([_ligne(reference='ref-gelee', prix_unitaire=999.99)])
+
+        self.assertEqual(presta.prix, 30.37)
+        self.assertEqual(presta.facture_id, facture)
+
+    def test_erreur_par_ligne_ne_bloque_pas_le_lot(self):
+        """Skip-and-report par ligne (ADR 0011) : une contrainte (ici UNIQUE sur
+        une référence dupliquée dans le même lot — violation du contrat v1) est
+        absorbée par le savepoint, comptée, et n'emporte pas les autres lignes."""
+        action = self._sync(
+            [
+                _ligne(reference='ref-dup'),
+                _ligne(reference='ref-dup', prix_unitaire=999.99),
+                _ligne(reference='ref-autre'),
+            ]
+        )
+
+        self.assertEqual(len(self._prestas('ref-dup')), 1)
+        self.assertTrue(self._prestas('ref-autre'))
+        self.assertIn('1 en erreur', action['params']['message'])
+
+    def test_contract_version_error_mappee_en_userror(self):
+        """Contrat obsolète -> erreur dure actionnable (UserError), pas de
+        traceback brut pour le·la facturiste."""
+        with patch.object(
+            refacturation_module.SouscriptionRefacturation,
+            '_tirer_prestations',
+            side_effect=refacturation_module.ContractVersionError('serveur v0 < attendu v1'),
+        ):
+            with self.assertRaises(UserError) as cm:
+                self.Refacturation.synchroniser_depuis_electricore()
+        self.assertIn('v0', str(cm.exception))

--- a/views/core/souscription_refacturation_views.xml
+++ b/views/core/souscription_refacturation_views.xml
@@ -9,6 +9,13 @@
         <field name="model">souscription.refacturation</field>
         <field name="arch" type="xml">
             <list string="Refacturations" default_order="prix desc">
+                <!-- Pull-tout depuis electricore, insert-si-absente par référence de
+                     contenu (#147) : déclencheur manuel (crons off en dev, garde-fou
+                     migration). -->
+                <header>
+                    <button name="synchroniser_depuis_electricore" type="object"
+                            string="Tirer d'electricore" class="btn-primary" display="always"/>
+                </header>
                 <field name="souscription_id"/>
                 <field name="pdl"/>
                 <field name="reference"/>


### PR DESCRIPTION
Closes #147. Réécriture de la PR #135 (fermée) selon les décisions du grill 2026-07-08.

## Ce que fait la PR

- Bouton **« Tirer d'electricore »** sur la liste des *Refacturations* (déclencheur manuel — crons off en dev, garde-fou migration). Client acquis en tête (ADR 0024 §5), couture transport `_tirer_prestations` patchable par les tests, savepoint par ligne (skip-and-report, ADR 0011).
- **Résolution par RSC seule, pas de repli PDL** (ADR 0010 §4) : RSC inconnue → ligne ignorée, comptée au rapport, rattrapée au run suivant (pull-tout).
- **Insert-si-absente, pas de chemin d'update** : la *Référence de contenu* EST le contenu ; gel des facturées automatique (ADR 0009 §4).
- **Nature depuis le taux F15** : `'NS'` → indemnité hors champ TVA ; taux numérique → prestation taxée. La TVA suit le produit choisi par la nature (ADR 0009 §5). `montant_ht` ignoré.
- **Notification véridique** : créées / ignorées (sans souscription) / erreurs — pas de compteur « mises à jour ».
- **ADR 0009 §2 amendé** (résolution RSC, insert-si-absente) + section d'amendement #147.

## Acceptance criteria

- [x] Bouton sur la liste ; insert par `reference`, 2ᵉ run = 0 création, 0 write (testé)
- [x] Résolution par RSC seule ; RSC inconnue → ignorée, non matérialisée, comptée (testé, y compris backfill rattrapé au run suivant)
- [x] Ligne tardive datée dans le passé matérialisée au run suivant (testé)
- [x] Nature indemnité/prestation classée depuis le taux `'NS'`/numérique (testé)
- [x] Note d'amendement sur ADR 0009
- [x] Tests sans HTTP (transport mocké) — suite complète verte en local : 0 failed, 0 error(s) of 334 tests
- [ ] ⚠️ **Écart assumé** : `requirements.txt` reste épinglé `0.2.0` — `electricore-client` 0.3.0 n'est **pas encore publié sur PyPI** (gate de déploiement de l'issue) et le build Docker de la CI installe requirements.txt : bumper avant publication casserait la CI. TODO d'une ligne posé dans requirements.txt, à faire à la levée de la gate.

## Deployment gates (inchangées, hors CI)

- [ ] `electricore-client` 0.3.0 publié (puis bump du pin)
- [ ] edn.electricore.fr redéployé avec Energie-De-Nantes/electricore#590

🤖 Generated with [Claude Code](https://claude.com/claude-code)