### PR TITLE
feat(dev): repli env var pour la config electricore en local

### DIFF
--- a/docker/.env.example
+++ b/docker/.env.example
@@ -1,0 +1,7 @@
+# Copiez ce fichier en docker/.env (non commité) pour le dev local.
+# La fabrique electricore lit ces variables en dernier recours quand les
+# paramètres système Odoo (souscriptions.electricore_url / _api_key) sont vides,
+# ce qui évite de les re-cliquer après chaque reset de base.
+# En prod, on ne s'en sert pas : on renseigne les paramètres système.
+ELECTRICORE_URL=
+ELECTRICORE_API_KEY=

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -32,6 +32,10 @@ services:
       # pour que `docker compose up` marche aussi hors dev.sh (mode demo).
       - DB=${DB:-souscriptions_demo}
       - LOAD_DEMO=${LOAD_DEMO-1}
+      # Repli config electricore en dev : renseignés dans docker/.env (non commité),
+      # lus en dernier recours par la fabrique quand les paramètres système sont vides.
+      - ELECTRICORE_URL=${ELECTRICORE_URL:-}
+      - ELECTRICORE_API_KEY=${ELECTRICORE_API_KEY:-}
     volumes:
       - odoo-web-data:/var/lib/odoo
       - ../:/mnt/extra-addons/souscriptions_odoo:rw

--- a/models/core/electricore_client_fabrique.py
+++ b/models/core/electricore_client_fabrique.py
@@ -22,6 +22,8 @@ s'arrête à « rends-moi un client configuré » (ADR 0024 §4, option écarté
 
 from __future__ import annotations
 
+import os
+
 from odoo import models
 from odoo.exceptions import UserError
 
@@ -55,8 +57,14 @@ class SouscriptionElectricoreClient(models.AbstractModel):
                 'Installez la dépendance épinglée dans requirements.txt puis réessayez.'
             )
         ICP = self.env['ir.config_parameter'].sudo()
-        url = ICP.get_param('souscriptions.electricore_url')
-        api_key = ICP.get_param('souscriptions.electricore_api_key')
+        # strip() : un paramètre système collé à la main arrive souvent avec un
+        # saut de ligne parasite — httpx refuse toute URL contenant '\n'.
+        # Repli env var (dev) : évite de re-cliquer les paramètres système après
+        # chaque reset de base. Le paramètre système (prod) reste prioritaire.
+        url = (ICP.get_param('souscriptions.electricore_url') or os.environ.get('ELECTRICORE_URL', '')).strip()
+        api_key = (
+            ICP.get_param('souscriptions.electricore_api_key') or os.environ.get('ELECTRICORE_API_KEY', '')
+        ).strip()
         if not url or not api_key:
             raise UserError(
                 'Configuration electricore manquante : renseignez les paramètres système '


### PR DESCRIPTION
## Friction

En dev, les paramètres système `souscriptions.electricore_url` / `souscriptions.electricore_api_key` devaient être re-cliqués à la main dans les réglages Odoo après **chaque reset de base** — pénible vu la fréquence des resets.

## Fix

La fabrique du client electricore lit ces valeurs **en dernier recours** dans les variables d'environnement `ELECTRICORE_URL` / `ELECTRICORE_API_KEY` :

- Le **paramètre système reste prioritaire** → prod strictement inchangée.
- Les env sont vivent dans le conteneur, pas dans la base → **survivent aux resets**, plus rien à re-cliquer.
- Renseignées via `docker/.env` (non commité — `.env` déjà dans `.gitignore`), passées au conteneur par `docker-compose`.

## Setup (une fois)

```bash
cp docker/.env.example docker/.env   # remplir url + api_key (publics)
./scripts/dev.sh --reset             # comme d'hab
```

## Fichiers

- `models/core/electricore_client_fabrique.py` — repli `or os.environ.get(...)`
- `docker/docker-compose.yml` — pass-through des deux env
- `docker/.env.example` — le knob documenté (pas de secret commité)

🤖 Generated with [Claude Code](https://claude.com/claude-code)