### PR TITLE
feat(portail): Aperçu back-office (access_token) + accès portail à l'onboarding

### DIFF
--- a/controllers/portal.py
+++ b/controllers/portal.py
@@ -1,6 +1,7 @@
 from odoo import http
 from odoo.addons.portal.controllers.portal import CustomerPortal
 from odoo.addons.portal.controllers.portal import pager as portal_pager
+from odoo.exceptions import MissingError
 from odoo.http import request
 
 
@@ -43,12 +44,15 @@ class SouscriptionPortal(CustomerPortal):
         return request.render('souscriptions_odoo.portal_my_souscriptions', values)
 
     @http.route(['/my/souscription/<int:souscription_id>'], type='http', auth='user', website=True)
-    def portal_my_souscription(self, souscription_id=None, **kw):
-        partner = request.env.user.partner_id
-        souscription = request.env['souscription.souscription'].browse(souscription_id)
-
-        # Vérifier que la souscription appartient bien au partenaire
-        if not souscription.exists() or souscription.partner_id != partner:
+    def portal_my_souscription(self, souscription_id=None, access_token=None, **kw):
+        # Accès soit par le·la souscripteur·rice (propriétaire), soit via un
+        # access_token signé — c'est ce qui alimente le bouton « Aperçu » côté
+        # back-office (portal.mixin), sans se connecter en tant que client.
+        # AccessError (ni propriétaire ni token valide) remonte en 403 ;
+        # MissingError (id inexistant) → retour à l'accueil portail.
+        try:
+            souscription = self._document_check_access('souscription.souscription', souscription_id, access_token)
+        except MissingError:
             return request.redirect('/my')
 
         # Historique des consommations intégré à la page : uniquement les périodes

--- a/models/core/souscription.py
+++ b/models/core/souscription.py
@@ -23,7 +23,7 @@ class Souscription(models.Model):
     # mail.activity.mixin (#89) : porte l'alerte du poll quotidien des affaires
     # Enedis quand la Souscription n'a pas de demande de raccordement liée
     # (saisie manuelle) — sinon l'alerte est portée par la demande.
-    _inherit = ['mail.thread', 'mail.activity.mixin']
+    _inherit = ['mail.thread', 'mail.activity.mixin', 'portal.mixin']
 
     name = fields.Char(string='Référence', required=True, copy=False, readonly=True, default='Nouveau')
     partner_id = fields.Many2one('res.partner', string='Souscripteur·trice')
@@ -258,6 +258,46 @@ class Souscription(models.Model):
             if vals.get('id_affaire') and not vals.get('id_affaire_date_saisie'):
                 vals['id_affaire_date_saisie'] = fields.Date.context_today(self)
         return super().create(vals_list)
+
+    def _octroyer_acces_portail(self):
+        """Donne l'accès portail au·à la souscripteur·trice.
+
+        Odoo ne le fait pas par défaut : un contact n'a aucun login. On réutilise
+        le wizard standard « Grant portal access » (crée le user portail + envoie
+        l'email d'invitation). Appelé depuis l'onboarding raccordement uniquement
+        (`_create_souscription`), pas depuis `create()` — sinon tests, imports et
+        synchro electricore déclencheraient des invitations en masse.
+        Idempotent : partenaires déjà portail/interne ignorés (`is_portal`/
+        `is_internal`), user portail archivé réactivé, sans email ignoré. Un échec
+        (email en doublon…) n'annule pas la souscription.
+        """
+        partners = self.partner_id.filtered('email')
+        if not partners:
+            return
+        wizard = self.env['portal.wizard'].with_context(active_ids=partners.ids).sudo().create({})
+        for wu in wizard.user_ids:
+            if wu.is_portal or wu.is_internal:
+                continue
+            try:
+                wu.action_grant_access()
+            except Exception as e:  # noqa: BLE001 — un souci portail ne bloque pas la souscription
+                _logger.warning('Accès portail non octroyé pour %s : %s', wu.partner_id.display_name, e)
+
+    def _compute_access_url(self):
+        """URL portail de la souscription (portal.mixin) → route custom."""
+        super()._compute_access_url()
+        for souscription in self:
+            souscription.access_url = f'/my/souscription/{souscription.id}'
+
+    def action_apercu_portail(self):
+        """Bouton « Aperçu » : ouvre la page portail du·de la souscripteur·rice
+        (URL signée par access_token) sans se connecter en tant que client."""
+        self.ensure_one()
+        return {
+            'type': 'ir.actions.act_url',
+            'url': self.get_portal_url(),
+            'target': 'new',
+        }
 
     _MESSAGE_RSC_RESTREINTE = (
         'La RSC (référence situation contractuelle) ne peut être modifiée que par '

--- a/models/raccordement/raccordement_demande.py
+++ b/models/raccordement/raccordement_demande.py
@@ -702,6 +702,10 @@ class RaccordementDemande(models.Model):
 
         souscription = self.env['souscription.souscription'].create(souscription_vals)
 
+        # Accès portail donné dès l'onboarding : le·la souscripteur·trice reçoit
+        # l'invitation à activer son espace usager·ère (Odoo ne le fait pas seul).
+        souscription._octroyer_acces_portail()
+
         # Journal de consentement (ADR 0017) : une finalité cochée = un acte
         # 'donné'. Capture back-office (preuve faible), tracée comme telle ; l'acte
         # réel du·de la souscripteur·rice viendra du formulaire public (#62).

--- a/tests/test_portal.py
+++ b/tests/test_portal.py
@@ -109,6 +109,29 @@ class PortalTestCase(SouscriptionsTestMixin, HttpCase):
         self.assertIn(self.souscription_base.name, response.text)
         self.assertIn(self.souscription_base.pdl, response.text)
 
+    def test_apercu_via_access_token(self):
+        """L'URL signée (access_token) ouvre la page à un non-propriétaire — c'est
+        ce qui alimente le bouton « Aperçu » back-office. Sans token : 403."""
+        autre_partner = self.env['res.partner'].create({'name': 'Autre', 'email': 'autre_apercu@test.com'})
+        autre = self.env['souscription.souscription'].create(
+            {
+                'partner_id': autre_partner.id,
+                'pdl': 'PDL_APERCU_TOKEN',
+                'puissance_souscrite': '6',
+                'type_tarif': 'base',
+                'etat_facturation_id': self.etat_facturation.id,
+            }
+        )
+        url = autre.get_portal_url()  # /my/souscription/<id>?access_token=...
+        self.assertIn('access_token=', url)
+
+        # portal_user n'est PAS le souscripteur d'`autre`
+        self.authenticate(self.portal_user.login, self.portal_user.login)
+        self.assertEqual(self.url_open(f'/my/souscription/{autre.id}').status_code, 403)
+        response = self.url_open(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertIn('PDL_APERCU_TOKEN', response.text)
+
     # --- Historique intégré ---
 
     def test_detail_affiche_historique_inline_sans_bouton(self):

--- a/tests/test_raccordement.py
+++ b/tests/test_raccordement.py
@@ -549,6 +549,11 @@ class TestRaccordementWorkflow(SouscriptionsTestMixin, TransactionCase):
         self.assertEqual(souscription.type_tarif, 'base')
         self.assertEqual(souscription.partner_id, partner)
 
+        # Accès portail donné dès l'onboarding : le·la souscripteur·trice a
+        # désormais un utilisateur portail actif (invitation envoyée).
+        self.assertTrue(partner.user_ids, 'Un utilisateur portail doit être créé')
+        self.assertTrue(partner.user_ids._is_portal(), 'Utilisateur créé dans le groupe portail')
+
     def test_create_odoo_entries_pro(self):
         """Test de création des entrées Odoo pour une demande professionnelle"""
         demande = self.create_complete_demande(

--- a/views/core/souscription_views.xml
+++ b/views/core/souscription_views.xml
@@ -17,6 +17,10 @@
                             string="Résoudre la RSC maintenant"
                             type="object"
                             invisible="etat == 'en_service'"/>
+                    <button name="action_apercu_portail"
+                            string="Aperçu portail"
+                            type="object"
+                            icon="fa-external-link"/>
                 </header>
                 <sheet>
                     <group>


### PR DESCRIPTION
## Contexte

Débuggant un « portail vide » (`/my/souscriptions` → *Aucune souscription trouvée*), on a confirmé que ce n'était pas un bug : l'admin n'est souscripteur d'aucun contrat, et aucun client importé n'a de compte portail. Deux besoins en sont sortis.

## 1. Bouton « Aperçu portail » (back-office)

`souscription.souscription` hérite désormais de `portal.mixin` (champs `access_token`, `get_portal_url()`). Le contrôleur `/my/souscription/<id>` valide l'accès via `_document_check_access` — **propriétaire OU token signé** — au lieu du check `partner_id == user` strict. Un bouton « Aperçu portail » sur le formulaire ouvre la page du client sans se connecter en tant que lui (comme l'Aperçu du module abonnement standard).

Sécurité préservée : un usager non-propriétaire **sans token** → `403` ; `MissingError` (id inexistant) → retour à l'accueil portail.

## 2. Accès portail donné dès l'onboarding

`_create_souscription` (flux raccordement) appelle `_octroyer_acces_portail()` : le·la souscripteur·rice reçoit l'invitation à activer son espace usager·ère. Branché sur le **flux métier** et non sur `create()` — sinon tests, imports et synchro electricore déclencheraient des invitations en masse (vérifié : brancher sur `create()` cassait les fixtures). Idempotent, réutilise le wizard standard « Grant portal access ».

## Tests

- `test_apercu_via_access_token` : token non-propriétaire → 200, sans token → 403.
- `test_create_odoo_entries_complete` : le user portail est créé à l'onboarding.
- Suite portail + raccordement : **76 tests, 0 échec**.

## Hors périmètre

Rien de rétroactif pour les clients déjà importés (l'Aperçu marche pour eux immédiatement ; l'invitation ne part qu'aux nouvelles souscriptions). L'invitation dépend d'un SMTP configuré.

🤖 Generated with [Claude Code](https://claude.com/claude-code)