### PR TITLE
fix(campagne): sync F15 validable à la main — débloque « vérif refacturations » (#153)

### DIFF
--- a/models/core/souscription_campagne.py
+++ b/models/core/souscription_campagne.py
@@ -25,11 +25,12 @@ from odoo.exceptions import UserError
 #  - 'action' : étape déclenchée par bouton (#158) sans backlog mensuel
 #               dérivable — la refacturation Enedis n'est pas rattachée à un
 #               mois (CONTEXT.md « Refacturation »), donc « sync F15 » n'a pas
-#               de reste-à-faire naturel. ponytail: elle reste donc
-#               structurellement « non faite » — ça ne bloque rien de dur
-#               (« créer factures » ne dépend que des deux portes de vérif,
-#               jamais de « sync F15 » directement) ; upgrade path si un vrai
-#               signal (ou une porte manuelle dédiée) devient nécessaire.
+#               de reste-à-faire naturel. Son « fait » est donc une validation
+#               MANUELLE (case à cocher, comme une porte) EN PLUS de son bouton
+#               Lancer : le·la facturiste tire la sync puis coche « fait » (PRD
+#               #153, « validation manuelle assumée »). Sans ça, « vérif
+#               refacturations » (prereq : sync_f15) resterait bloquée à vie —
+#               son badge n'aurait jamais de sens.
 ETAPES_CAMPAGNE = {
     'pull_meta_periodes': {
         'label': 'Pull méta-périodes',
@@ -343,9 +344,9 @@ class SouscriptionCampagneEtape(models.Model):
         string='Type',
     )
 
-    # Porte manuelle (#156, ADR 0025 §2) : seul état vraiment persisté du DAG
-    # avec les notes (#159). validé_par/validé_le sont estampillés au write
-    # (jamais saisis à la main) — cf. write() ci-dessous.
+    # Validation manuelle (#156, ADR 0025 §2) : portes de vérif ET l'action sync
+    # F15 — seul état vraiment persisté du DAG avec les notes (#159). validé_par/
+    # validé_le sont estampillés au write (jamais saisis à la main) — cf. write().
     valide = fields.Boolean(string='Validé')
     valide_par_id = fields.Many2one('res.users', string='Validé par', readonly=True)
     valide_le = fields.Datetime(string='Validé le', readonly=True)
@@ -355,10 +356,9 @@ class SouscriptionCampagneEtape(models.Model):
         string='Prérequis',
         compute='_compute_etat_prerequis',
     )
-    # « Fait » : pour une porte manuelle, la validation ; pour une étape à
-    # signal dérivé, son reste-à-faire (#157 : fait quand nb_reste_a_faire == 0) ;
-    # pour une action sans signal (sync F15), jamais fait automatiquement (cf.
-    # commentaire sur le catalogue).
+    # « Fait » : pour une porte manuelle OU une action (sync F15), la validation
+    # manuelle ; pour une étape à signal dérivé, son reste-à-faire (#157 : fait
+    # quand nb_reste_a_faire == 0). Cf. commentaire sur le catalogue.
     fait = fields.Boolean(string='Fait', compute='_compute_fait')
 
     # Reste-à-faire dérivé (#157) : nombre de souscriptions que cette étape
@@ -396,14 +396,14 @@ class SouscriptionCampagneEtape(models.Model):
     @api.depends('valide', 'type_etape', 'nb_reste_a_faire')
     def _compute_fait(self):
         for etape in self:
-            if etape.type_etape == 'porte':
-                etape.fait = etape.valide
-            elif etape.type_etape == 'derive':
+            if etape.type_etape == 'derive':
                 etape.fait = etape.nb_reste_a_faire == 0
             else:
-                # 'action' : jamais de signal dérivé (cf. ETAPES_CAMPAGNE : sync
-                # F15 n'a pas de backlog mensuel dérivable).
-                etape.fait = False
+                # 'porte' comme 'action' (sync F15) : « fait » = validation
+                # manuelle. La sync F15 n'a pas de reste-à-faire dérivable, donc
+                # son « fait » est une assomption manuelle (PRD #153) — sinon
+                # « vérif refacturations » (prereq : sync_f15) resterait bloquée.
+                etape.fait = etape.valide
 
     @api.depends('code', 'campagne_id.etape_ids.fait')
     def _compute_etat_prerequis(self):

--- a/tests/test_campagne_facturation.py
+++ b/tests/test_campagne_facturation.py
@@ -109,6 +109,30 @@ class TestCampagneFacturationSpine(SouscriptionsTestCase):
         campagne.etape_ids.invalidate_recordset()
         self.assertEqual(creer_factures.etat_prerequis, 'bloquee')
 
+    def test_valider_sync_f15_debloque_verif_refacturations(self):
+        """La sync F15 (étape « action ») n'a pas de reste-à-faire dérivable :
+        son « fait » est une validation manuelle assumée (PRD #153). Sans elle,
+        « vérif refacturations » (prereq : sync_f15) resterait bloquée à vie et
+        son badge n'aurait aucun sens. La valider (comme une porte) débloque la
+        porte avale."""
+        campagne = self._campagne()
+        sync_f15 = self._etape(campagne, 'sync_f15')
+        verif_refacturations = self._etape(campagne, 'verif_refacturations')
+
+        self.assertFalse(sync_f15.fait, 'non faite tant que non validée manuellement')
+        self.assertEqual(verif_refacturations.etat_prerequis, 'bloquee')
+
+        sync_f15.write({'valide': True})
+        campagne.etape_ids.invalidate_recordset()
+
+        self.assertTrue(sync_f15.fait, 'validée manuellement -> faite')
+        self.assertEqual(sync_f15.valide_par_id, self.env.user, 'validé_par estampillé comme une porte')
+        self.assertEqual(
+            verif_refacturations.etat_prerequis,
+            'prete',
+            'sync F15 faite -> vérif refacturations débloquée',
+        )
+
     def test_aucun_champ_verification_ajoute_sur_periode_ou_refacturation(self):
         """AC (ADR 0025) : la porte de vérif reste à la maille campagne — 0
         champ de vérification sur souscription.periode / .refacturation."""

--- a/views/core/souscription_campagne_views.xml
+++ b/views/core/souscription_campagne_views.xml
@@ -31,14 +31,15 @@
                                     <field name="etat_prerequis" widget="badge"
                                            decoration-success="etat_prerequis == 'prete'"
                                            decoration-warning="etat_prerequis == 'bloquee'"/>
-                                    <field name="valide" widget="boolean_toggle" invisible="type_etape != 'porte'"/>
+                                    <field name="valide" widget="boolean_toggle" invisible="type_etape == 'derive'"/>
                                     <field name="valide_par_id" readonly="1" invisible="not valide"/>
                                     <field name="valide_le" readonly="1" invisible="not valide"/>
                                     <field name="nb_reste_a_faire" invisible="type_etape != 'derive'"/>
                                     <field name="fait" widget="boolean" readonly="1"/>
                                     <!-- Étapes dérivées/action (#158) : un seul bouton générique qui
-                                         dispatche vers l'action de la Campagne (pull/sync/créer/émettre) ;
-                                         les portes manuelles se valident via la case `valide` ci-dessus. -->
+                                         dispatche vers l'action de la Campagne (pull/sync/créer/émettre).
+                                         Portes de vérif ET sync F15 se valident via la case `valide`
+                                         ci-dessus (sync F15 : on tire, puis on coche « fait »). -->
                                     <button name="action_executer" type="object" string="Lancer"
                                             class="btn-link" invisible="type_etape == 'porte'"/>
                                     <button name="action_drill_down" type="object" string="Voir" icon="fa-search"/>


### PR DESCRIPTION
Suite au retour d'usage sur la Campagne de facturation (#153) : l'étape **« sync F15 »**
apparaissait **« bloquée » en permanence** côté `vérif refacturations`.

## Cause
`sync F15` est une étape de type `action` (bouton Lancer, sans reste-à-faire dérivable —
la refacturation Enedis n'est pas rattachée à un mois). Son `_compute_fait` renvoyait
**toujours `False`**. Or `vérif refacturations` a `sync_f15` en prérequis → sa porte
affichait `bloquée` quoi qu'il arrive, un badge sans aucun sens (on pouvait cocher la
porte par-dessus, mais l'UX mentait).

## Fix
Fidèle au PRD #153 (« validation manuelle assumée » pour F15) : l'étape `action` porte
désormais une **validation manuelle** (`fait = valide`, case à cocher) **en plus** de son
bouton Lancer. Flux : le·la facturiste **tire** la sync (Lancer) puis **coche « fait »** →
`vérif refacturations` se débloque normalement.

- `_compute_fait` : `action` → `fait = valide` (collapse porte+action)
- vue : case `valide` visible pour `porte` **et** `action` (cachée pour `derive`)
- test : `test_valider_sync_f15_debloque_verif_refacturations` (sync_f15 validée → `vérif
  refacturations` passe de `bloquée` à `prête`)

## Tests
Suite Odoo complète verte — `0 failed, 0 error(s) of 386` (CI-equivalent, `ELECTRICORE_*`
vides). Aucun test existant cassé (les portes de vérif se validaient déjà directement).

Adresse la finding « badge bloquée trompeur » remontée sur #162.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
