### PR TITLE
test(electricore): fabrique — tests hermétiques face au repli env #152

### DIFF
--- a/tests/test_electricore_client_fabrique.py
+++ b/tests/test_electricore_client_fabrique.py
@@ -7,6 +7,7 @@ couture de transport (`_appeler` / `_ouvrir_flux`), plus jamais cette garde
 (cf. tests/test_rsc_service.py, tests/test_pull_meta_periodes.py).
 """
 
+import os
 from unittest.mock import patch
 
 from odoo.addons.souscriptions_odoo.models.core import electricore_client_fabrique as fabrique_module
@@ -25,6 +26,15 @@ class TestElectricoreClientFabrique(SouscriptionsTestCase):
         patcher = patch.object(fabrique_module, 'ELECTRICORE_CLIENT_DISPONIBLE', True)
         patcher.start()
         self.addCleanup(patcher.stop)
+        # #152 : la fabrique retombe sur les variables d'environnement
+        # ELECTRICORE_URL/API_KEY quand l'ir.config_parameter est absent. On les
+        # neutralise ici pour rendre ces tests hermétiques (config = config_parameter
+        # seul) — sinon un .env local (ELECTRICORE_* réels, monté par docker-compose)
+        # fait passer le repli et les cas « config absente → UserError » échouent en
+        # local (verts en CI, où l'env est vide).
+        env_patcher = patch.dict(os.environ, {'ELECTRICORE_URL': '', 'ELECTRICORE_API_KEY': ''})
+        env_patcher.start()
+        self.addCleanup(env_patcher.stop)
         ICP = self.env['ir.config_parameter'].sudo()
         ICP.set_param('souscriptions.electricore_url', 'https://electricore.example.test')
         ICP.set_param('souscriptions.electricore_api_key', 'fake-api-key')


### PR DESCRIPTION
Rend hermétiques les 2 tests de garde de la fabrique electricore, cassés **en local** depuis #152.

## Cause
#152 (repli env var electricore) fait lire à la fabrique `os.environ['ELECTRICORE_URL' / 'ELECTRICORE_API_KEY']` quand l'`ir.config_parameter` est absent. Or `test_url_manquante_leve_userror` / `test_api_key_manquante_leve_userror` suppriment le paramètre de config et attendent un `UserError`. Dès qu'un `.env` local porte des `ELECTRICORE_*` réels (monté par `docker-compose`), le repli les trouve → pas de `UserError` → **2 échecs en local**. Verts en CI (env vide), rouges chez le dev.

## Fix
`patch.dict(os.environ, {'ELECTRICORE_URL': '', 'ELECTRICORE_API_KEY': ''})` dans le `setUp` de la classe : la config vient alors du seul `ir.config_parameter`, tests hermétiques quel que soit l'environnement d'exécution.

## Tests
`--test-tags souscriptions_electricore_client_fabrique` → **0 failed of 4**, exécuté **avec** un `.env` local `ELECTRICORE_*` présent (le cas qui échouait). Changement test-only.

Découvert en shippant #163 (fix badge F15). Indépendant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
