### PR TITLE
fix(refacturation): fail-safe fiscal taux TVA null → indemnité (+ recette cookbook odoo-shell)

### DIFF
--- a/COOKBOOK.md
+++ b/COOKBOOK.md
@@ -43,3 +43,16 @@ do: use the odoo MCP tools (search_records, read_record, get_model_fields…) ag
   # `dev`     = http://localhost:8069, db souscriptions_demo — the local docker; HAS the souscriptions module
   # `default` = energie-de-nantes.odoo.com SaaS — does NOT carry the souscriptions module
 observe: the returned records/fields
+
+## odoo-shell
+mode: human
+when: you need an interactive Python shell to read/write records (MCP is read-only) — purge/fix data, run ORM code
+do: stack up (see `bring-up`), then in another terminal:
+  `docker compose -f docker/docker-compose.yml exec odoo odoo shell -d {db} --db_host=db --db_user=odoo --db_password=odoo --no-http`
+  # {db}: souscriptions_demo (mode demo) OR souscriptions_prodlocal (mode prod, real electricore sync data)
+  # the db flags are mandatory — `exec` skips the entrypoint, so shell would hit a local socket without them
+  # writes need an explicit `env.cr.commit()` — the shell never commits on its own
+look: prompt with `env`/`self` bound; pick the db that actually holds your records
+  # gotcha: souscriptions_demo carries only the F15-DEMO-* demo rows; real synced data lives in souscriptions_prodlocal
+  # gotcha: a stale schema (e.g. `column … does not exist`) means the module wasn't upgraded on that db — re-run bring-up with --reset, or `-u souscriptions_odoo`
+expect: your ORM code runs; after `env.cr.commit()` the change persists

--- a/models/core/souscription_refacturation.py
+++ b/models/core/souscription_refacturation.py
@@ -190,12 +190,19 @@ class SouscriptionRefacturation(models.Model):
 
     @api.model
     def _vals_prestation(self, ligne, souscription):
-        # 'NS' (non soumis) = indemnité hors champ TVA (pénalité due par Enedis) ;
-        # tout taux numérique = prestation taxée. La TVA elle-même suit le PRODUIT
-        # choisi par la nature (ADR 0009 §5) — jamais un taux recopié par ligne.
+        # On ne classe 'prestation' (taxée) QUE sur un taux numérique explicite.
+        # 'NS', null, vide ou toute valeur non numérique -> 'indemnite' (hors champ
+        # TVA, pénalité due par Enedis). Le fail-safe est fiscal : sans lui, un taux
+        # null — vu sur des DCOUP_PEN de l'API prestations — retombait sur 'prestation'
+        # et facturait de la TVA sur une pénalité qui n'en porte pas. La TVA elle-même
+        # suit le PRODUIT choisi par la nature (ADR 0009 §5) — jamais ce taux.
         # `montant_ht` est ignoré : prix × quantité fait foi (vérifié en spike,
         # 0 écart sur toutes les lignes UNITE).
-        non_soumis = (ligne.get('taux_tva_applicable') or '').strip().upper() == 'NS'
+        taux = (ligne.get('taux_tva_applicable') or '').strip().replace(',', '.')
+        try:
+            taxee = float(taux) > 0
+        except ValueError:
+            taxee = False
         return {
             'reference': ligne['reference'],
             'souscription_id': souscription.id,
@@ -204,7 +211,7 @@ class SouscriptionRefacturation(models.Model):
             'libelle': ligne.get('libelle_ev') or ligne.get('id_ev') or 'Prestation Enedis',
             'prix': ligne.get('prix_unitaire') or 0.0,
             'quantite': ligne.get('quantite') or 1.0,
-            'nature': 'indemnite' if non_soumis else 'prestation',
+            'nature': 'prestation' if taxee else 'indemnite',
         }
 
     def _composer_ligne(self):

--- a/tests/test_sync_prestations.py
+++ b/tests/test_sync_prestations.py
@@ -90,6 +90,19 @@ class TestSyncPrestations(SouscriptionsTestCase):
         self.assertEqual(pen.code_enedis, 'DCOUP_PEN')
         self.assertIn('2 créée(s)', action['params']['message'])
 
+    def test_taux_null_ou_vide_classe_indemnite(self):
+        """Régression : l'API prestations renvoie des DCOUP_PEN à `taux_tva_applicable`
+        null. Un null (ou vide) ne doit JAMAIS retomber sur 'prestation' — sinon on
+        facture de la TVA sur une pénalité hors champ. Seul un taux numérique taxe."""
+        self._sync(
+            [
+                _ligne(reference='ref-null', id_ev='DCOUP_PEN', taux_tva_applicable=None),
+                _ligne(reference='ref-vide', id_ev='DCOUP_PEN', taux_tva_applicable=''),
+            ]
+        )
+        self.assertEqual(self._prestas('ref-null').nature, 'indemnite')
+        self.assertEqual(self._prestas('ref-vide').nature, 'indemnite')
+
     def test_rerun_idempotent_zero_creation_zero_write(self):
         """AC1 : 2ᵉ run = 0 création, 0 write — insert-si-absente, aucun chemin
         d'update. Même un payload amont différent à référence constante ne touche


### PR DESCRIPTION
Récupère deux morceaux encore pertinents d'un WIP local (le reste — accès portail — a déjà été mergé par #160).

## 1. Fail-safe fiscal : taux TVA null/vide → `indemnite` (fix)
`_vals_prestation` ne classait `indemnite` (hors champ TVA) que sur le libellé exact `'NS'`. Or l'API prestations renvoie des **`DCOUP_PEN` à `taux_tva_applicable` null** : ceux-là retombaient sur `'prestation'` → **TVA facturée sur une pénalité qui n'en porte pas**.

Nouvelle règle : on ne taxe (`prestation`) **que** sur un **taux numérique explicite > 0** ; `NS`, null, vide ou toute valeur non numérique → `indemnite`. La TVA suit toujours le PRODUIT choisi par la nature (ADR 0009 §5), jamais le taux par ligne.

- `models/core/souscription_refacturation.py` : `_vals_prestation` — parse numérique tolérant (virgule décimale, `ValueError` → non taxé).
- `tests/test_sync_prestations.py` : `test_taux_null_ou_vide_classe_indemnite` (régression null + vide → `indemnite`).

## 2. Recette cookbook `odoo-shell` (docs)
Ajoute au `COOKBOOK.md` la recette `odoo-shell` (shell Python interactif read/write, là où le MCP odoo est read-only) — utile pour purger/corriger des données ou lancer du code ORM.

## Tests
Suite Odoo complète verte — CI-equivalent (`ELECTRICORE_*` vides). Le fix taux-null est couvert par le nouveau test + les tests de nature existants inchangés.

## Hors périmètre (à décider)
Le WIP portait aussi un **bump `electricore-client` 0.2.0 → 0.4.0** (requis pour le *vrai* sync prestations en prod). **Volontairement exclu ici** : c'était un *deploy-gate* que #147 avait différé (bumper un pin non publié casse le build Docker CI). À traiter séparément une fois 0.4.0 confirmé publié sur PyPI — je peux le vérifier + ouvrir la PdR si tu veux.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
