### PR TITLE
chore(deps): bump electricore-client 0.2.0 → 0.4.0 (lève le deploy-gate #147)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,8 +7,9 @@
 # manifeste : l'absence du paquet ne doit pas empêcher l'installation du
 # module (garde d'import dans models/wizard/souscription_pull_meta_periodes_wizard.py,
 # UserError explicite au clic si absent).
-# TODO(#147 gate) : bump à 0.3.0 (méthode prestations(), sync de la file « à
-# refacturer ») dès sa publication sur PyPI — le pin est installé par le build
-# Docker de la CI, bumper avant publication casserait le build. D'ici là le
-# bouton « Tirer d'electricore » échoue en réel (gate de déploiement, pas de merge).
-electricore-client==0.2.0
+# 0.4.0 : ajoute prestations() (requis par la sync #147 « à refacturer »,
+# souscription_refacturation._tirer_prestations). Publié sur PyPI, surface
+# prestations() vérifiée au tag ; les symboles importés par l'addon
+# (ElectricoreClient, ContractVersionError, IngestionEnCours, PreconditionNonRemplie)
+# sont tous présents en 0.4.0. Lève le gate de déploiement du #147.
+electricore-client==0.4.0


### PR DESCRIPTION
Lève le **deploy-gate** que #147 avait posé : le pin restait à `0.2.0` (sans `prestations()`), donc le vrai « Tirer d'electricore » des refacturations échouait en réel.

## Pourquoi c'est safe maintenant (vérifié, pas supposé)
- **`electricore-client==0.4.0` est publié sur PyPI** (installé sans souci dans un venv de sonde).
- **`ElectricoreClient.prestations()` existe** au tag 0.4.0 — l'endpoint que `_tirer_prestations` consomme.
- **Tous les symboles importés par l'addon** résolvent en 0.4.0 : `ElectricoreClient`, `ContractVersionError`, `IngestionEnCours`, `PreconditionNonRemplie` (+ `ObjetReleve`/`PeriodeMeta` pour le pull). L'addon n'importe **jamais** `PrestationF15` (juste cité en commentaire ; `_tirer_prestations` fait `.model_dump()` → dicts plats), donc son absence d'export top-level ne gêne rien.

## Tests
Suite Odoo complète **avec image reconstruite sur 0.4.0** (`docker compose run --build`) : verte. Bonus, `TestAmorcerDepuisMetaAvecPaquetReel` (skippé tant que le client est absent) **tourne maintenant** contre les vrais modèles pydantic `PeriodeMeta`/`ObjetReleve` — le mapping contrat v3 est validé sur le type réel, pas seulement les stubs.

Dernier morceau du WIP local réconcilié (après #160 portail déjà mergé et #165 taux-null/cookbook). Le `stash@{0}` peut être `drop` après ça.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
