### PR TITLE
fix(grille): dupliquer crée un brouillon inactif, sans périmer la grille en cours

### DIFF
--- a/models/core/grille_prix.py
+++ b/models/core/grille_prix.py
@@ -126,6 +126,11 @@ class GrillePrix(models.Model):
         gênent jamais, même sur des dates identiques (CONTEXT.md « Régime de
         prix » : chaque régime versionne ses grilles indépendamment)."""
         for grille in self:
+            # Un brouillon inactif est hors timeline (cf. create()) : il ne ferme
+            # aucune sœur et ne déclenche pas l'anti-chevauchement. Sans ce skip,
+            # dupliquer une grille ouverte lèverait un chevauchement contre elle.
+            if not grille.active:
+                continue
             if not grille.date_debut:
                 continue
             start_a = grille.date_debut

--- a/models/core/grille_prix.py
+++ b/models/core/grille_prix.py
@@ -56,6 +56,11 @@ class GrillePrix(models.Model):
     @api.model_create_multi
     def create(self, vals_list):
         for vals in vals_list:
+            # Une grille créée inactive est un brouillon hors timeline (ex. copie
+            # à retravailler en grille Moulin) : elle ne ferme aucune sœur.
+            if vals.get('active', True) is False:
+                continue
+
             date_debut_nouvelle = vals['date_debut']
             regime = vals.get('regime_prix') or 'standard'
 
@@ -172,10 +177,17 @@ class GrillePrix(models.Model):
         return prix_journalier
 
     def dupliquer_cette_grille(self):
-        """Action pour dupliquer cette grille avec toutes ses lignes"""
+        """Action pour dupliquer cette grille avec toutes ses lignes.
+
+        La copie est créée en **brouillon (inactive)** : dupliquer sert à
+        amorcer une nouvelle grille (ex. une grille Moulin) sans perturber la
+        timeline en cours. Tant qu'elle est inactive, elle ne ferme aucune
+        grille sœur et ne déclenche pas l'anti-chevauchement. L'utilisateur
+        ajuste régime/dates puis l'active.
+        """
         self.ensure_one()
 
-        # Créer une copie de la grille avec date d'aujourd'hui
+        # Date de départ indicative : l'utilisateur la corrige avant activation.
         today = fields.Date.today()
 
         # Préparer les lignes à copier
@@ -203,6 +215,7 @@ class GrillePrix(models.Model):
                 'date_debut': today,
                 'date_fin': False,
                 'regime_prix': self.regime_prix,
+                'active': False,
                 'ligne_ids': lignes_vals,
             }
         )

--- a/tests/test_grille_prix.py
+++ b/tests/test_grille_prix.py
@@ -262,3 +262,19 @@ class TestGrillePrix(TransactionCase):
         action = grille_moulin.dupliquer_cette_grille()
         nouvelle = self.env['grille.prix'].browse(action['res_id'])
         self.assertEqual(nouvelle.regime_prix, 'moulin')
+
+    def test_dupliquer_grille_ne_perime_pas_la_sœur(self):
+        """La copie est un brouillon inactif : dupliquer une grille ouverte ne
+        ferme pas la grille en cours (ancien comportement corrigé)."""
+        grille_active = self.env['grille.prix'].create(
+            {
+                'name': 'Grille juin 2025',
+                'date_debut': date(2025, 6, 1),
+                'regime_prix': 'standard',
+            }
+        )
+        action = grille_active.dupliquer_cette_grille()
+        nouvelle = self.env['grille.prix'].browse(action['res_id'])
+
+        self.assertFalse(nouvelle.active, 'La copie doit être un brouillon inactif')
+        self.assertFalse(grille_active.date_fin, "La grille d'origine ne doit pas être fermée")


### PR DESCRIPTION
## Problème

Cliquer **« Dupliquer cette grille »** rendait la grille d'origine périmée : la copie passait par `create()`, qui ferme automatiquement la grille ouverte du même régime. On voulait pouvoir dupliquer une grille pour en amorcer une autre (ex. une grille Moulin) **sans** expirer la grille en cours.

## Correctif

La copie est désormais créée **inactive (brouillon)** :
- `create()` ignore la fermeture automatique pour une grille créée inactive ;
- un brouillon inactif est hors timeline → il ne ferme aucune grille sœur et ne déclenche pas l'anti-chevauchement.

L'utilisateur ajuste régime/dates puis active la copie quand elle est prête.

## Test

`test_dupliquer_grille_ne_perime_pas_la_sœur` : dupliquer une grille ouverte laisse `date_fin` de l'origine vide et produit une copie inactive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)