### PR TITLE
chore/wip campagne releves index

### DIFF
--- a/models/core/souscription_campagne.py
+++ b/models/core/souscription_campagne.py
@@ -23,14 +23,18 @@ from odoo.exceptions import UserError
 #  - 'derive' : signal dérivé des données (#157) — un reste-à-faire existe,
 #               l'étape est faite quand il vaut 0 ;
 #  - 'action' : étape déclenchée par bouton (#158) sans backlog mensuel
-#               dérivable — la refacturation Enedis n'est pas rattachée à un
-#               mois (CONTEXT.md « Refacturation »), donc « sync F15 » n'a pas
-#               de reste-à-faire naturel. Son « fait » est donc une validation
-#               MANUELLE (case à cocher, comme une porte) EN PLUS de son bouton
-#               Lancer : le·la facturiste tire la sync puis coche « fait » (PRD
-#               #153, « validation manuelle assumée »). Sans ça, « vérif
-#               refacturations » (prereq : sync_f15) resterait bloquée à vie —
-#               son badge n'aurait jamais de sens.
+#               dérivable — le pull F15 tire TOUT (pas de fenêtre temporelle,
+#               ADR 0009 §2), donc pas de reste-à-faire mensuel. Elle est
+#               « faite » dès qu'elle a été lancée sans erreur pour la
+#               campagne (champ `lance` persisté, posé par action_executer) :
+#               c'est ce qui lui permet de gater sa vérif au même titre que le
+#               pull des périodes. Revirement assumé du PRD #153 (« validation
+#               manuelle ») décidé au rebase de cette branche : le lancement
+#               suffit, plus de coche (#163 est remplacé).
+#
+# Les deux « vrais pulls » (méta-périodes + F15) gatent chacun leur porte de
+# vérif. Les relevés d'index NE sont PAS une étape : ils arrivent avec le pull
+# des périodes (enfants souscription.releve, cf. _amorcer_depuis_meta).
 ETAPES_CAMPAGNE = {
     'pull_meta_periodes': {
         'label': 'Pull méta-périodes',
@@ -42,15 +46,10 @@ ETAPES_CAMPAGNE = {
         'type': 'action',
         'prerequis': (),
     },
-    'releves_index': {
-        'label': "Relevés d'index",
-        'type': 'porte',
-        'prerequis': (),
-    },
     'verif_periodes': {
         'label': 'Vérif périodes',
         'type': 'porte',
-        'prerequis': ('pull_meta_periodes', 'releves_index'),
+        'prerequis': ('pull_meta_periodes',),
     },
     'verif_refacturations': {
         'label': 'Vérif refacturations',
@@ -218,31 +217,39 @@ class SouscriptionCampagneFacturation(models.Model):
             return 'a_facturer'
         return 'emise' if periode.facture_state == 'posted' else 'facturee'
 
-    def _souscriptions_par_statut(self, statut):
-        """ponytail: une requête par souscription facturable (échelle
-        facturiste — dizaines/centaines, pas un flux temps réel) ; upgrade en
-        une seule requête SQL groupée si ça devient lent un jour."""
-        self.ensure_one()
-        cibles = self._souscriptions_facturables()
-        return cibles.filtered(lambda s: self._statut_facturation(s) == statut)
+    # Statuts de facturation, dans l'ordre du cycle (#157). Le reste-à-faire
+    # d'une étape dérivée = toutes les souscriptions pas encore parvenues au
+    # statut *cible* de l'étape (cumulatif amont), pas seulement celles dans le
+    # bucket juste avant : sinon une étape aval lit « fait » (reste 0) tant que
+    # rien n'a atteint sa file — « émettre » se marquait faite alors que
+    # « créer » avait encore tout son backlog (aucune facture créée => 0
+    # souscription en « facturée » => reste 0).
+    _STATUTS_ORDONNES = ('a_tirer', 'a_facturer', 'facturee', 'emise')
 
-    # Étape à signal dérivé -> statut de facturation dont le reste-à-faire la
-    # concerne. Les étapes absentes (portes, action) n'ont pas de signal
+    # Étape à signal dérivé -> statut cible atteint = étape faite pour cette
+    # souscription. Les étapes absentes (portes, action) n'ont pas de signal
     # dérivé (cf. ETAPES_CAMPAGNE) : reste-à-faire vide par construction.
-    _STATUT_PAR_ETAPE_DERIVEE = {
-        'pull_meta_periodes': 'a_tirer',
-        'creer_factures': 'a_facturer',
-        'emettre_factures': 'facturee',
+    _CIBLE_PAR_ETAPE_DERIVEE = {
+        'pull_meta_periodes': 'a_facturer',
+        'creer_factures': 'facturee',
+        'emettre_factures': 'emise',
     }
 
     def _reste_a_faire(self, code):
-        """Souscriptions restantes pour l'étape dérivée `code` (#157) — feed
-        aussi bien le compteur affiché (`nb_reste_a_faire`) que le drill-down."""
+        """Souscriptions restantes pour l'étape dérivée `code` (#157) — toutes
+        celles pas encore parvenues au statut cible de l'étape. Feed aussi bien
+        le compteur affiché (`nb_reste_a_faire`) que le drill-down.
+
+        ponytail: une requête par souscription facturable (échelle facturiste —
+        dizaines/centaines, pas un flux temps réel) ; upgrade en une seule
+        requête SQL groupée si ça devient lent un jour."""
         self.ensure_one()
-        statut = self._STATUT_PAR_ETAPE_DERIVEE.get(code)
-        if not statut:
+        cible = self._CIBLE_PAR_ETAPE_DERIVEE.get(code)
+        if not cible:
             return self.env['souscription.souscription']
-        return self._souscriptions_par_statut(statut)
+        pas_encore = set(self._STATUTS_ORDONNES[: self._STATUTS_ORDONNES.index(cible)])
+        cibles = self._souscriptions_facturables()
+        return cibles.filtered(lambda s: self._statut_facturation(s) in pas_encore)
 
     def _factures_du_mois(self):
         """Factures (account.move) des périodes du mois de la campagne."""
@@ -359,21 +366,28 @@ class SouscriptionCampagneEtape(models.Model):
         string='Type',
     )
 
-    # Validation manuelle (#156, ADR 0025 §2) : portes de vérif ET l'action sync
-    # F15 — seul état vraiment persisté du DAG avec les notes (#159). validé_par/
-    # validé_le sont estampillés au write (jamais saisis à la main) — cf. write().
+    # Porte manuelle (#156, ADR 0025 §2) : état persisté du DAG avec `lance`
+    # ci-dessous et les notes (#159). validé_par/validé_le sont estampillés au
+    # write (jamais saisis à la main) — cf. write() ci-dessous.
     valide = fields.Boolean(string='Validé')
     valide_par_id = fields.Many2one('res.users', string='Validé par', readonly=True)
     valide_le = fields.Datetime(string='Validé le', readonly=True)
+
+    # Étape 'action' (sync F15) : « faite » = lancée au moins une fois pour
+    # cette campagne. Le pull F15 tire tout, sans signal mensuel dérivable
+    # (ADR 0009 §2) ; ce drapeau persisté joue le rôle de « pull effectué »
+    # pour gater « vérif refacturations », comme le reste-à-faire gate « vérif
+    # périodes ». Posé par action_executer, jamais saisi à la main.
+    lance = fields.Boolean(string='Lancé', readonly=True)
 
     etat_prerequis = fields.Selection(
         [('prete', 'Prête'), ('bloquee', 'Bloquée')],
         string='Prérequis',
         compute='_compute_etat_prerequis',
     )
-    # « Fait » : pour une porte manuelle OU une action (sync F15), la validation
-    # manuelle ; pour une étape à signal dérivé, son reste-à-faire (#157 : fait
-    # quand nb_reste_a_faire == 0). Cf. commentaire sur le catalogue.
+    # « Fait » : pour une porte manuelle, la validation ; pour une étape à
+    # signal dérivé, son reste-à-faire (#157 : fait quand nb_reste_a_faire == 0) ;
+    # pour une action (sync F15), son lancement (`lance`). Cf. le catalogue.
     fait = fields.Boolean(string='Fait', compute='_compute_fait')
 
     # Reste-à-faire dérivé (#157) : nombre de souscriptions que cette étape
@@ -408,23 +422,27 @@ class SouscriptionCampagneEtape(models.Model):
             else:
                 etape.nb_reste_a_faire = 0
 
-    @api.depends('valide', 'type_etape', 'nb_reste_a_faire')
+    @api.depends('valide', 'type_etape', 'nb_reste_a_faire', 'lance')
     def _compute_fait(self):
         for etape in self:
-            if etape.type_etape == 'derive':
+            if etape.type_etape == 'porte':
+                etape.fait = etape.valide
+            elif etape.type_etape == 'derive':
                 etape.fait = etape.nb_reste_a_faire == 0
             else:
-                # 'porte' comme 'action' (sync F15) : « fait » = validation
-                # manuelle. La sync F15 n'a pas de reste-à-faire dérivable, donc
-                # son « fait » est une assomption manuelle (PRD #153) — sinon
-                # « vérif refacturations » (prereq : sync_f15) resterait bloquée.
-                etape.fait = etape.valide
+                # 'action' : pas de backlog dérivable (sync F15 tire tout,
+                # ADR 0009 §2) — « faite » une fois lancée pour la campagne.
+                etape.fait = etape.lance
 
-    @api.depends('code', 'campagne_id.etape_ids.fait')
+    @api.depends('code', 'valide', 'type_etape', 'campagne_id.etape_ids.fait')
     def _compute_etat_prerequis(self):
         for etape in self:
             prerequis = ETAPES_CAMPAGNE.get(etape.code, {}).get('prerequis', ())
-            if not prerequis:
+            # Une porte validée n'est jamais « bloquée » : la validation
+            # manuelle EST l'override du·de la facturiste — Bloquée veut dire
+            # « pas encore le moment », pas « déjà accompli ». Sans ça une porte
+            # validée hors-séquence s'affiche Bloquée ET Faite (incohérent).
+            if not prerequis or (etape.type_etape == 'porte' and etape.valide):
                 etape.etat_prerequis = 'prete'
                 continue
             freres = {e.code: e.fait for e in etape.campagne_id.etape_ids}
@@ -466,7 +484,12 @@ class SouscriptionCampagneEtape(models.Model):
             raise UserError(
                 _("Pas d'action pour l'étape « %s ».", ETAPES_CAMPAGNE.get(self.code, {}).get('label', self.code))
             )
-        return getattr(self.campagne_id, methode)()
+        resultat = getattr(self.campagne_id, methode)()
+        # Étape 'action' réussie (pas d'exception) = « pull effectué » pour la
+        # campagne : débloque sa vérif (cf. champ `lance`).
+        if self.type_etape == 'action':
+            self.lance = True
+        return resultat
 
 
 class SouscriptionCampagneNote(models.Model):

--- a/tests/test_campagne_etapes_actions.py
+++ b/tests/test_campagne_etapes_actions.py
@@ -187,6 +187,21 @@ class TestCampagneEtapeSyncF15(SouscriptionsTestCase):
             action = etape.action_executer()
         self.assertEqual(action['type'], 'ir.actions.client')
 
+    def test_lancer_sync_f15_debloque_verif_refacturations(self):
+        """Le pull F15 gate sa vérif : « vérif refacturations » est bloquée
+        tant que sync F15 n'a pas tourné, puis prête une fois lancé."""
+        sync = self.campagne.etape_ids.filtered(lambda e: e.code == 'sync_f15')
+        verif = self.campagne.etape_ids.filtered(lambda e: e.code == 'verif_refacturations')
+        self.assertFalse(sync.fait)
+        self.assertEqual(verif.etat_prerequis, 'bloquee')
+
+        with patch.object(refacturation_module.SouscriptionRefacturation, '_tirer_prestations', return_value=[]):
+            sync.action_executer()
+        self.campagne.etape_ids.invalidate_recordset()
+
+        self.assertTrue(sync.fait)
+        self.assertEqual(verif.etat_prerequis, 'prete')
+
 
 @tagged('souscriptions', 'souscriptions_campagne', 'post_install', '-at_install')
 class TestCampagneEtapeCreerFactures(SouscriptionsTestCase):

--- a/tests/test_campagne_facturation.py
+++ b/tests/test_campagne_facturation.py
@@ -1,10 +1,11 @@
 """Tests de la Campagne de facturation — spine (#156, ADR 0025).
 
-Le DAG déclaré par `ETAPES_CAMPAGNE` : `pull_meta_periodes`/`sync_f15`/
-`releves_index` sont des racines indépendantes ; `verif_periodes` (prereq :
-pull + relevés) et `verif_refacturations` (prereq : sync F15) sont des portes
-manuelles ; `creer_factures` (prereq : les deux vérifs) et `emettre_factures`
-(prereq : créer) sont des étapes à signal dérivé.
+Le DAG déclaré par `ETAPES_CAMPAGNE` : `pull_meta_periodes`/`sync_f15` sont les
+deux racines (les deux « vrais pulls ») ; chacun gate sa porte de vérif —
+`verif_periodes` (prereq : pull méta-périodes) et `verif_refacturations`
+(prereq : sync F15) ; `creer_factures` (prereq : les deux vérifs) et
+`emettre_factures` (prereq : créer) sont des étapes à signal dérivé. Les
+relevés d'index ne sont pas une étape : ils arrivent avec le pull des périodes.
 
 Dans cette tranche, les étapes à signal dérivé (pull, créer, émettre) sont
 volontairement toujours « non faites » (leur signal arrive en #157, cf.
@@ -47,33 +48,33 @@ class TestCampagneFacturationSpine(SouscriptionsTestCase):
         self.assertEqual(campagne.mois, date(2026, 7, 1))
 
     def test_racines_du_dag_toujours_pretes(self):
-        """Les étapes sans prérequis (pull, sync F15, relevés) sont toujours
-        « prête » : aucune dépendance à satisfaire."""
+        """Les deux racines (les vrais pulls : méta-périodes + sync F15) sont
+        toujours « prête » : aucune dépendance à satisfaire."""
         campagne = self._campagne()
-        racines = campagne.etape_ids.filtered(lambda e: e.code in ('pull_meta_periodes', 'sync_f15', 'releves_index'))
-        self.assertEqual(len(racines), 3)
+        racines = campagne.etape_ids.filtered(lambda e: e.code in ('pull_meta_periodes', 'sync_f15'))
+        self.assertEqual(len(racines), 2)
         self.assertTrue(all(e.etat_prerequis == 'prete' for e in racines))
 
     def test_etape_avec_prerequis_bloquee_tant_que_non_satisfaits(self):
-        """`verif_periodes` (prereq : pull + relevés) reste bloquée : le pull
-        (signal dérivé) est toujours non fait dans cette tranche (#157)."""
+        """`verif_refacturations` (prereq : sync F15) reste bloquée tant que le
+        pull F15 n'a pas été lancé pour la campagne (`lance` = False)."""
         campagne = self._campagne()
-        self.assertEqual(self._etape(campagne, 'verif_periodes').etat_prerequis, 'bloquee')
+        self.assertEqual(self._etape(campagne, 'verif_refacturations').etat_prerequis, 'bloquee')
 
     def test_valider_porte_persiste_valide_par_et_valide_le(self):
-        """AC : valider une porte manuelle (« relevés d'index », sans
-        prérequis) persiste validé_par/validé_le et la rend « faite »."""
+        """AC : valider une porte manuelle persiste validé_par/validé_le et la
+        rend « faite » (la validation manuelle vaut override du prérequis)."""
         campagne = self._campagne()
-        releves = self._etape(campagne, 'releves_index')
-        self.assertFalse(releves.valide_par_id)
-        self.assertFalse(releves.valide_le)
-        self.assertFalse(releves.fait)
+        verif = self._etape(campagne, 'verif_periodes')
+        self.assertFalse(verif.valide_par_id)
+        self.assertFalse(verif.valide_le)
+        self.assertFalse(verif.fait)
 
-        releves.write({'valide': True})
+        verif.write({'valide': True})
 
-        self.assertEqual(releves.valide_par_id, self.env.user)
-        self.assertTrue(releves.valide_le)
-        self.assertTrue(releves.fait)
+        self.assertEqual(verif.valide_par_id, self.env.user)
+        self.assertTrue(verif.valide_le)
+        self.assertTrue(verif.fait)
 
     def test_validation_des_deux_portes_amont_debloque_letape_avale(self):
         """AC : valider une porte flippe les étapes avales de bloquée à
@@ -108,30 +109,6 @@ class TestCampagneFacturationSpine(SouscriptionsTestCase):
         verif_periodes.write({'valide': False})
         campagne.etape_ids.invalidate_recordset()
         self.assertEqual(creer_factures.etat_prerequis, 'bloquee')
-
-    def test_valider_sync_f15_debloque_verif_refacturations(self):
-        """La sync F15 (étape « action ») n'a pas de reste-à-faire dérivable :
-        son « fait » est une validation manuelle assumée (PRD #153). Sans elle,
-        « vérif refacturations » (prereq : sync_f15) resterait bloquée à vie et
-        son badge n'aurait aucun sens. La valider (comme une porte) débloque la
-        porte avale."""
-        campagne = self._campagne()
-        sync_f15 = self._etape(campagne, 'sync_f15')
-        verif_refacturations = self._etape(campagne, 'verif_refacturations')
-
-        self.assertFalse(sync_f15.fait, 'non faite tant que non validée manuellement')
-        self.assertEqual(verif_refacturations.etat_prerequis, 'bloquee')
-
-        sync_f15.write({'valide': True})
-        campagne.etape_ids.invalidate_recordset()
-
-        self.assertTrue(sync_f15.fait, 'validée manuellement -> faite')
-        self.assertEqual(sync_f15.valide_par_id, self.env.user, 'validé_par estampillé comme une porte')
-        self.assertEqual(
-            verif_refacturations.etat_prerequis,
-            'prete',
-            'sync F15 faite -> vérif refacturations débloquée',
-        )
 
     def test_aucun_champ_verification_ajoute_sur_periode_ou_refacturation(self):
         """AC (ADR 0025) : la porte de vérif reste à la maille campagne — 0

--- a/tests/test_campagne_notes.py
+++ b/tests/test_campagne_notes.py
@@ -103,5 +103,5 @@ class TestCampagneNotes(SouscriptionsTestCase):
         juin = self._campagne(date(2026, 6, 1))
         self.assertTrue(juin.note_ids.filtered('reprise'), 'précondition : une note reprise existe bien')
 
-        racines = juin.etape_ids.filtered(lambda e: e.code in ('pull_meta_periodes', 'sync_f15', 'releves_index'))
+        racines = juin.etape_ids.filtered(lambda e: e.code in ('pull_meta_periodes', 'sync_f15'))
         self.assertTrue(all(e.etat_prerequis == 'prete' for e in racines))

--- a/tests/test_campagne_signaux.py
+++ b/tests/test_campagne_signaux.py
@@ -96,14 +96,15 @@ class TestCampagneSignauxDerives(SouscriptionsTestCase):
         self.assertEqual(self._etape('pull_meta_periodes').nb_reste_a_faire, 0)
         self.assertTrue(self._etape('pull_meta_periodes').fait)
 
-    def test_creer_factures_reste_a_faire_compte_periodes_sans_facture(self):
-        """Seules les souscriptions « à facturer » comptent — pas celles
-        encore « à tirer »."""
+    def test_creer_factures_reste_a_faire_compte_tout_ce_qui_nest_pas_facture(self):
+        """Reste-à-faire cumulatif amont : toute souscription pas encore
+        facturée compte — celle « à facturer » ET celle encore « à tirer »
+        (sinon « créer » lirait « fait » avant que tout soit tiré)."""
         self._periode(self.souscription_base)  # à facturer
-        # souscription_hphc reste sans période -> à tirer, hors décompte créer.
+        # souscription_hphc reste sans période -> à tirer : compte aussi.
         self.campagne.etape_ids.invalidate_recordset()
 
-        self.assertEqual(self._etape('creer_factures').nb_reste_a_faire, 1)
+        self.assertEqual(self._etape('creer_factures').nb_reste_a_faire, 2)
         self.assertFalse(self._etape('creer_factures').fait)
 
     def test_emettre_factures_reste_a_faire_compte_brouillons(self):
@@ -174,7 +175,7 @@ class TestCampagneSignauxDerives(SouscriptionsTestCase):
     def test_sync_f15_et_portes_nont_pas_de_reste_a_faire(self):
         """Les étapes sans signal dérivé (action, portes) ont un
         reste-à-faire vide par construction — cf. ETAPES_CAMPAGNE."""
-        for code in ('sync_f15', 'releves_index', 'verif_periodes', 'verif_refacturations'):
+        for code in ('sync_f15', 'verif_periodes', 'verif_refacturations'):
             self.assertEqual(self._etape(code).nb_reste_a_faire, 0, code)
 
     # --- Drill-down (#157) ---

--- a/views/core/souscription_campagne_views.xml
+++ b/views/core/souscription_campagne_views.xml
@@ -31,15 +31,15 @@
                                     <field name="etat_prerequis" widget="badge"
                                            decoration-success="etat_prerequis == 'prete'"
                                            decoration-warning="etat_prerequis == 'bloquee'"/>
-                                    <field name="valide" widget="boolean_toggle" invisible="type_etape == 'derive'"/>
+                                    <field name="valide" widget="boolean_toggle" invisible="type_etape != 'porte'"/>
                                     <field name="valide_par_id" readonly="1" invisible="not valide"/>
                                     <field name="valide_le" readonly="1" invisible="not valide"/>
                                     <field name="nb_reste_a_faire" invisible="type_etape != 'derive'"/>
                                     <field name="fait" widget="boolean" readonly="1"/>
                                     <!-- Étapes dérivées/action (#158) : un seul bouton générique qui
                                          dispatche vers l'action de la Campagne (pull/sync/créer/émettre).
-                                         Portes de vérif ET sync F15 se valident via la case `valide`
-                                         ci-dessus (sync F15 : on tire, puis on coche « fait »). -->
+                                         Seules les portes se valident via la case `valide` ci-dessus ;
+                                         sync F15 (action) est « faite » dès son lancement (`lance`). -->
                                     <button name="action_executer" type="object" string="Lancer"
                                             class="btn-link" invisible="type_etape == 'porte'"/>
                                     <button name="action_drill_down" type="object" string="Voir" icon="fa-search"/>


### PR DESCRIPTION
- **chore(deps): bump electricore-client 0.2.0 → 0.4.0 (lève le deploy-gate #147)**
- **wip(campagne): retirer la porte « relevés d'index » du DAG**
