### PR TITLE
feat(campagne): pull méta-périodes en un clic + périmètre mensuel correct (#174)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -282,6 +282,19 @@ l'enregistrement mensuel) ; **pipeline linéaire** (les étapes forment un DAG) 
 *Périodes* / *Refacturations* d'un drapeau « vérifiée » (la vérif est une porte à la maille
 campagne).
 
+**Périmètre de campagne** (souscriptions concernées par le mois M) :
+L'ensemble des *Souscriptions* qu'une *Campagne de facturation* du mois M doit traiter — base de
+tous ses **reste-à-faire** dérivés (pull, création, émission). Défini par **recouvrement de
+l'intervalle de service avec M**, calculé sur les **dates propres** de la Souscription : RSC
+acquise **et** `date_debut ≤ dernier jour de M` **et** (`date_fin` vide **ou** `date_fin ≥ premier
+jour de M`). C'est **historique et figé** par le mois — à distinguer de l'état *En service* qui est
+un **instantané vivant** (« a une RSC et n'est pas encore résiliée *aujourd'hui* »). Utiliser
+l'instantané pour cadrer une campagne d'un mois passé **sur-compte** les souscriptions entrées en
+service après M (jamais concernées, reste-à-faire jamais résorbé) et **sous-compte** celles
+résiliées depuis (concernées par M, mais devenues *Résiliée*). Corollaire : la justesse du périmètre
+**dépend** de la fiabilité de `date_debut` / `date_fin`.
+_Éviter_ : cadrer le périmètre sur `etat == 'en_service'` (instantané, pas maille-mois).
+
 **Accueilliste** :
 Rôle métier qui instruit les demandes de *raccordement* au quotidien : accueil des nouvelles
 demandes, demandes SGE selon la *situation d'entrée* (F120 / F130), saisie de l'*id_Affaire*,

--- a/models/core/souscription.py
+++ b/models/core/souscription.py
@@ -241,6 +241,33 @@ class Souscription(models.Model):
             else:
                 sous.etat = 'en_instance'
 
+    @api.model
+    def souscriptions_concernees(self, mois):
+        """Périmètre de campagne (CONTEXT.md « Périmètre de campagne ») : les
+        Souscriptions concernées par le mois `M`, par recouvrement de
+        l'intervalle de service avec `M` sur les dates propres de la
+        Souscription — RSC acquise ET `date_debut <= dernier jour de M` ET
+        (`date_fin` vide OU `date_fin >= premier jour de M`).
+
+        Point unique du prédicat : la Campagne (`_souscriptions_facturables`)
+        et le wizard ad-hoc de pull le consomment tous les deux, pour ne
+        jamais diverger. Historique et figé par le mois — à distinguer de
+        `etat == 'en_service'`, un instantané vivant (aujourd'hui), qui
+        sur-compte les Souscriptions entrées après `M` et sous-compte celles
+        résiliées depuis (ADR 0025)."""
+        premier_jour = fields.Date.to_date(mois).replace(day=1)
+        premier_jour_suivant = (premier_jour + timedelta(days=31)).replace(day=1)
+        dernier_jour = premier_jour_suivant - timedelta(days=1)
+        return self.search(
+            [
+                ('ref_situation_contractuelle', '!=', False),
+                ('date_debut', '<=', dernier_jour),
+                '|',
+                ('date_fin', '=', False),
+                ('date_fin', '>=', premier_jour),
+            ]
+        )
+
     @api.model_create_multi
     def create(self, vals_list):
         for vals in vals_list:

--- a/models/core/souscription_campagne.py
+++ b/models/core/souscription_campagne.py
@@ -185,10 +185,12 @@ class SouscriptionCampagneFacturation(models.Model):
     # souscription.periode / account.move (ADR 0025 §2). ---
 
     def _souscriptions_facturables(self):
-        """Souscriptions concernées par une campagne : *en service* (RSC
-        acquise, facturable) — les souscriptions *en instance* sont hors
-        périmètre de facturation (CONTEXT.md « En instance / En service »)."""
-        return self.env['souscription.souscription'].search([('etat', '=', 'en_service')])
+        """Souscriptions concernées par la campagne : le Périmètre de
+        campagne du mois (CONTEXT.md « Périmètre de campagne ») — recouvrement
+        de l'intervalle de service avec `self.mois`, jamais l'instantané vivant
+        `etat == 'en_service'` (#175)."""
+        self.ensure_one()
+        return self.env['souscription.souscription'].souscriptions_concernees(self.mois)
 
     def _statut_facturation(self, souscription):
         """Statut de facturation dérivé de `(souscription, mois de la

--- a/models/core/souscription_campagne.py
+++ b/models/core/souscription_campagne.py
@@ -279,20 +279,33 @@ class SouscriptionCampagneFacturation(models.Model):
             raise UserError(_('Étape « %s » bloquée : prérequis non satisfaits.', ETAPES_CAMPAGNE[code]['label']))
 
     def action_pull_meta_periodes(self):
-        """Ouvre le wizard de pull existant (#77), mois de la campagne
-        pré-rempli via le contexte `default_mois` (#158). Même forme d'action
-        que `action_souscription_pull_meta_periodes_wizard`
-        (souscription_pull_meta_periodes_wizard_views.xml) — reconstruite ici
-        plutôt que résolue par xml-id pour ne dépendre que du modèle, jamais
-        de l'id de vue."""
+        """Lance le tirage en un clic (#176), sans fenêtre intermédiaire :
+        cible le Périmètre de campagne (#175) pour `self.mois` — aucun mois
+        re-proposé, la scope est déjà celle de la campagne — et délègue la
+        boucle de tirage au point partagé avec le wizard ad-hoc
+        (`souscription.pull.meta.periodes.wizard._tirer_meta_periodes`, même
+        couture réseau `_ouvrir_flux`/fabrique client, ADR 0024). Retourne une
+        notification résumant créées/déjà présentes/erreurs — sticky si des
+        erreurs, auto-dismiss sinon — aucun résumé persisté."""
         self.ensure_one()
+        cibles = self._souscriptions_facturables()
+        creees, existantes, erreurs = self.env['souscription.pull.meta.periodes.wizard']._tirer_meta_periodes(
+            cibles, self.mois
+        )
         return {
-            'type': 'ir.actions.act_window',
-            'name': 'Récupérer les périodes du mois',
-            'res_model': 'souscription.pull.meta.periodes.wizard',
-            'view_mode': 'form',
-            'target': 'new',
-            'context': {'default_mois': self.mois},
+            'type': 'ir.actions.client',
+            'tag': 'display_notification',
+            'params': {
+                'title': _('Pull méta-périodes'),
+                'message': _(
+                    'Créées : %(creees)s · Déjà présentes : %(existantes)s · Erreurs : %(erreurs)s',
+                    creees=len(creees),
+                    existantes=len(existantes),
+                    erreurs=len(erreurs),
+                ),
+                'type': 'warning' if erreurs else 'success',
+                'sticky': bool(erreurs),
+            },
         }
 
     def action_sync_f15(self):

--- a/models/wizard/souscription_pull_meta_periodes_wizard.py
+++ b/models/wizard/souscription_pull_meta_periodes_wizard.py
@@ -60,23 +60,49 @@ class SouscriptionPullMetaPeriodesWizard(models.TransientModel):
         RSC, crée les périodes manquantes (create-missing-only), résume le
         résultat (créées / déjà existantes / sans RSC / erreurs).
 
-        Le client est acquis en tête, avant toute recherche (échec rapide et
-        déterministe, ADR 0024 §5) : un même clic produit toujours la même
-        classe de résultat, que des souscriptions à RSC existent ou non."""
+        Chemin ad-hoc (mois saisi, portée toutes-RSC) : délègue la boucle de
+        tirage à `_tirer_meta_periodes` (#176), partagée avec le chemin
+        Campagne (`souscription.campagne.facturation.action_pull_meta_periodes`,
+        portée Périmètre de campagne)."""
         self.ensure_one()
-        client = self.env['souscription.electricore.client'].client()
-
         Souscription = self.env['souscription.souscription']
-        Periode = self.env['souscription.periode']
 
         avec_rsc = Souscription.search([('ref_situation_contractuelle', '!=', False), ('active', '=', True)])
         sans_rsc = Souscription.search([('ref_situation_contractuelle', '=', False), ('active', '=', True)])
-        par_rsc = {s.ref_situation_contractuelle: s for s in avec_rsc}
+
+        creees, existantes, erreurs = self._tirer_meta_periodes(avec_rsc, self.mois)
+
+        self.resultat = self._formatter_resultat(creees, existantes, sans_rsc, erreurs)
+        self.state = 'done'
+        return {
+            'type': 'ir.actions.act_window',
+            'res_model': self._name,
+            'res_id': self.id,
+            'view_mode': 'form',
+            'target': 'new',
+        }
+
+    @api.model
+    def _tirer_meta_periodes(self, souscriptions, mois):
+        """Boucle de tirage partagée (#176) : acquiert le client (fabrique
+        `souscription.electricore.client`, ADR 0024), ouvre le flux
+        `meta_periodes` pour `mois` sur les RSC de `souscriptions`, crée les
+        périodes manquantes (create-missing-only) avec savepoint par élément
+        (skip-and-report, ADR 0011) et mappe les exceptions typées electricore
+        en `UserError`. Rend `(creees, existantes, erreurs)` — trois listes de
+        libellés, consommées par le résumé du wizard ad-hoc et par le
+        résultat/toast de la Campagne (#158/#176). `souscriptions` est déjà le
+        périmètre voulu par l'appelant (toutes-RSC pour le wizard, Périmètre
+        de campagne du mois pour la Campagne) : aucun filtre supplémentaire
+        ici."""
+        client = self.env['souscription.electricore.client'].client()
+        Periode = self.env['souscription.periode']
+        par_rsc = {s.ref_situation_contractuelle: s for s in souscriptions if s.ref_situation_contractuelle}
 
         creees, existantes, erreurs = [], [], []
 
         if par_rsc:
-            mois_str = fields.Date.to_string(self.mois)
+            mois_str = fields.Date.to_string(mois)
             try:
                 with self._ouvrir_flux(client, mois_str, list(par_rsc)) as stream:
                     for meta in stream:
@@ -99,15 +125,7 @@ class SouscriptionPullMetaPeriodesWizard(models.TransientModel):
             except ContractVersionError as exc:
                 raise UserError(f'Contrat electricore obsolète : {exc}')
 
-        self.resultat = self._formatter_resultat(creees, existantes, sans_rsc, erreurs)
-        self.state = 'done'
-        return {
-            'type': 'ir.actions.act_window',
-            'res_model': self._name,
-            'res_id': self.id,
-            'view_mode': 'form',
-            'target': 'new',
-        }
+        return creees, existantes, erreurs
 
     def _amorcer_une(self, Periode, souscription, meta, creees, existantes):
         """Create-missing-only (ADR 0011) : un `(souscription, mois)` déjà

--- a/tests/test_campagne_etapes_actions.py
+++ b/tests/test_campagne_etapes_actions.py
@@ -76,38 +76,49 @@ class TestCampagneEtapePullMetaPeriodes(SouscriptionsTestCase):
         )
         self.campagne = self.env['souscription.campagne.facturation'].create({'mois': self.MOIS})
 
-    def test_bouton_pull_ouvre_le_wizard_avec_le_mois_pre_rempli(self):
-        """AC : le step pull ouvre le wizard, mois pré-rempli."""
-        action = self.campagne.action_pull_meta_periodes()
-        self.assertEqual(action['res_model'], 'souscription.pull.meta.periodes.wizard')
-        self.assertEqual(action['context']['default_mois'], self.campagne.mois)
-
-    def test_bouton_pull_delegue_a_laction_deja_couverte(self):
-        """Le bouton délègue à l'action wizard déjà couverte par
-        test_pull_meta_periodes.py — même couture réseau (_ouvrir_flux),
-        aucune nouvelle."""
-        action = self.campagne.action_pull_meta_periodes()
-        wizard = self.env['souscription.pull.meta.periodes.wizard'].with_context(**action['context']).create({})
-        self.assertEqual(wizard.mois, self.campagne.mois)
-
+    def test_bouton_pull_agit_directement_et_retourne_une_notification(self):
+        """AC #176 : le bouton n'ouvre plus de fenêtre — il tire directement
+        (Périmètre de campagne du mois) et retourne un toast, pas une
+        ouverture de fenêtre."""
         client = _fake_electricore_client([_periode_meta()])
         with patch.object(fabrique_module.SouscriptionElectricoreClient, 'client', return_value=client):
-            wizard.action_lancer()
+            action = self.campagne.action_pull_meta_periodes()
+
+        self.assertEqual(action['type'], 'ir.actions.client')
+        self.assertEqual(action['tag'], 'display_notification')
+        params = action['params']
+        self.assertIn('Créées : 1', params['message'])
+        self.assertIn('Déjà présentes : 0', params['message'])
+        self.assertIn('Erreurs : 0', params['message'])
+        self.assertEqual(params['type'], 'success')
+        self.assertFalse(params['sticky'], "pas d'erreur -> toast auto-dismiss")
 
         periode = self.env['souscription.periode'].search(
             [('souscription_id', '=', self.souscription_base.id), ('mois', '=', self.MOIS)]
         )
         self.assertEqual(len(periode), 1)
 
-    def test_pull_idempotent_via_le_wizard(self):
-        """AC : rejouer le pull deux fois ne double pas la période
-        (create-missing-only, #77/#158)."""
-        action = self.campagne.action_pull_meta_periodes()
+    def test_bouton_pull_toast_sticky_quand_une_souscription_echoue(self):
+        """AC #176 : skip-and-report préservé — un échec sur une souscription
+        n'interrompt pas le lot, apparaît au compteur d'erreurs, et rend le
+        toast sticky."""
+        meta_invalide = _periode_meta(debut=None)  # déclenche une erreur de mapping (Date invalide)
+        client = _fake_electricore_client([meta_invalide])
+        with patch.object(fabrique_module.SouscriptionElectricoreClient, 'client', return_value=client):
+            action = self.campagne.action_pull_meta_periodes()
+
+        params = action['params']
+        self.assertIn('Erreurs : 1', params['message'])
+        self.assertEqual(params['type'], 'warning')
+        self.assertTrue(params['sticky'], 'une erreur -> toast sticky')
+
+    def test_pull_idempotent_via_la_campagne(self):
+        """AC #176 : rejouer le pull deux fois ne double pas la période
+        (create-missing-only préservé, #77/#158)."""
         client = _fake_electricore_client([_periode_meta()])
         for _run in range(2):
-            wizard = self.env['souscription.pull.meta.periodes.wizard'].with_context(**action['context']).create({})
             with patch.object(fabrique_module.SouscriptionElectricoreClient, 'client', return_value=client):
-                wizard.action_lancer()
+                self.campagne.action_pull_meta_periodes()
 
         periode = self.env['souscription.periode'].search(
             [('souscription_id', '=', self.souscription_base.id), ('mois', '=', self.MOIS)]
@@ -118,8 +129,22 @@ class TestCampagneEtapePullMetaPeriodes(SouscriptionsTestCase):
         """`action_executer` de la ligne d'étape « pull » délègue à
         `campagne.action_pull_meta_periodes` — un seul point de dispatch (#158)."""
         etape = self.campagne.etape_ids.filtered(lambda e: e.code == 'pull_meta_periodes')
-        action = etape.action_executer()
-        self.assertEqual(action['res_model'], 'souscription.pull.meta.periodes.wizard')
+        client = _fake_electricore_client([])
+        with patch.object(fabrique_module.SouscriptionElectricoreClient, 'client', return_value=client):
+            action = etape.action_executer()
+        self.assertEqual(action['tag'], 'display_notification')
+
+    def test_wizard_ad_hoc_fonctionne_toujours(self):
+        """Non-régression : le wizard « Récupérer les périodes du mois » et
+        son bouton d'en-tête restent inchangés (chemin secondaire, #176)."""
+        wizard = self.env['souscription.pull.meta.periodes.wizard'].create({'mois': self.MOIS})
+        client = _fake_electricore_client([_periode_meta()])
+        with patch.object(fabrique_module.SouscriptionElectricoreClient, 'client', return_value=client):
+            action = wizard.action_lancer()
+
+        self.assertEqual(action['type'], 'ir.actions.act_window')
+        self.assertEqual(wizard.state, 'done')
+        self.assertIn('Créées : 1', wizard.resultat)
 
 
 @tagged('souscriptions', 'souscriptions_campagne', 'post_install', '-at_install')

--- a/tests/test_campagne_signaux.py
+++ b/tests/test_campagne_signaux.py
@@ -33,6 +33,25 @@ class TestCampagneSignauxDerives(SouscriptionsTestCase):
     def _periode(self, souscription):
         return self.create_test_periode(souscription, date_debut=self.MOIS, date_fin=self.FIN_MOIS)
 
+    def _creer_souscription_rsc(self, name, rsc, date_debut, date_fin=False):
+        """Souscription minimale, RSC acquise, dates propres pilotées par le
+        test — pour exercer le Périmètre de campagne (#175) sans perturber
+        les fixtures partagées souscription_base/souscription_hphc."""
+        sous = self.env['souscription.souscription'].create(
+            {
+                'partner_id': self.partner_test.id,
+                'pdl': name,
+                'puissance_souscrite': '6',
+                'type_tarif': 'base',
+                'etat_facturation_id': self.etat_facturation.id,
+                'date_debut': date_debut,
+                'date_fin': date_fin,
+                'provision_mensuelle_kwh': 300.0,
+            }
+        )
+        sous.with_context(rsc_automatisme=True).write({'ref_situation_contractuelle': rsc})
+        return sous
+
     # --- Statut par souscription, quatre configurations fixture (AC #157) ---
 
     def test_statut_a_tirer_sans_periode_du_mois(self):
@@ -107,6 +126,51 @@ class TestCampagneSignauxDerives(SouscriptionsTestCase):
 
         self.assertEqual(self._etape('emettre_factures').nb_reste_a_faire, 0)
         self.assertTrue(self._etape('emettre_factures').fait)
+
+    # --- Périmètre de campagne (#175, CONTEXT.md) : recouvrement de
+    # l'intervalle de service avec le mois M, sur les dates propres de la
+    # Souscription — jamais l'instantané vivant `etat == 'en_service'`. ---
+
+    def test_perimetre_exclut_souscription_entree_en_service_apres_le_mois(self):
+        """Mise en service en avril, campagne de mars : hors périmètre — pas
+        de sur-compte (le reste-à-faire ne l'attend jamais)."""
+        self._creer_souscription_rsc('PDL_APRES', 'RSC-APRES', date(2024, 4, 1))
+        self.campagne.invalidate_recordset()
+
+        self.assertEqual(self._etape('pull_meta_periodes').nb_reste_a_faire, 2)
+
+    def test_perimetre_inclut_souscription_en_service_pendant_le_mois_mais_resiliee_depuis(self):
+        """En service dès janvier, résiliée en juin (dans le passé par
+        rapport à aujourd'hui) : concernée par mars, donc dans le
+        périmètre — pas de sous-compte malgré `etat == 'resiliee'`."""
+        resiliee = self._creer_souscription_rsc('PDL_RESILIEE', 'RSC-RESILIEE', date(2024, 1, 1), date(2024, 6, 30))
+        self.assertEqual(resiliee.etat, 'resiliee')
+        self.campagne.invalidate_recordset()
+
+        self.assertIn(resiliee, self.campagne._souscriptions_facturables())
+        self.assertEqual(self._etape('pull_meta_periodes').nb_reste_a_faire, 3)
+
+    def test_perimetre_inclut_souscription_entree_en_service_en_cours_de_mois(self):
+        """Mise en service le 15 mars : concernée par mars dès son entrée,
+        pas seulement à partir du mois suivant."""
+        en_cours = self._creer_souscription_rsc('PDL_EN_COURS', 'RSC-EN-COURS', date(2024, 3, 15))
+        self.campagne.invalidate_recordset()
+
+        self.assertIn(en_cours, self.campagne._souscriptions_facturables())
+        self.assertEqual(self._etape('pull_meta_periodes').nb_reste_a_faire, 3)
+
+    def test_drill_down_liste_exactement_les_souscriptions_du_perimetre(self):
+        """Le drill-down d'une étape dérivée liste exactement les
+        souscriptions comptées par son reste-à-faire (#175)."""
+        self._creer_souscription_rsc('PDL_APRES', 'RSC-APRES-DD', date(2024, 4, 1))
+        en_cours = self._creer_souscription_rsc('PDL_EN_COURS_DD', 'RSC-EN-COURS-DD', date(2024, 3, 15))
+        self.campagne.invalidate_recordset()
+
+        action = self._etape('pull_meta_periodes').action_drill_down()
+        self.assertEqual(
+            set(action['domain'][0][2]),
+            {self.souscription_base.id, self.souscription_hphc.id, en_cours.id},
+        )
 
     def test_sync_f15_et_portes_nont_pas_de_reste_a_faire(self):
         """Les étapes sans signal dérivé (action, portes) ont un


### PR DESCRIPTION
Closes #175
Closes #176

Parent : #174

**Périmètre de campagne** : `souscriptions_concernees(mois)` devient le point unique du prédicat de recouvrement (RSC acquise + `date_debut`/`date_fin` vs mois M), en remplacement de l'instantané `etat=='en_service'` dans `_souscriptions_facturables()` — corrige d'un coup le sur/sous-compte des étapes pull/créer/émettre et leur drill-down.

**Pull en un clic** : depuis la campagne, le pull méta-périodes s'exécute directement (plus de fenêtre wizard intermédiaire) et retourne un toast « Créées : N · Déjà présentes : N · Erreurs : N » (sticky si erreurs). La boucle de tirage est partagée entre la campagne et le wizard ad-hoc, ce dernier restant inchangé (chemin secondaire).

Tests : `test_campagne_signaux.py` (fixtures datées : après-M exclue, résiliée-mais-concernée incluse, en-cours-de-mois incluse, drill-down exact), `test_campagne_etapes_actions.py` (notification + counts + sticky, skip-and-report, idempotence, wizard ad-hoc préservé). Suite verte (56/56 campagne, 18/18 pull).

🤖 Generated with [Claude Code](https://claude.com/claude-code)