### PR TITLE
chore: ignorer FEATURES.report.html (snapshot éphémère de /story-map)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,6 @@ odoo-server.log
 
 # Rendered diagram previews (keep the .excalidraw source, not the heavy PNG)
 docs/diagrams/*.png
+
+# Snapshot éphémère du skill story-map (jamais commité)
+FEATURES.report.html


### PR DESCRIPTION
Le skill `story-map` génère à la demande un rapport HTML (`FEATURES.report.html`) à la racine — un snapshot éphémère qui ne doit jamais être commité, contrairement à `FEATURES.md` qui est la story map versionnée.

Une ligne dans `.gitignore` pour qu'il ne se glisse pas dans un commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)