### PR TITLE
chore(souscription): sortir « Active » du formulaire et de la liste

### DIFF
--- a/views/core/souscription_views.xml
+++ b/views/core/souscription_views.xml
@@ -23,11 +23,12 @@
                             icon="fa-external-link"/>
                 </header>
                 <sheet>
+                    <widget name="web_ribbon" title="Archivée" bg_color="text-bg-danger" invisible="active"/>
+                    <field name="active" invisible="1"/>
                     <group>
                         <field name="name" />
                         <field name="partner_id" />
                         <field name="cotitulaires" widget="many2many_tags" options="{'no_create': True}"/>
-                        <field name="active" />
                         <field name="etat" widget="badge"
                                decoration-warning="etat == 'en_instance'"
                                decoration-success="etat == 'en_service'"
@@ -148,7 +149,6 @@
                    decoration-danger="etat == 'resiliee'"/>
             <field name="id_affaire" optional="hide"/>
             <field name="ref_situation_contractuelle" optional="hide"/>
-            <field name="active"/>
           </list>
         </field>
     </record>


### PR DESCRIPTION
Suite de #180/#181 : `active` est la trappe d'archivage standard Odoo, pas un état métier à afficher — la case au formulaire et la colonne toujours-vraie en liste n'apportaient que du bruit.

- Formulaire : case remplacée par le pattern standard — champ invisible + ruban « Archivée » (visible seulement sur une archivée). L'archivage reste accessible via le menu ⚙ Actions.
- Liste : colonne `active` supprimée.
- Le filtre « Archivée » de la vue recherche est conservé (seul moyen de revoir une archivée).

Suite complète (docker) : 0 failed, 0 error(s) of 403 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)