### PR TITLE
feat(paiements): retirer cheque_energie du Mode de paiement

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -173,6 +173,29 @@ _Éviter_ : confondre « facturée » (une facture existe) et « émise » (fact
 Aide de l'État versée **au fournisseur à la place** du·de la *souscripteur·rice* (`souscription.cheque_energie`). C'est un **tiers-payeur**, **jamais une remise** : la fourniture n'est pas moins chère, une partie est payée par l'État — le **chiffre d'affaires et la TVA de la _Facture_ restent intacts**. Sur la *Facture*, il apparaît en **« payé / reste à payer »**, pas en ligne négative. Porte une **valeur nominale**, un **numéro** (unique), une **date d'expiration** (~mars N+1) et un **cycle de vie** : **reçu** (saisi, sans effet) → **validé** (la **porte** : saisie *à la main* sur le site étatique par le·la *facturiste* — aucun signal dérivable — qui le rend **imputable**) → **rejeté / expiré**. Rattaché au·à la *souscripteur·rice* (nominatif à la personne, pas au contrat) ; s'impute sur ses *Factures* **à leur création**, à hauteur de `min(solde, total)` sans jamais rendre la facture négative, **FIFO par expiration** quand la personne en détient plusieurs (renouvellement annuel). Le **solde** (portion non encore imputée) est **dérivé**, pas saisi. Un rejet/expiration *après* imputation se corrige **à la main** (pas d'automatisme). Le modèle **possède** l'identité et le cycle de vie ; la mécanique de solde et de lettrage est **déléguée** (cf. ADR 0026), non réimplémentée.
 _Éviter_ : **« remise »** ou ligne négative sur la *Facture* (c'est un paiement tiers, pas une minoration du prix ni de la TVA) ; imputer un chèque **non validé** (le site étatique est la porte) ; « solde saisi » (il est dérivé).
 
+**Mode de paiement** :
+La façon dont le·la *souscripteur·rice* règle le **solde** de ses *Factures*, portée par la
+**Souscription** (c'est le contrat qui fait foi, pas la personne : deux *Souscriptions* d'une même
+personne peuvent avoir des modes différents). Valeur **exclusive** parmi : prélèvement, monnaie
+locale (Moneko), espèces, virement, chèque. Sépare les factures en deux circuits de règlement :
+**prélèvement** (fichier SEPA en masse, adossé à un mandat) et **saisie manuelle** (tous les
+autres). Ne concerne que les factures à **reste à payer non nul** — une facture soldée (chèque
+énergie, 0 €) ne déclenche aucun règlement.
+_Éviter_ : le *Chèque énergie* comme mode de paiement (c'est un **tiers-payeur** qui s'impute
+avant règlement, le reste dû suit le mode de paiement normal) ; les **étiquettes** partenaire
+comme source de vérité du mode (non exclusives, non historisées, rattachées à la personne et non
+au contrat).
+
+**Mandat de prélèvement (SEPA)** :
+L'autorisation signée par le·la *souscripteur·rice* de débiter son compte, identifiée par un
+**RUM** unique, adossée à un IBAN et à l'ICS du fournisseur. Préalable obligatoire à tout
+*Mode de paiement* « prélèvement ». Le cycle de vie (actif → clos/révoqué, séquences, fichier
+SEPA) est **délégué à l'outillage comptable**, non réimplémenté ; le module ne fait que le
+**créer, actif d'emblée**, à l'acceptation d'un *raccordement* en prélèvement — l'acceptation
+est la porte humaine (IBAN vérifié, mandat signé exigé), pas de re-validation ensuite.
+_Éviter_ : un second circuit de validation du mandat (l'acceptation de la demande est la porte) ;
+prélever sans mandat actif ; re-saisir à la main ce que la demande de raccordement porte déjà.
+
 **Configuration Enedis** :
 La configuration *réseau* d'un PDL — FTA, calendrier distributeur, puissance réseau, cadrans
 réseau — propriété d'electricore (source : C15). Détermine le coût d'acheminement (TURPE).

--- a/__manifest__.py
+++ b/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Souscriptions Électricité',
-    'version': '19.0.1.9.0',
+    'version': '19.0.1.10.0',
     'depends': ['base', 'mail', 'contacts', 'account', 'portal'],
     'author': 'Virgile Daugé',
     'category': 'Energy',

--- a/demo/raccordement_demo.xml
+++ b/demo/raccordement_demo.xml
@@ -157,7 +157,7 @@
             <field name="contact_street">5 rue des Écoles</field>
             <field name="contact_zip">59000</field>
             <field name="contact_city">Lille</field>
-            <field name="mode_paiement">cheque_energie</field>
+            <field name="mode_paiement">virement</field>
             <field name="situation_entree">mes</field>
             <field name="id_affaire">DEMO-AFFAIRE-MENSU</field>
             <field name="id_affaire_date_saisie" eval="(DateTime.today() - relativedelta(days=20)).strftime('%Y-%m-%d')"/>

--- a/demo/souscriptions_demo.xml
+++ b/demo/souscriptions_demo.xml
@@ -107,7 +107,7 @@
             <field name="provision_mensuelle_kwh">150</field>
             <field name="lisse">True</field>
             <field name="tarif_solidaire">True</field>
-            <field name="mode_paiement">cheque_energie</field>
+            <field name="mode_paiement">virement</field>
             <field name="ref_compteur">85111222</field>
         </record>
 

--- a/migrations/19.0.1.10.0/post-migrate.py
+++ b/migrations/19.0.1.10.0/post-migrate.py
@@ -1,0 +1,17 @@
+"""Retrait de `cheque_energie` du Mode de paiement (#184, #183).
+
+Le chèque énergie est un tiers-payeur (ADR 0026, CONTEXT.md « Chèque
+énergie ») : il s'impute sur les Factures avant règlement, il ne règle pas
+le solde. Le proposer comme Mode de paiement contredisait le modèle — la
+valeur est retirée des deux Selections (souscription.souscription,
+raccordement.demande).
+
+Les enregistrements existants portant cette valeur sont vidés (pas de mode
+devinable, à renseigner à la main) ; les autres valeurs ne sont pas
+touchées. Idempotent, no-op sur install neuve ou base sans occurrence.
+"""
+
+
+def migrate(cr, version):
+    cr.execute("UPDATE souscription_souscription SET mode_paiement = NULL WHERE mode_paiement = 'cheque_energie'")
+    cr.execute("UPDATE raccordement_demande SET mode_paiement = NULL WHERE mode_paiement = 'cheque_energie'")

--- a/models/core/souscription.py
+++ b/models/core/souscription.py
@@ -130,7 +130,6 @@ class Souscription(models.Model):
     mode_paiement = fields.Selection(
         [
             ('prelevement', 'Prélèvement'),
-            ('cheque_energie', 'Chèque énergie'),
             ('monnaie_locale', 'Monnaie locale'),
             ('especes', 'Espèces'),
             ('virement', 'Virement'),

--- a/models/raccordement/raccordement_demande.py
+++ b/models/raccordement/raccordement_demande.py
@@ -170,7 +170,6 @@ class RaccordementDemande(models.Model):
     mode_paiement = fields.Selection(
         [
             ('prelevement', 'Prélèvement'),
-            ('cheque_energie', 'Chèque énergie'),
             ('monnaie_locale', 'Monnaie locale'),
             ('especes', 'Espèces'),
             ('virement', 'Virement'),

--- a/reports/souscription_conditions_particulieres_report.xml
+++ b/reports/souscription_conditions_particulieres_report.xml
@@ -109,7 +109,6 @@
                                 Mode de paiement retenu :
                                 <strong>
                                     <t t-if="souscription.mode_paiement == 'prelevement'">Prélèvement automatique</t>
-                                    <t t-elif="souscription.mode_paiement == 'cheque_energie'">Chèque énergie</t>
                                     <t t-elif="souscription.mode_paiement == 'monnaie_locale'">Monnaie locale</t>
                                     <t t-elif="souscription.mode_paiement == 'especes'">Espèces</t>
                                     <t t-elif="souscription.mode_paiement == 'virement'">Virement</t>

--- a/tests/data/test_raccordement_fixtures.xml
+++ b/tests/data/test_raccordement_fixtures.xml
@@ -8,14 +8,14 @@
             <field name="color">1</field>
             <field name="description">Étape de test pour nouvelles demandes</field>
         </record>
-        
+
         <record id="test_stage_validated" model="raccordement.stage">
             <field name="name">Test Validée</field>
             <field name="sequence">20</field>
             <field name="color">3</field>
             <field name="description">Étape de test pour demandes validées</field>
         </record>
-        
+
         <record id="test_stage_final" model="raccordement.stage">
             <field name="name">Test Souscrite</field>
             <field name="sequence">99</field>
@@ -24,7 +24,7 @@
             <field name="is_close">True</field>
             <field name="description">Étape finale de test</field>
         </record>
-        
+
         <!-- Demandes de raccordement de test -->
         <record id="test_demande_base" model="raccordement.demande">
             <field name="name">TEST-RACC-001</field>
@@ -48,7 +48,7 @@
             <field name="stage_id" ref="test_stage_new"/>
             <field name="notes">Demande de test pour tarif base</field>
         </record>
-        
+
         <record id="test_demande_hphc" model="raccordement.demande">
             <field name="name">TEST-RACC-002</field>
             <field name="pdl">PDL_TEST_RACC_002</field>
@@ -75,7 +75,7 @@
             <field name="stage_id" ref="test_stage_validated"/>
             <field name="notes">Demande de test pour tarif HP/HC</field>
         </record>
-        
+
         <record id="test_demande_solidaire" model="raccordement.demande">
             <field name="name">TEST-RACC-003</field>
             <field name="pdl">PDL_TEST_RACC_003</field>
@@ -91,11 +91,11 @@
             <field name="contact_street">789 place du Test</field>
             <field name="contact_zip">54321</field>
             <field name="contact_city">TestVille Solidaire</field>
-            <field name="mode_paiement">cheque_energie</field>
+            <field name="mode_paiement">virement</field>
             <field name="stage_id" ref="test_stage_new"/>
             <field name="notes">Demande de test pour tarif solidaire</field>
         </record>
-        
+
         <record id="test_demande_invalid_iban" model="raccordement.demande">
             <field name="name">TEST-RACC-004</field>
             <field name="pdl">PDL_TEST_RACC_004</field>
@@ -118,6 +118,6 @@
             <field name="notes">Demande de test avec IBAN invalide</field>
             <field name="kanban_state">blocked</field>
         </record>
-        
+
     </data>
 </odoo>

--- a/tests/test_raccordement.py
+++ b/tests/test_raccordement.py
@@ -53,6 +53,17 @@ class TestRaccordementBasic(SouscriptionsTestMixin, TransactionCase):
         self.assertIn('raccordement.demande', self.env)
         self.assertIn('raccordement.stage', self.env)
 
+    def test_mode_paiement_selection_verrouillee(self):
+        """Selection jumelle de celle de la Souscription (#184, CONTEXT.md
+        « Mode de paiement ») : le chèque énergie est un tiers-payeur, pas un
+        mode de règlement, il ne doit plus apparaître."""
+        valeurs = [key for key, _ in self.env['raccordement.demande']._fields['mode_paiement'].selection]
+        self.assertEqual(
+            valeurs,
+            ['prelevement', 'monnaie_locale', 'especes', 'virement', 'cheque'],
+        )
+        self.assertNotIn('cheque_energie', valeurs)
+
     def test_sequence_generation(self):
         """Test que la séquence de référence fonctionne"""
         demande = self.env['raccordement.demande'].create(

--- a/tests/test_souscription.py
+++ b/tests/test_souscription.py
@@ -151,3 +151,14 @@ class TestSouscription(TransactionCase):
         """L'adresse du PDL est exposée au formulaire Souscription (#106)."""
         view = self.env['souscription.souscription'].get_view(view_type='form')
         self.assertIn('adresse_pdl', view['arch'])
+
+    def test_mode_paiement_selection_verrouillee(self):
+        """Le chèque énergie est un tiers-payeur, pas un mode de règlement
+        (#184, CONTEXT.md « Mode de paiement ») : il ne doit plus apparaître
+        parmi les valeurs possibles."""
+        valeurs = [key for key, _ in self.env['souscription.souscription']._fields['mode_paiement'].selection]
+        self.assertEqual(
+            valeurs,
+            ['prelevement', 'monnaie_locale', 'especes', 'virement', 'cheque'],
+        )
+        self.assertNotIn('cheque_energie', valeurs)


### PR DESCRIPTION
Closes #184

Retire `cheque_energie` des deux Selections « Mode de paiement » (Souscription et demande de raccordement) : c'est un tiers-payeur (ADR 0026) qui s'impute avant règlement, pas un mode de règlement. Migration qui vide la valeur sur les enregistrements existants sans toucher aux autres. Purge au passage les données de démo/fixtures et une branche morte du rapport CGV qui référençaient encore cette valeur, et verrouille les deux Selections par test structurel.

Suite complète : 0 failed, 0 error(s) of 405 tests (docker, base fraîche).

🤖 Generated with [Claude Code](https://claude.com/claude-code)