### PR TITLE
feat(raccordement): pont vers le mandat SEPA actif à l'acceptation

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -173,6 +173,29 @@ _Éviter_ : confondre « facturée » (une facture existe) et « émise » (fact
 Aide de l'État versée **au fournisseur à la place** du·de la *souscripteur·rice* (`souscription.cheque_energie`). C'est un **tiers-payeur**, **jamais une remise** : la fourniture n'est pas moins chère, une partie est payée par l'État — le **chiffre d'affaires et la TVA de la _Facture_ restent intacts**. Sur la *Facture*, il apparaît en **« payé / reste à payer »**, pas en ligne négative. Porte une **valeur nominale**, un **numéro** (unique), une **date d'expiration** (~mars N+1) et un **cycle de vie** : **reçu** (saisi, sans effet) → **validé** (la **porte** : saisie *à la main* sur le site étatique par le·la *facturiste* — aucun signal dérivable — qui le rend **imputable**) → **rejeté / expiré**. Rattaché au·à la *souscripteur·rice* (nominatif à la personne, pas au contrat) ; s'impute sur ses *Factures* **à leur création**, à hauteur de `min(solde, total)` sans jamais rendre la facture négative, **FIFO par expiration** quand la personne en détient plusieurs (renouvellement annuel). Le **solde** (portion non encore imputée) est **dérivé**, pas saisi. Un rejet/expiration *après* imputation se corrige **à la main** (pas d'automatisme). Le modèle **possède** l'identité et le cycle de vie ; la mécanique de solde et de lettrage est **déléguée** (cf. ADR 0026), non réimplémentée.
 _Éviter_ : **« remise »** ou ligne négative sur la *Facture* (c'est un paiement tiers, pas une minoration du prix ni de la TVA) ; imputer un chèque **non validé** (le site étatique est la porte) ; « solde saisi » (il est dérivé).
 
+**Mode de paiement** :
+La façon dont le·la *souscripteur·rice* règle le **solde** de ses *Factures*, portée par la
+**Souscription** (c'est le contrat qui fait foi, pas la personne : deux *Souscriptions* d'une même
+personne peuvent avoir des modes différents). Valeur **exclusive** parmi : prélèvement, monnaie
+locale (Moneko), espèces, virement, chèque. Sépare les factures en deux circuits de règlement :
+**prélèvement** (fichier SEPA en masse, adossé à un mandat) et **saisie manuelle** (tous les
+autres). Ne concerne que les factures à **reste à payer non nul** — une facture soldée (chèque
+énergie, 0 €) ne déclenche aucun règlement.
+_Éviter_ : le *Chèque énergie* comme mode de paiement (c'est un **tiers-payeur** qui s'impute
+avant règlement, le reste dû suit le mode de paiement normal) ; les **étiquettes** partenaire
+comme source de vérité du mode (non exclusives, non historisées, rattachées à la personne et non
+au contrat).
+
+**Mandat de prélèvement (SEPA)** :
+L'autorisation signée par le·la *souscripteur·rice* de débiter son compte, identifiée par un
+**RUM** unique, adossée à un IBAN et à l'ICS du fournisseur. Préalable obligatoire à tout
+*Mode de paiement* « prélèvement ». Le cycle de vie (actif → clos/révoqué, séquences, fichier
+SEPA) est **délégué à l'outillage comptable**, non réimplémenté ; le module ne fait que le
+**créer, actif d'emblée**, à l'acceptation d'un *raccordement* en prélèvement — l'acceptation
+est la porte humaine (IBAN vérifié, mandat signé exigé), pas de re-validation ensuite.
+_Éviter_ : un second circuit de validation du mandat (l'acceptation de la demande est la porte) ;
+prélever sans mandat actif ; re-saisir à la main ce que la demande de raccordement porte déjà.
+
 **Configuration Enedis** :
 La configuration *réseau* d'un PDL — FTA, calendrier distributeur, puissance réseau, cadrans
 réseau — propriété d'electricore (source : C15). Détermine le coût d'acheminement (TURPE).

--- a/__manifest__.py
+++ b/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Souscriptions Électricité',
-    'version': '19.0.1.9.0',
+    'version': '19.0.1.10.0',
     'depends': ['base', 'mail', 'contacts', 'account', 'portal'],
     'author': 'Virgile Daugé',
     'category': 'Energy',

--- a/models/raccordement/raccordement_demande.py
+++ b/models/raccordement/raccordement_demande.py
@@ -567,10 +567,14 @@ class RaccordementDemande(models.Model):
             partner = self._create_partner()
             self.partner_id = partner
 
-            # 2. Créer le compte bancaire si nécessaire
+            # 2. Créer le compte bancaire si nécessaire, puis le mandat SEPA
+            # (#187) : la garde IBAN (_verifier_garde_iban_acceptation,
+            # exécutée avant l'écriture qui déclenche _create_odoo_entries)
+            # garantit déjà un IBAN valide ici en mode prélèvement.
             if self.bank_iban and self.mode_paiement == 'prelevement':
                 partner_bank = self._create_partner_bank(partner)
                 self.partner_bank_id = partner_bank
+                self._creer_mandat_sepa(partner, partner_bank)
 
             # 3. Créer la souscription
             souscription = self._create_souscription(partner)
@@ -663,6 +667,94 @@ class RaccordementDemande(models.Model):
                 bank_vals['bank_id'] = bank.id
 
         return self.env['res.partner.bank'].create(bank_vals)
+
+    # --- Pont vers le mandat SEPA (#187, CONTEXT.md « Mandat de
+    # prélèvement (SEPA) », PRD #183) ---
+    #
+    # Le modèle de mandat (`sdd.mandate`) vit dans le module Enterprise
+    # « Direct Debit » : absent en Community/CI, jamais dans les
+    # `depends` du manifeste (décision PRD #183 — pas de dépendance à un
+    # module privé). Garde runtime au point d'entrée unique
+    # (_creer_mandat_sepa) : idem l'idiome de dépendance molle
+    # d'electricore-client (ADR 0024), mais sur le *registre* de modèles
+    # plutôt que sur un *import* Python.
+
+    def _creer_mandat_sepa(self, partner, partner_bank):
+        """Crée le mandat SEPA, actif d'emblée, à l'acceptation d'une
+        demande en mode prélèvement (#187). L'acceptation est la porte
+        humaine (IBAN vérifié par _verifier_garde_iban_acceptation, mandat
+        signé exigé côté saisie) : pas de second circuit de validation
+        (CONTEXT.md « Mandat de prélèvement »).
+
+        No-op silencieux si `sdd.mandate` est absent du registre (Community/
+        CI) : le reste de l'acceptation se déroule à l'identique."""
+        self.ensure_one()
+        if 'sdd.mandate' not in self.env:
+            return
+        journal = self._resoudre_journal_sdd()
+        mandat = self.env['sdd.mandate'].create(self._mandat_sepa_vals(partner, partner_bank, journal))
+        # Traçable depuis la demande sans nouveau champ relationnel vers un
+        # modèle absent en Community (un Many2one déclaré ici casserait
+        # l'install Community à l'_auto_init) : on recopie la référence
+        # (RUM, saisie ou générée par l'outillage) sur le champ existant, et
+        # on trace le rattachement au chatter.
+        self.sepa_mandate_ref = mandat.name
+        self.message_post(body=f'Mandat SEPA créé et actif (RUM : {mandat.name}, journal : {journal.name}).')
+
+    def _resoudre_journal_sdd(self):
+        """Résout dynamiquement le journal comptable portant la méthode de
+        paiement SDD (prélèvement SEPA) — jamais configuré en dur (#187).
+        Erreur explicite si aucun journal ne l'expose ou si plusieurs le
+        font : pas de mandat silencieusement rattaché au mauvais journal."""
+        self.ensure_one()
+        journaux = self.env['account.journal'].search(
+            [
+                ('company_id', '=', self.company_id.id),
+                ('inbound_payment_method_line_ids.code', '=', 'sdd'),
+            ]
+        )
+        if not journaux:
+            raise UserError(
+                "Aucun journal comptable n'expose la méthode de paiement SDD (prélèvement SEPA) : "
+                "configurez-en un dans l'outillage comptable avant d'accepter une demande en prélèvement."
+            )
+        if len(journaux) > 1:
+            raise UserError(
+                'Plusieurs journaux comptables exposent la méthode de paiement SDD (prélèvement SEPA), '
+                f'ambiguïté à résoudre avant acceptation : {", ".join(journaux.mapped("name"))}.'
+            )
+        return journaux
+
+    def _mandat_sepa_vals(self, partner, partner_bank, journal):
+        """Construction pure des valeurs du mandat SEPA (#187) — seule
+        couture nouvelle du chantier, sans accès au registre ni à la base :
+        testable en CI Community sans le modèle Enterprise `sdd.mandate`.
+
+        RUM = référence saisie sur la demande si présente, sinon absente du
+        dict pour laisser le défaut de l'outillage la générer. Date de
+        début = date de signature du mandat si saisie, sinon aujourd'hui.
+        Schéma CORE, actif d'emblée (l'acceptation est la porte humaine).
+
+        ponytail : noms de champs (`payment_journal_id`, `scheme`, `state`)
+        alignés sur le module Enterprise `account_sepa_direct_debit` d'après
+        sa documentation publique — invérifiables ici (pas de source
+        Enterprise, pas de réseau en sandbox). À confronter au modèle réel
+        avant premier usage en instance Enterprise ; un nom erroné lève une
+        erreur explicite au `create()`, jamais un mandat silencieusement
+        faux.
+        """
+        self.ensure_one()
+        vals = {
+            'partner_id': partner.id,
+            'partner_bank_id': partner_bank.id,
+            'payment_journal_id': journal.id,
+            'start_date': self.sepa_mandate_date or fields.Date.context_today(self),
+            'state': 'active',
+            'scheme': 'CORE',
+        }
+        if self.sepa_mandate_ref:
+            vals['name'] = self.sepa_mandate_ref
+        return vals
 
     def _create_souscription(self, partner):
         """Crée une souscription"""

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -24,6 +24,7 @@ from . import (
     test_pull_meta_periodes,
     test_raccordement,
     test_raccordement_kanban_faits,
+    test_raccordement_mandat_sepa,
     test_refacturation,
     test_releve,
     test_releve_demo,

--- a/tests/test_raccordement_mandat_sepa.py
+++ b/tests/test_raccordement_mandat_sepa.py
@@ -108,9 +108,10 @@ class TestResoudreJournalSdd(SouscriptionsTestMixin, TransactionCase):
         return self.env['raccordement.demande'].create(defaults)
 
     def _donner_methode_sdd(self, journal):
-        method = self.env['account.payment.method'].create(
-            {'name': 'SDD Test', 'code': 'sdd', 'payment_type': 'inbound'}
-        )
+        # (code, payment_type) est unique : une seule méthode sdd, partagée
+        method = self.env['account.payment.method'].search(
+            [('code', '=', 'sdd'), ('payment_type', '=', 'inbound')], limit=1
+        ) or self.env['account.payment.method'].create({'name': 'SDD Test', 'code': 'sdd', 'payment_type': 'inbound'})
         self.env['account.payment.method.line'].create(
             {'name': 'SDD', 'payment_method_id': method.id, 'journal_id': journal.id}
         )

--- a/tests/test_raccordement_mandat_sepa.py
+++ b/tests/test_raccordement_mandat_sepa.py
@@ -1,0 +1,197 @@
+"""Tests #187 — pont raccordement -> mandat SEPA actif à l'acceptation
+(PRD #183, CONTEXT.md « Mandat de prélèvement (SEPA) »).
+
+Le modèle de mandat (`sdd.mandate`) vit dans le module Enterprise « Direct
+Debit », absent en Community/CI (décision PRD #183 : pas de dépendance
+manifeste à un module privé). La seule couture testable ici sans lui est la
+méthode pure de construction des valeurs (`_mandat_sepa_vals`) et la
+résolution du journal SDD (`_resoudre_journal_sdd`, lecture seule sur
+`account.journal`/`account.payment.method`, tous deux Community) ; le garde
+runtime (`_creer_mandat_sepa`) se teste côté no-op — la création réelle d'un
+`sdd.mandate` ne peut être exercée qu'en instance Enterprise, hors de portée
+de cette suite.
+"""
+
+from datetime import date, timedelta
+from unittest.mock import patch
+
+from odoo.exceptions import UserError
+from odoo.tests.common import TransactionCase, tagged
+
+from .common import SouscriptionsTestMixin
+
+IBAN_VALIDE = 'FR1420041010050500013M02606'
+
+
+def _demande_defaults(email):
+    return {
+        'pdl': 'TEST_MANDAT_' + email,
+        'date_debut_souhaitee': date.today() + timedelta(days=30),
+        'puissance_souscrite': '6',
+        'contact_nom': 'Test',
+        'contact_email': email,
+        'contact_street': 'Test Street',
+        'contact_zip': '12345',
+        'contact_city': 'Test City',
+        'mode_paiement': 'prelevement',
+        'bank_iban': IBAN_VALIDE,
+    }
+
+
+@tagged('souscriptions', 'souscriptions_raccordement', 'post_install', '-at_install')
+class TestMandatSepaValsPur(SouscriptionsTestMixin, TransactionCase):
+    """`_mandat_sepa_vals` : construction pure, sans accès au registre ni à
+    la base au-delà des champs de `self` — la seam Community/CI de #187."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.setUpSouscriptionsData()
+        cls.partner = cls.env['res.partner'].create({'name': 'Mandat Vals Partner'})
+        cls.partner_bank = cls.env['res.partner.bank'].create({'partner_id': cls.partner.id, 'acc_number': IBAN_VALIDE})
+        cls.journal = cls.env['account.journal'].create(
+            {'name': 'Journal Test Mandat', 'code': 'MNDT', 'type': 'bank', 'company_id': cls.env.company.id}
+        )
+
+    def create_demande(self, **kwargs):
+        defaults = _demande_defaults('mandat-vals@example.com')
+        defaults.update(kwargs)
+        return self.env['raccordement.demande'].create(defaults)
+
+    def test_rum_saisi_repris_tel_quel(self):
+        demande = self.create_demande(sepa_mandate_ref='SEPA-TEST-001')
+        vals = demande._mandat_sepa_vals(self.partner, self.partner_bank, self.journal)
+        self.assertEqual(vals['name'], 'SEPA-TEST-001')
+
+    def test_rum_absent_laisse_le_defaut_de_l_outillage_generer(self):
+        demande = self.create_demande(sepa_mandate_ref=False)
+        vals = demande._mandat_sepa_vals(self.partner, self.partner_bank, self.journal)
+        self.assertNotIn('name', vals)
+
+    def test_date_debut_reprend_la_date_de_signature(self):
+        demande = self.create_demande(sepa_mandate_date=date(2026, 3, 15))
+        vals = demande._mandat_sepa_vals(self.partner, self.partner_bank, self.journal)
+        self.assertEqual(vals['start_date'], date(2026, 3, 15))
+
+    def test_date_debut_par_defaut_aujourd_hui_si_signature_absente(self):
+        demande = self.create_demande(sepa_mandate_date=False)
+        vals = demande._mandat_sepa_vals(self.partner, self.partner_bank, self.journal)
+        self.assertEqual(vals['start_date'], date.today())
+
+    def test_compte_bancaire_partenaire_et_journal_repris_tels_quels(self):
+        demande = self.create_demande()
+        vals = demande._mandat_sepa_vals(self.partner, self.partner_bank, self.journal)
+        self.assertEqual(vals['partner_id'], self.partner.id)
+        self.assertEqual(vals['partner_bank_id'], self.partner_bank.id)
+        self.assertEqual(vals['payment_journal_id'], self.journal.id)
+
+    def test_actif_d_emblee_schema_core(self):
+        demande = self.create_demande()
+        vals = demande._mandat_sepa_vals(self.partner, self.partner_bank, self.journal)
+        self.assertEqual(vals['state'], 'active')
+        self.assertEqual(vals['scheme'], 'CORE')
+
+
+@tagged('souscriptions', 'souscriptions_raccordement', 'post_install', '-at_install')
+class TestResoudreJournalSdd(SouscriptionsTestMixin, TransactionCase):
+    """`_resoudre_journal_sdd` : résolution dynamique (jamais configurée en
+    dur), erreur explicite si introuvable ou ambigu (#187)."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.setUpSouscriptionsData()
+
+    def create_demande(self, **kwargs):
+        defaults = _demande_defaults('journal-sdd@example.com')
+        defaults.update(kwargs)
+        return self.env['raccordement.demande'].create(defaults)
+
+    def _donner_methode_sdd(self, journal):
+        method = self.env['account.payment.method'].create(
+            {'name': 'SDD Test', 'code': 'sdd', 'payment_type': 'inbound'}
+        )
+        self.env['account.payment.method.line'].create(
+            {'name': 'SDD', 'payment_method_id': method.id, 'journal_id': journal.id}
+        )
+
+    def test_leve_si_aucun_journal_sdd(self):
+        demande = self.create_demande()
+        with self.assertRaises(UserError) as cm:
+            demande._resoudre_journal_sdd()
+        self.assertIn('SDD', str(cm.exception))
+
+    def test_resout_le_journal_unique(self):
+        journal = self.env['account.journal'].create(
+            {'name': 'Journal SDD Unique', 'code': 'SDDU', 'type': 'bank', 'company_id': self.env.company.id}
+        )
+        self._donner_methode_sdd(journal)
+        demande = self.create_demande()
+        self.assertEqual(demande._resoudre_journal_sdd(), journal)
+
+    def test_leve_si_journaux_ambigus(self):
+        journal_a = self.env['account.journal'].create(
+            {'name': 'Journal SDD A', 'code': 'SDDA', 'type': 'bank', 'company_id': self.env.company.id}
+        )
+        journal_b = self.env['account.journal'].create(
+            {'name': 'Journal SDD B', 'code': 'SDDB', 'type': 'bank', 'company_id': self.env.company.id}
+        )
+        self._donner_methode_sdd(journal_a)
+        self._donner_methode_sdd(journal_b)
+        demande = self.create_demande()
+        with self.assertRaises(UserError) as cm:
+            demande._resoudre_journal_sdd()
+        self.assertIn('Plusieurs', str(cm.exception))
+
+
+@tagged('souscriptions', 'souscriptions_raccordement', 'post_install', '-at_install')
+class TestCreerMandatSepaGuard(SouscriptionsTestMixin, TransactionCase):
+    """Garde runtime (#187) : `sdd.mandate` absent du registre en
+    Community/CI -> no-op silencieux, acceptation inchangée ; un autre mode
+    de paiement ne crée jamais de mandat."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.setUpSouscriptionsData()
+        cls.stage_final = cls.env.ref('souscriptions_odoo.stage_accepte_iban_verifie')
+
+    def create_demande(self, email, **kwargs):
+        defaults = _demande_defaults(email)
+        defaults.update(kwargs)
+        return self.env['raccordement.demande'].create(defaults)
+
+    def test_registre_sans_sdd_mandate_en_community(self):
+        """Confirme l'hypothèse sur laquelle repose tout ce fichier : cette
+        suite tourne en Community/CI, sans le modèle Enterprise."""
+        self.assertNotIn('sdd.mandate', self.env)
+
+    def test_creer_mandat_sepa_noop_sans_outillage(self):
+        demande = self.create_demande('guard-noop@example.com')
+        partner = self.env['res.partner'].create({'name': 'Mandat Guard Partner'})
+        partner_bank = self.env['res.partner.bank'].create({'partner_id': partner.id, 'acc_number': demande.bank_iban})
+        # La résolution de journal planterait sans `sdd.mandate` (aucun
+        # journal SDD configuré) : si elle était appelée malgré le garde,
+        # cette assertion le détecterait immédiatement.
+        with patch.object(
+            type(demande), '_resoudre_journal_sdd', side_effect=AssertionError('ne doit pas être appelé')
+        ):
+            demande._creer_mandat_sepa(partner, partner_bank)  # ne doit pas lever
+        self.assertFalse(demande.sepa_mandate_ref)
+
+    def test_acceptation_prelevement_sans_outillage_comportement_inchange(self):
+        """AC #187 : acceptation en prélèvement sans l'outillage -> aucun
+        crash, souscription et compte bancaire créés comme avant #187."""
+        demande = self.create_demande('guard-accept@example.com')
+        demande.stage_id = self.stage_final
+        self.assertTrue(demande.souscription_id)
+        self.assertTrue(demande.partner_bank_id)
+
+    def test_acceptation_autre_mode_aucun_mandat_cree(self):
+        """AC #187 : hors prélèvement, `_creer_mandat_sepa` n'est même pas
+        invoquée."""
+        demande = self.create_demande('guard-virement@example.com', mode_paiement='virement', bank_iban=False)
+        with patch.object(type(demande), '_creer_mandat_sepa') as mock_creer:
+            demande.stage_id = self.stage_final
+        mock_creer.assert_not_called()
+        self.assertTrue(demande.souscription_id)


### PR DESCRIPTION
Closes #187

Pont raccordement → mandat SEPA : à l'acceptation d'une demande en mode prélèvement, le mandat est créé actif d'emblée dans l'outillage comptable (`sdd.mandate`), sans re-saisie de l'IBAN/RUM/date déjà portés par la demande.

Garde runtime au registre (pas de dépendance manifest à un module privé) : no-op silencieux en Community/CI. La construction des valeurs du mandat (`_mandat_sepa_vals`) est isolée, pure, et testée sans le modèle Enterprise — c'est la seule couture nouvelle du chantier.

Suite complète : 0 failed, 0 error(s) of 416 tests (docker, base fraîche).

⚠️ Les noms de champs `sdd.mandate` sont inférés (pas de source Enterprise en sandbox) — smoke-test sur instance Enterprise requis avant prod (flaggé `ponytail:` dans `_mandat_sepa_vals`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)