### PR TITLE
chore(souscription): journal des actes unifié — actes d'adhésion au journal, suppression des champs plats (ADR 0027)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -57,7 +57,8 @@ lissage/provisions, mode de paiement — **et porte ses déclarations/consenteme
 adhésion association, acceptation CGV, courbe de charge, renonciation rétractation) **et la
 signature électronique**. Il **complète** les *conditions générales* (CGV — cadre légal générique,
 **référencées** et non reproduites), pas l'inverse. C'est une **projection** de la *Souscription*
-(les consentements et la date de signature sont **portés par la *Souscription***), jamais un
+(les actes — consentements, acceptation CGV, renonciation, signature — sont **portés par le
+*Journal des actes*** de la *Souscription*), jamais un
 enregistrement distinct ni un acte de vente. Lève l'ambiguïté du terme « contrat » : le cadre
 contractuel = *CGV* + *conditions particulières* ; l'enregistrement = la *Souscription*.
 _Éviter_ : « contrat » seul (préciser *conditions particulières*, *CGV* ou *Souscription*) ;
@@ -225,13 +226,29 @@ facturation* existe en deux exemplaires parallèles — standard et solidaire �
 sélectionne le bon selon ce drapeau (ADR 0013).
 _Éviter_ : réduire le solidaire à une **remise** (ce n'est pas qu'un prix : c'est une comptabilité isolée).
 
+**Journal des actes** :
+Le registre **append-only** possédé par la *Souscription* (`souscription.consentement` — le nom
+technique reste, le vocabulaire vivant est *Journal des actes*, ADR 0027) où chaque **Acte** du·de
+la *souscripteur·rice* est tracé : une ligne = une **finalité**, un **horodatage**, la **version du
+texte montré**, une **source/canal**. Deux **natures** d'actes :
+- **consentement RGPD** (cf. *Consentement (données de consommation)*) — **révocable** : le retrait
+  **ajoute** une ligne, n'écrase rien ;
+- **acte d'adhésion** (acceptation CGV, renonciation au délai de rétractation) — **irrévocable**
+  (one-shot contractuel : on ne « retire » pas une signature) : le journal **refuse** le retrait ;
+  l'horodatage **est** la date de signature.
+L'état courant d'une finalité est sa **dernière** ligne ; l'**absence de ligne** est la seule
+représentation du « non » (pas d'acte = pas de preuve). Les *conditions particulières* lisent le
+journal, jamais des champs plats.
+_Éviter_ : « journal de consentement » pour l'ensemble (le consentement RGPD n'est qu'une des deux
+natures) ; un booléen ou une date plate comme preuve d'un acte ; fabriquer une ligne sans acte réel.
+
 **Consentement (données de consommation)** :
 La base légale RGPD (art. 6-1-a) par laquelle un·e *souscripteur·rice* autorise EDN à faire
 **collecter auprès d'*Enedis*** ses données de consommation **plus fines que l'index de
 facturation** (consommations quotidiennes transmises au fournisseur, courbe de charge). Distinct de
 l'**acceptation contractuelle** (CGV / *conditions particulières*) et du **mandat SEPA**. Capté par
 un **acte positif** au *raccordement* (formulaire public, cases **non** pré-cochées, **par
-finalité**), tracé dans un **journal append-only** possédé par la *Souscription* — preuve opposable
+finalité**), tracé dans le *Journal des actes* — preuve opposable
 (*accountability*, art. 7-1) à la CNIL **et** à Enedis (à qui EDN **déclare** détenir le
 consentement), retrait compris (art. 7-3). L'**index** seul, pour facturer, relève de l'**exécution
 du contrat** (art. 6-1-b) et **ne requiert pas** de consentement.
@@ -342,8 +359,9 @@ Les étapes à entrée **factuelle** (id_Affaire saisi, RSC acquise) avancent se
 forcent pas : on corrige le fait, la carte suit. Chaque colonne du kanban dit qui doit agir :
 **action attendue** (un humain), **attente externe** (personne — le poll veille), **fait**.
 C'est le point de **capture** des données
-saisies à l'adhésion — **dont les consentements et la signature** (équivalent du *LSD* de
-prod) —, **recopiées** sur la *Souscription* qui en devient **propriétaire** (système de
+saisies à l'adhésion — **dont les actes** (consentements, acceptation CGV, renonciation —
+équivalent du *LSD* de prod) —, **journalisées** dans le *Journal des actes* de la *Souscription*
+qui en devient **propriétaire** (système de
 référence) ; la *demande* reste un intake transitoire. Les *conditions particulières* lisent ces
 données sur la *Souscription*, jamais sur la demande.
 _Éviter_ : confondre la **demande de raccordement** (intake) et la *Souscription* (l'enregistrement

--- a/__manifest__.py
+++ b/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Souscriptions Électricité',
-    'version': '19.0.1.10.0',
+    'version': '19.0.1.11.0',
     'depends': ['base', 'mail', 'contacts', 'account', 'portal'],
     'author': 'Virgile Daugé',
     'category': 'Energy',

--- a/docs/adr/0027-journal-des-actes-unifie-adhesion-irrevocable-consentements.md
+++ b/docs/adr/0027-journal-des-actes-unifie-adhesion-irrevocable-consentements.md
@@ -1,0 +1,55 @@
+# Journal des actes unifié : les actes d'adhésion rejoignent le journal de consentement
+
+La *Souscription* trace **tous les actes** du·de la *souscripteur·rice* — consentements RGPD
+**et** actes d'adhésion contractuels (acceptation CGV, renonciation au délai de rétractation) —
+dans le **même journal append-only** (`souscription.consentement`, ADR 0017), rebaptisé
+***Journal des actes*** dans le vocabulaire (le nom technique du modèle ne change pas : renommer
+la table serait du churn de migration sans gain). Les champs plats `date_validation` et
+`renonce_retractation` de la souscription sont **supprimés** ; les *conditions particulières*
+lisent le journal (dernière ligne par finalité). Les finalités contractuelles sont
+**irrévocables** : le journal **refuse** un retrait sur `acceptation_cgv` /
+`renonciation_retractation` — on ne « retire » pas une signature.
+
+Motif : un seul registre de preuves (horodatage + **version du texte montré** + source), la même
+garantie d'intégrité texte↔preuve que l'ADR 0017, au lieu de deux mécanismes parallèles — journal
+riche pour le RGPD, champs plats **muets** (ni texte, ni source) pour le contractuel. La preuve
+d'époque **existe** : le kanban prod (`x_souscription_differe`) enregistre le texte validé au
+formulaire (`x_cgv`, `x_responsabilite`) et l'horodatage de soumission (`x_date_soumission_form`).
+La **reprise est portée par le pipeline** `souscriptions_migration`, qui crée les lignes de
+journal avec ces textes réels.
+
+## Options considérées
+
+- **Statu quo (champs plats conservés)** — deux natures de preuve ; la CP imprime depuis des
+  champs sans texte ni source ; la section « Adhésion » du formulaire fait doublon visuel avec le
+  journal affiché dessous. Rejeté.
+- **Deux journaux séparés** (consentements / actes d'adhésion) — duplique la mécanique
+  append-only pour distinguer ce que la colonne `finalite` distingue déjà. Rejeté.
+- **Sémantique donné/retiré étendue telle quelle aux actes contractuels** — un « retrait »
+  d'acceptation CGV est juridiquement absurde. Rejeté au profit du garde d'irrévocabilité : même
+  table, natures distinguées par finalité, retrait refusé sur les irrévocables.
+- **Pre-migrate défensif dans l'addon** (conversion champs plats → lignes sentinelles à
+  l'upgrade) — protégerait une base qui porte ces données **et** n'est pas reconstructible par le
+  pipeline ; cette base n'existe pas (prodlocal est un produit du pipeline, re-runnable). Rejeté
+  (YAGNI) ; en contrepartie l'ordre de déploiement est contraint (voir Conséquences).
+
+## Conséquences
+
+- `souscription.consentement` gagne deux finalités (`acceptation_cgv`,
+  `renonciation_retractation`) et un garde : le **retrait** (ligne `etat = retire`) est refusé
+  sur ces finalités — write/unlink restent interdits (append-only, ADR 0017).
+- Le *raccordement* **journalise** ces actes à la création de la souscription (comme les deux
+  finalités RGPD) au lieu de recopier des champs ; ses champs d'intake restent sur la demande
+  (transitoire).
+- La CP lit la **dernière ligne** par finalité : « Adhésion validée le » depuis
+  `acceptation_cgv`, paragraphe de renonciation si une ligne `renonciation_retractation` existe ;
+  **absence de ligne = pas de mention** (pas d'acte = pas de preuve).
+- Reprise (pipeline) : `x_cgv` → ligne `acceptation_cgv` ; `x_responsabilite` → ligne
+  `renonciation_retractation` quand une variante « rapide » (exécution avant la fin du délai) est
+  présente, **y compris en double coche** « rapide, 15j » ; horodatage = `x_date_soumission_form`,
+  `version_texte` = le texte/slug d'époque tel quel (les variantes « 14 jours »/« 15 jours »
+  d'époque sont conservées telles quelles — c'est précisément l'intérêt de journaliser le texte),
+  `source` = reprise kanban.
+- **Ordre de déploiement** : re-runner le pipeline **immédiatement après** l'upgrade — le `-u`
+  droppe les colonnes plates, les mentions CP des souscriptions existantes sont vides entre les
+  deux.

--- a/models/core/souscription.py
+++ b/models/core/souscription.py
@@ -27,20 +27,6 @@ class Souscription(models.Model):
     )
     active = fields.Boolean(string='Active', default=True)
 
-    # Déclarations contractuelles captées au Raccordement puis recopiées ici à la
-    # création (ADR 0016) : la Souscription en est propriétaire, les rapports les
-    # lisent sur elle, jamais sur la demande.
-    date_validation = fields.Date(
-        string='Date de signature',
-        help="Date de l'acte d'adhésion (signature électronique) sur support durable.",
-    )
-    renonce_retractation = fields.Boolean(
-        string='Renonce au délai de rétractation',
-        default=False,
-        help='Le·la souscripteur·rice a demandé une exécution avant la fin du délai '
-        'de rétractation de 14 jours et y renonce expressément.',
-    )
-
     date_debut = fields.Date(string='Début de la souscription')
     date_fin = fields.Date(string='Fin de la souscription')
     # facture_ids = fields.One2many(
@@ -52,7 +38,7 @@ class Souscription(models.Model):
     )
     periode_ids = fields.One2many('souscription.periode', 'souscription_id', string='Périodes de facturation')
     refacturation_ids = fields.One2many('souscription.refacturation', 'souscription_id', string='Refacturations')
-    consentement_ids = fields.One2many('souscription.consentement', 'souscription_id', string='Journal de consentement')
+    consentement_ids = fields.One2many('souscription.consentement', 'souscription_id', string='Journal des actes')
     # Données métier
 
     ## Utiles facturation
@@ -587,23 +573,32 @@ class Souscription(models.Model):
             'mensualite': mensualite if self.lisse else 0.0,
         }
 
-    def etat_consentement(self, finalite):
-        """État courant d'une finalité de *Consentement* = état de sa **dernière**
-        ligne de journal (ADR 0017). Retourne ``'donne'`` / ``'retire'`` / ``False``
-        si la finalité n'a jamais été tracée. Source unique pour les rapports et le
-        portail (le retrait n'écrase pas, il ajoute une ligne)."""
+    def _dernier_acte(self, finalite):
+        """La **dernière** ligne de journal pour une finalité (Journal des actes,
+        ADR 0027) — recordset vide si la finalité n'a jamais été tracée. Source
+        unique pour les rapports et le portail : l'absence de ligne est la seule
+        représentation du « non » (pas d'acte = pas de preuve)."""
         self.ensure_one()
-        ligne = self.env['souscription.consentement'].search(
+        return self.env['souscription.consentement'].search(
             [('souscription_id', '=', self.id), ('finalite', '=', finalite)],
             order='date_consentement desc, id desc',
             limit=1,
         )
-        return ligne.etat if ligne else False
 
-    def enregistrer_consentement(self, finalite, etat='donne', source=None, date_retrait=None):
-        """Ajoute une ligne au journal de consentement append-only (ne réécrit
-        jamais une ligne existante). La version du texte est figée par défaut du
-        modèle (intégrité texte ↔ preuve, ADR 0017)."""
+    def etat_consentement(self, finalite):
+        """État courant d'une finalité = état de sa **dernière** ligne de journal
+        (ADR 0017). Retourne ``'donne'`` / ``'retire'`` / ``False`` si la finalité
+        n'a jamais été tracée."""
+        self.ensure_one()
+        return self._dernier_acte(finalite).etat or False
+
+    def enregistrer_consentement(self, finalite, etat='donne', source=None, date_retrait=None, date_consentement=None):
+        """Ajoute une ligne au journal des actes append-only (ne réécrit jamais
+        une ligne existante). La version du texte est figée par défaut du modèle
+        (intégrité texte ↔ preuve, ADR 0017). ``date_consentement`` permet de
+        journaliser à une date antérieure à « maintenant » (l'horodatage d'un
+        acte d'adhésion **est** sa date de signature, ADR 0027) ; sans lui, le
+        défaut du modèle (maintenant) s'applique — cas des consentements RGPD."""
         self.ensure_one()
         vals = {
             'souscription_id': self.id,
@@ -611,6 +606,8 @@ class Souscription(models.Model):
             'etat': etat,
             'source': source,
         }
+        if date_consentement:
+            vals['date_consentement'] = date_consentement
         if date_retrait:
             vals['date_retrait'] = date_retrait
         return self.env['souscription.consentement'].create(vals)

--- a/models/core/souscription_consentement.py
+++ b/models/core/souscription_consentement.py
@@ -1,4 +1,4 @@
-from odoo import fields, models
+from odoo import api, fields, models
 from odoo.exceptions import UserError
 
 # Version courante du texte de consentement affiché au·à la souscripteur·rice.
@@ -6,19 +6,32 @@ from odoo.exceptions import UserError
 # montré et la preuve conservée (ADR 0017). À incrémenter quand le texte change.
 CONSENT_TEXT_VERSION = '2026-06-v1'
 
+# Finalités des actes d'adhésion contractuels : irrévocables (ADR 0027) — un
+# « retrait » d'acceptation CGV ou de renonciation à la rétractation est
+# juridiquement absurde (on ne retire pas une signature). Distinctes des
+# finalités de consentement RGPD (révocables), au sein du même journal.
+FINALITES_IRREVOCABLES = ('acceptation_cgv', 'renonciation_retractation')
+
 
 class SouscriptionConsentement(models.Model):
-    """Journal **append-only** du *Consentement (données de consommation)*.
+    """Journal **append-only** des *Actes* du·de la *souscripteur·rice*
+    (« Journal des actes », ADR 0027 ; le nom technique du modèle reste
+    ``souscription.consentement``, historique).
 
-    Trace l'autorisation RGPD (art. 6-1-a) donnée à EDN de faire collecter chez
-    Enedis des données plus fines que l'index (consommations quotidiennes, courbe
-    de charge). Possédé par la *Souscription* (ADR 0017). L'état courant d'une
-    finalité est sa **dernière** ligne ; un retrait **crée** une ligne, n'écrase
-    rien — d'où le verrou append-only ci-dessous (write/unlink interdits).
+    Deux natures d'actes, distinguées par ``finalite`` :
+    - **consentement RGPD** (art. 6-1-a) — collecte chez Enedis de données
+      plus fines que l'index (consommations quotidiennes, courbe de charge) :
+      **révocable**, un retrait crée une ligne ;
+    - **acte d'adhésion contractuel** (acceptation CGV, renonciation au délai
+      de rétractation) — **irrévocable** : le retrait est refusé (voir
+      ``create``).
+
+    Possédé par la *Souscription* (ADR 0017). L'état courant d'une finalité
+    est sa **dernière** ligne ; write/unlink restent interdits (append-only).
     """
 
     _name = 'souscription.consentement'
-    _description = 'Journal de consentement (données de consommation)'
+    _description = "Journal des actes (consentements RGPD et actes d'adhésion)"
     _order = 'date_consentement desc, id desc'
 
     souscription_id = fields.Many2one(
@@ -33,6 +46,8 @@ class SouscriptionConsentement(models.Model):
         [
             ('conso_quotidienne', 'Consommations quotidiennes'),
             ('courbe_charge', 'Courbe de charge'),
+            ('acceptation_cgv', 'Acceptation des CGV'),
+            ('renonciation_retractation', 'Renonciation au délai de rétractation'),
         ],
         string='Finalité',
         required=True,
@@ -55,6 +70,16 @@ class SouscriptionConsentement(models.Model):
         help="Origine de l'acte (formulaire public + IP, saisie back-office, retrait au portail…).",
     )
     date_retrait = fields.Date(string='Date de retrait')
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        for vals in vals_list:
+            if vals.get('etat') == 'retire' and vals.get('finalite') in FINALITES_IRREVOCABLES:
+                raise UserError(
+                    f"« {vals['finalite']} » est un acte d'adhésion irrévocable : on ne "
+                    '« retire » pas une signature (ADR 0027).'
+                )
+        return super().create(vals_list)
 
     def write(self, vals):
         raise UserError(

--- a/models/raccordement/raccordement_demande.py
+++ b/models/raccordement/raccordement_demande.py
@@ -766,10 +766,10 @@ class RaccordementDemande(models.Model):
             'tarif_solidaire': self.tarif_solidaire,
             'mode_paiement': self.mode_paiement,
             'lisse': True,  # Activer le lissage par défaut
-            # Déclarations contractuelles captées à l'adhésion → la Souscription
-            # en devient propriétaire (ADR 0016).
-            'date_validation': self.date_validation,
-            'renonce_retractation': self.renonce_retractation,
+            # Cotitulaires captés à l'adhésion → la Souscription en devient
+            # propriétaire (ADR 0016). Les actes d'adhésion (acceptation CGV,
+            # renonciation) ne sont plus recopiés en champs plats : ils sont
+            # journalisés ci-dessous (ADR 0027).
             'cotitulaires': [(6, 0, self.cotitulaires.ids)],
             # Identité electricore (ADR 0010/0021) : id_Affaire recopié comme
             # amorce de réconciliation, avec sa date de saisie (grâce du poll #89).
@@ -792,14 +792,29 @@ class RaccordementDemande(models.Model):
         # l'invitation à activer son espace usager·ère (Odoo ne le fait pas seul).
         souscription._octroyer_acces_portail()
 
-        # Journal de consentement (ADR 0017) : une finalité cochée = un acte
-        # 'donné'. Capture back-office (preuve faible), tracée comme telle ; l'acte
-        # réel du·de la souscripteur·rice viendra du formulaire public (#62).
+        # Journal des actes (ADR 0017/0027) : capture back-office (preuve
+        # faible), tracée comme telle ; l'acte réel du·de la souscripteur·rice
+        # viendra du formulaire public (#62).
         source = f'Raccordement {self.name} (back-office)'
+
+        # Consentements RGPD : une finalité cochée = un acte 'donné'.
         if self.consent_conso_quotidienne:
             souscription.enregistrer_consentement('conso_quotidienne', source=source)
         if self.consent_courbe_charge:
             souscription.enregistrer_consentement('courbe_charge', source=source)
+
+        # Actes d'adhésion irrévocables : journalisés (pas recopiés en champs
+        # plats, ADR 0027) — l'horodatage de la ligne EST la date de signature
+        # saisie sur la demande. Sans date de signature, aucun acte n'est
+        # journalisé (pas d'acte = pas de preuve) : une demande peut être close
+        # avant que l'adhésion soit signée.
+        if self.date_validation:
+            horodatage = fields.Datetime.to_datetime(self.date_validation)
+            souscription.enregistrer_consentement('acceptation_cgv', source=source, date_consentement=horodatage)
+            if self.renonce_retractation:
+                souscription.enregistrer_consentement(
+                    'renonciation_retractation', source=source, date_consentement=horodatage
+                )
 
         return souscription
 

--- a/reports/souscription_conditions_particulieres_report.xml
+++ b/reports/souscription_conditions_particulieres_report.xml
@@ -20,6 +20,11 @@
         <t t-call="web.html_container">
             <t t-foreach="docs" t-as="souscription">
                 <t t-set="prix" t-value="souscription._prix_documents()"/>
+                <!-- Actes d'adhésion irrévocables (Journal des actes, ADR 0027) : lus
+                     depuis la dernière ligne par finalité, jamais depuis des champs
+                     plats. Absence de ligne = pas de mention (pas d'acte = pas de preuve). -->
+                <t t-set="acceptation_cgv" t-value="souscription._dernier_acte('acceptation_cgv')"/>
+                <t t-set="renonciation_retractation" t-value="souscription._dernier_acte('renonciation_retractation')"/>
                 <t t-call="web.external_layout">
                     <div class="page fe_wrap">
                         <!-- Styles `fe_*` : bundle de marque partagé (report_brand.scss). -->
@@ -117,7 +122,7 @@
                                 </strong>.
                             </li>
                             <li t-if="souscription.lisse">J'opte pour le paiement mensualisé (lissé), avec régularisation périodique.</li>
-                            <li t-if="souscription.renonce_retractation">
+                            <li t-if="renonciation_retractation">
                                 Je demande l'exécution du contrat avant la fin du délai de rétractation de 14 jours
                                 et je renonce expressément à ce délai de rétractation.
                             </li>
@@ -147,8 +152,8 @@
                         <!-- ===== Signature ===== -->
                         <div class="fe_section">Signature</div>
                         <div class="fe_kv">
-                            <t t-if="souscription.date_validation">
-                                Adhésion validée le <strong><span t-field="souscription.date_validation" t-options="{'widget': 'date'}"/></strong>,
+                            <t t-if="acceptation_cgv">
+                                Adhésion validée le <strong><span t-field="acceptation_cgv.date_consentement" t-options="{'widget': 'date'}"/></strong>,
                                 par signature électronique.
                             </t>
                             <t t-else="">Signature électronique en attente.</t>

--- a/tests/test_documents_contractuels.py
+++ b/tests/test_documents_contractuels.py
@@ -1,9 +1,11 @@
-"""Documents contractuels & consentement (#63).
+"""Documents contractuels & Journal des actes (#63, ADR 0027).
 
-Couvre la chaîne « capter au *Raccordement* → posséder sur la *Souscription* →
-projeter dans les rapports » (ADR 0016) : les déclarations/consentements et la
-date de signature sont saisis sur la demande de raccordement, recopiés à la
-création de la Souscription, puis rendus par les *Conditions particulières* et
+Couvre la chaîne « capter au *Raccordement* → journaliser sur la *Souscription*
+→ projeter dans les rapports » (ADR 0016/0027) : les déclarations/consentements
+et les actes d'adhésion (acceptation CGV, renonciation au délai de
+rétractation) sont saisis sur la demande de raccordement, journalisés (Journal
+des actes, append-only) à la création de la Souscription — jamais recopiés en
+champs plats —, puis rendus par les *Conditions particulières* et
 l'*Attestation de fourniture*.
 """
 
@@ -11,6 +13,7 @@ import os
 from datetime import date, timedelta
 
 from lxml import etree
+from odoo import fields
 from odoo.tests.common import HttpCase, TransactionCase, tagged
 
 from .common import SouscriptionsTestMixin, build_grille_lignes
@@ -18,7 +21,9 @@ from .common import SouscriptionsTestMixin, build_grille_lignes
 
 @tagged('souscriptions', 'souscriptions_documents', 'post_install', '-at_install')
 class TestCaptureConsentement(SouscriptionsTestMixin, TransactionCase):
-    """Les déclarations captées au Raccordement sont recopiées sur la Souscription."""
+    """Les déclarations captées au Raccordement sont journalisées sur la
+    Souscription (ADR 0027) : cotitulaires recopiés, actes d'adhésion écrits au
+    Journal des actes, jamais recopiés en champs plats."""
 
     @classmethod
     def setUpClass(cls):
@@ -45,9 +50,11 @@ class TestCaptureConsentement(SouscriptionsTestMixin, TransactionCase):
         defaults.update(kwargs)
         return self.env['raccordement.demande'].create(defaults)
 
-    def test_declarations_recopiees_sur_souscription(self):
-        """date_validation / renonce_retractation / cotitulaires passent de la
-        demande à la Souscription créée à la clôture du Raccordement."""
+    def test_actes_adhesion_journalises_sur_souscription(self):
+        """Signature + renonciation saisies sur la demande produisent des lignes
+        de Journal des actes sur la Souscription créée à la clôture du
+        Raccordement — horodatage = la date de signature, plus de recopie de
+        champs plats (ADR 0027)."""
         cotitulaire = self.env['res.partner'].create({'name': 'Cotitulaire Test'})
         signature = date.today()
 
@@ -60,20 +67,42 @@ class TestCaptureConsentement(SouscriptionsTestMixin, TransactionCase):
 
         souscription = demande.souscription_id
         self.assertTrue(souscription, 'Souscription devrait être créée')
-        self.assertEqual(souscription.date_validation, signature)
-        self.assertTrue(souscription.renonce_retractation)
         self.assertEqual(souscription.cotitulaires, cotitulaire)
 
+        acceptation = souscription._dernier_acte('acceptation_cgv')
+        renonciation = souscription._dernier_acte('renonciation_retractation')
+        self.assertTrue(acceptation, "L'acceptation CGV devrait être journalisée")
+        self.assertTrue(renonciation, 'La renonciation devrait être journalisée')
+        self.assertEqual(acceptation.date_consentement.date(), signature)
+        self.assertEqual(renonciation.date_consentement.date(), signature)
+        self.assertIn(demande.name, acceptation.source)
+
+        # Plus de champs plats sur la Souscription (ADR 0027).
+        self.assertNotIn('date_validation', souscription._fields)
+        self.assertNotIn('renonce_retractation', souscription._fields)
+
     def test_declarations_par_defaut_vides(self):
-        """Sans capture, la Souscription naît sans déclaration ni cotitulaire :
-        une demande peut être close avant que la rétractation soit tranchée."""
+        """Sans capture, la Souscription naît sans acte d'adhésion journalisé ni
+        cotitulaire : une demande peut être close avant que la rétractation soit
+        tranchée. Absence de ligne = pas de mention (ADR 0027)."""
         demande = self._demande()
         demande.stage_id = self.stage_final
 
         souscription = demande.souscription_id
-        self.assertFalse(souscription.renonce_retractation)
-        self.assertFalse(souscription.date_validation)
+        self.assertFalse(souscription._dernier_acte('acceptation_cgv'))
+        self.assertFalse(souscription._dernier_acte('renonciation_retractation'))
         self.assertFalse(souscription.cotitulaires)
+
+    def test_renonciation_seule_sans_signature_non_journalisee(self):
+        """La renonciation n'a de sens qu'ancrée à une date de signature : sans
+        date_validation, aucun acte n'est journalisé même si renonce_retractation
+        est coché (pas d'horodatage fiable, pas de preuve, ADR 0027)."""
+        demande = self._demande(renonce_retractation=True)
+        demande.stage_id = self.stage_final
+
+        souscription = demande.souscription_id
+        self.assertFalse(souscription._dernier_acte('acceptation_cgv'))
+        self.assertFalse(souscription._dernier_acte('renonciation_retractation'))
 
 
 CP_URL = '/report/html/souscriptions_odoo.souscription_conditions_particulieres_document/%s'
@@ -112,12 +141,17 @@ class TestConditionsParticulieres(SouscriptionsTestMixin, HttpCase):
                 'puissance_souscrite': '6',
                 'type_tarif': 'base',
                 'date_debut': date(2024, 1, 1),
-                'date_validation': date(2025, 3, 14),
-                'renonce_retractation': True,
                 'lisse': True,
                 'provision_mensuelle_kwh': 300.0,
                 'mode_paiement': 'prelevement',
             }
+        )
+        # Actes d'adhésion journalisés (ADR 0027) : plus de champs plats sur la
+        # Souscription — la CP les lit depuis le Journal des actes.
+        signature = fields.Datetime.to_datetime('2025-03-14 09:00:00')
+        cls.cp_particulier.enregistrer_consentement('acceptation_cgv', source='test', date_consentement=signature)
+        cls.cp_particulier.enregistrer_consentement(
+            'renonciation_retractation', source='test', date_consentement=signature
         )
         # Société : prix affichés HT.
         cls.cp_societe = cls.env['souscription.souscription'].create(
@@ -158,14 +192,24 @@ class TestConditionsParticulieres(SouscriptionsTestMixin, HttpCase):
 
     def test_declarations_signature_et_support_durable(self):
         html = self._html(self.cp_particulier)
-        # Renonciation au délai de rétractation captée.
+        # Renonciation au délai de rétractation journalisée.
         self.assertIn('rétractation', html.lower())
         # Lissage et mode de paiement déclarés.
         self.assertIn('Prélèvement', html)
-        # Signature : l'année de date_validation (2025), distincte de date_debut (2024).
+        # Signature : l'année de la ligne acceptation_cgv (2025), distincte de
+        # date_debut (2024).
         self.assertIn('2025', html)
         # Mention de la confirmation sur support durable.
         self.assertIn('support durable', html.lower())
+
+    def test_sans_acte_journalise_aucune_mention(self):
+        """Une Souscription sans ligne de journal n'imprime aucune mention
+        d'adhésion ni de renonciation : absence de ligne = pas de preuve, donc
+        pas de mention (ADR 0027) — la société de test n'a aucun acte journalisé."""
+        html = self._html(self.cp_societe)
+        self.assertIn('en attente', html.lower())
+        self.assertNotIn('Adhésion validée le', html)
+        self.assertNotIn('rétractation', html.lower())
 
     def test_mensualite_affichee_si_lisse(self):
         """Contrat lissé → une mensualité estimée figure sur la CP."""
@@ -259,7 +303,9 @@ class TestAttestationFourniture(SouscriptionsTestMixin, HttpCase):
 
 @tagged('souscriptions', 'souscriptions_documents', 'post_install', '-at_install')
 class TestJournalConsentement(SouscriptionsTestMixin, TransactionCase):
-    """Journal de consentement append-only possédé par la Souscription (ADR 0017)."""
+    """Journal des actes append-only possédé par la Souscription (ADR 0017/0027) :
+    consentements RGPD (révocables) et actes d'adhésion contractuels
+    (irrévocables), au sein du même journal (`souscription.consentement`)."""
 
     @classmethod
     def setUpClass(cls):
@@ -334,6 +380,52 @@ class TestJournalConsentement(SouscriptionsTestMixin, TransactionCase):
         souscription = demande.souscription_id
         self.assertEqual(souscription.etat_consentement('courbe_charge'), 'donne')
         self.assertFalse(souscription.etat_consentement('conso_quotidienne'))
+
+    def test_retrait_refuse_sur_acceptation_cgv(self):
+        """Le journal refuse un retrait sur une finalité contractuelle
+        irrévocable (ADR 0027) : on ne « retire » pas une signature."""
+        from odoo.exceptions import UserError
+
+        with self.assertRaises(UserError):
+            self._ligne(self.souscription_base, finalite='acceptation_cgv', etat='retire')
+
+    def test_retrait_refuse_sur_renonciation_retractation(self):
+        """Même garde pour la renonciation au délai de rétractation."""
+        from odoo.exceptions import UserError
+
+        with self.assertRaises(UserError):
+            self._ligne(self.souscription_base, finalite='renonciation_retractation', etat='retire')
+
+    def test_retrait_rgpd_fonctionne_inchange(self):
+        """Le garde d'irrévocabilité ne s'applique qu'aux deux finalités
+        contractuelles : les retraits RGPD existants continuent de fonctionner."""
+        ligne = self._ligne(self.souscription_base, finalite='courbe_charge', etat='retire')
+        self.assertEqual(ligne.etat, 'retire')
+
+    def test_don_accepte_sur_acte_irrevocable(self):
+        """Un acte irrévocable peut être *donné* (c'est la signature elle-même) :
+        seul le retrait est refusé."""
+        ligne = self._ligne(self.souscription_base, finalite='acceptation_cgv', etat='donne')
+        self.assertEqual(ligne.etat, 'donne')
+
+    def test_dernier_acte_retourne_la_derniere_ligne(self):
+        """`_dernier_acte` retourne l'enregistrement (pas seulement l'état) de la
+        dernière ligne par finalité, vide si aucun acte."""
+        self._ligne(self.souscription_base, finalite='acceptation_cgv', etat='donne')
+        acte = self.souscription_base._dernier_acte('acceptation_cgv')
+        self.assertTrue(acte)
+        self.assertEqual(acte.finalite, 'acceptation_cgv')
+        self.assertFalse(self.souscription_base._dernier_acte('renonciation_retractation'))
+
+    def test_enregistrer_consentement_accepte_horodatage_explicite(self):
+        """`enregistrer_consentement` accepte un horodatage explicite (date de
+        signature) au lieu du défaut « maintenant » — nécessaire pour journaliser
+        un acte d'adhésion à la date réelle de signature (ADR 0027)."""
+        signature = fields.Datetime.to_datetime('2025-03-14 09:00:00')
+        ligne = self.souscription_base.enregistrer_consentement(
+            'acceptation_cgv', source='test', date_consentement=signature
+        )
+        self.assertEqual(ligne.date_consentement, signature)
 
 
 @tagged('souscriptions', 'souscriptions_documents', 'post_install', '-at_install')

--- a/views/core/souscription_views.xml
+++ b/views/core/souscription_views.xml
@@ -71,11 +71,6 @@
                         <field name="date_derniere_resolution_rsc" invisible="not date_derniere_resolution_rsc"/>
                     </group>
 
-                    <group string="Adhésion (captée au raccordement)">
-                        <field name="date_validation"/>
-                        <field name="renonce_retractation"/>
-                    </group>
-
                     <notebook>
                         <page string="Périodes de facturation">
                             <field name="periode_ids">
@@ -115,7 +110,7 @@
                                 </list>
                             </field>
                         </page>
-                        <page string="Journal de consentement" name="consentement">
+                        <page string="Journal des actes" name="consentement">
                             <field name="consentement_ids">
                                 <list>
                                     <field name="date_consentement"/>


### PR DESCRIPTION
Closes #192

Étend le journal append-only `souscription.consentement` (« Journal des actes », ADR 0027) aux actes d'adhésion irrévocables — acceptation CGV et renonciation au délai de rétractation — et supprime les champs plats correspondants (`date_validation`, `renonce_retractation`) de `souscription.souscription`.

Le raccordement journalise désormais ces actes à la naissance de la Souscription (horodatage = date de signature saisie) au lieu de recopier des champs ; les champs d'intake restent sur la demande, transitoire. Les conditions particulières lisent la dernière ligne par finalité : absence de ligne = aucune mention. Pas de reprise de données dans l'addon (YAGNI, ADR 0027) — re-run du pipeline `souscriptions_migration` requis juste après le `-u`.

Suite complète verte en local (Docker) : 0 failed, 0 error(s) of 426 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)