### PR TITLE
fix(raccordement): sdd_scheme, pas scheme — confronté au sdd.mandate réel via MCP

### DIFF
--- a/models/raccordement/raccordement_demande.py
+++ b/models/raccordement/raccordement_demande.py
@@ -737,9 +737,10 @@ class RaccordementDemande(models.Model):
         Noms de champs confrontés au `sdd.mandate` réel de la prod
         Enterprise (via MCP, 2026-07-11) : `payment_journal_id`,
         `sdd_scheme`, `state`, `partner_bank_id`, `start_date` confirmés ;
-        `company_id` non requis. Attention : `name` (RUM) est requis et la
-        prod ne porte aucune séquence sdd — sans référence saisie, le
-        `create()` lève (bruyant, jamais un mandat silencieusement faux).
+        `company_id` non requis. Omettre `name` (RUM) est le bon geste :
+        l'action serveur prod créait ses ~1000 mandats sans le passer, le
+        défaut de l'outillage le génère (un nom erroné lèverait au
+        `create()`, jamais un mandat silencieusement faux).
         """
         self.ensure_one()
         vals = {

--- a/models/raccordement/raccordement_demande.py
+++ b/models/raccordement/raccordement_demande.py
@@ -734,13 +734,12 @@ class RaccordementDemande(models.Model):
         début = date de signature du mandat si saisie, sinon aujourd'hui.
         Schéma CORE, actif d'emblée (l'acceptation est la porte humaine).
 
-        ponytail : noms de champs (`payment_journal_id`, `scheme`, `state`)
-        alignés sur le module Enterprise `account_sepa_direct_debit` d'après
-        sa documentation publique — invérifiables ici (pas de source
-        Enterprise, pas de réseau en sandbox). À confronter au modèle réel
-        avant premier usage en instance Enterprise ; un nom erroné lève une
-        erreur explicite au `create()`, jamais un mandat silencieusement
-        faux.
+        Noms de champs confrontés au `sdd.mandate` réel de la prod
+        Enterprise (via MCP, 2026-07-11) : `payment_journal_id`,
+        `sdd_scheme`, `state`, `partner_bank_id`, `start_date` confirmés ;
+        `company_id` non requis. Attention : `name` (RUM) est requis et la
+        prod ne porte aucune séquence sdd — sans référence saisie, le
+        `create()` lève (bruyant, jamais un mandat silencieusement faux).
         """
         self.ensure_one()
         vals = {
@@ -749,7 +748,7 @@ class RaccordementDemande(models.Model):
             'payment_journal_id': journal.id,
             'start_date': self.sepa_mandate_date or fields.Date.context_today(self),
             'state': 'active',
-            'scheme': 'CORE',
+            'sdd_scheme': 'CORE',
         }
         if self.sepa_mandate_ref:
             vals['name'] = self.sepa_mandate_ref

--- a/tests/test_raccordement_mandat_sepa.py
+++ b/tests/test_raccordement_mandat_sepa.py
@@ -89,7 +89,7 @@ class TestMandatSepaValsPur(SouscriptionsTestMixin, TransactionCase):
         demande = self.create_demande()
         vals = demande._mandat_sepa_vals(self.partner, self.partner_bank, self.journal)
         self.assertEqual(vals['state'], 'active')
-        self.assertEqual(vals['scheme'], 'CORE')
+        self.assertEqual(vals['sdd_scheme'], 'CORE')
 
 
 @tagged('souscriptions', 'souscriptions_raccordement', 'post_install', '-at_install')


### PR DESCRIPTION
Rescue repo-janitor : deux commits du 2026-07-11 restés sur `feat/187-raccordement-mandat-sepa` après le merge de #191.

- `_creer_mandat_sepa` écrivait `'scheme': 'CORE'` — le champ réel du `sdd.mandate` Enterprise est `sdd_scheme` (confronté au modèle prod via MCP). Sans ce fix, le `create()` lève en instance Enterprise.
- Docstring : omettre `name` (RUM) est le geste prod — l'action serveur historique créait ses mandats sans le passer, le défaut de l'outillage le génère.

🤖 Generated with [Claude Code](https://claude.com/claude-code)