### PR TITLE
feat(paiements): vue « Règlements en attente » + étape « Préparer les prélèvements » (#183)

### DIFF
--- a/__manifest__.py
+++ b/__manifest__.py
@@ -66,6 +66,7 @@ vit dans models/wizard/ et ne lève qu'au clic sur l'action du wizard.
         'views/wizard/souscription_pull_meta_periodes_wizard_views.xml',
         'views/core/souscription_campagne_views.xml',
         'views/core/souscription_cheque_energie_views.xml',
+        'views/core/account_move_views.xml',
         'views/core/souscription_portal_menu.xml',
         'views/portal_templates.xml',
         'views/raccordement/raccordement_demande_views.xml',

--- a/models/core/account_move.py
+++ b/models/core/account_move.py
@@ -15,6 +15,17 @@ class AccountMove(models.Model):
 
     is_facture_energie = fields.Boolean(string="Facture d'énergie", compute='_compute_is_facture_energie', store=True)
 
+    # Plomberie dérivée (#185, PRD #183) : la Souscription est l'unique source
+    # de vérité du Mode de paiement (CONTEXT.md) — jamais saisi sur la
+    # Facture. related stocké pour rester filtrable/groupable (vue
+    # « Règlements en attente ») ; se recalcule quand la Souscription change.
+    mode_paiement = fields.Selection(
+        related='souscription_id.mode_paiement',
+        string='Mode de paiement',
+        store=True,
+        readonly=True,
+    )
+
     @api.depends('periode_id', 'souscription_id')
     def _compute_is_facture_energie(self):
         """Détermine si c'est une facture d'énergie (souscription électricité)"""

--- a/models/core/souscription_campagne.py
+++ b/models/core/souscription_campagne.py
@@ -35,6 +35,13 @@ from odoo.exceptions import UserError
 # Les deux « vrais pulls » (méta-périodes + F15) gatent chacun leur porte de
 # vérif. Les relevés d'index NE sont PAS une étape : ils arrivent avec le pull
 # des périodes (enfants souscription.releve, cf. _amorcer_depuis_meta).
+#
+# « Préparer les prélèvements » (#186, PRD #183) : étape 'action' dont le
+# bouton ouvre une liste (SDD, préparation seulement — aucun paiement/batch/
+# fichier créé par le module, cf. action_preparer_prelevements). Contrairement
+# à sync F15, son « fait » n'est PAS le lancement (`lance`) mais un signal
+# dérivé (cf. _compute_fait/_compute_nb_reste_a_faire) — aucun champ de
+# verrou ajouté sur Période/Facture (esprit ADR 0025).
 ETAPES_CAMPAGNE = {
     'pull_meta_periodes': {
         'label': 'Pull méta-périodes',
@@ -65,6 +72,11 @@ ETAPES_CAMPAGNE = {
         'label': 'Émettre factures',
         'type': 'derive',
         'prerequis': ('creer_factures',),
+    },
+    'preparer_prelevements': {
+        'label': 'Préparer les prélèvements',
+        'type': 'action',
+        'prerequis': ('emettre_factures',),
     },
 }
 
@@ -264,6 +276,44 @@ class SouscriptionCampagneFacturation(models.Model):
             campagne.nb_factures_creees = len(factures)
             campagne.nb_factures_emises = len(factures.filtered(lambda f: f.state == 'posted'))
 
+    # --- Préparer les prélèvements (#186, PRD #183) : domaine partagé entre
+    # le bouton (toutes périodes) et le signal dérivé « fait » (mois de la
+    # campagne seulement) — mode explicitement `prelevement` uniquement,
+    # jamais le mode vide (qui relève de la vue « Règlements en attente »,
+    # #185). ---
+
+    _DOMAINE_FACTURES_PRELEVEMENT_DUES = [
+        ('is_facture_energie', '=', True),
+        ('state', '=', 'posted'),
+        ('amount_residual', '>', 0),
+        ('mode_paiement', '=', 'prelevement'),
+    ]
+
+    def _factures_prelevement_dues_du_mois(self):
+        """Factures prélèvement du mois de la campagne encore dues (#186) —
+        `amount_residual > 0` encode déjà « aucun paiement (complet) en
+        face » : pas de champ de verrou dédié, recalculé à chaque lecture
+        (esprit ADR 0025)."""
+        self.ensure_one()
+        return self._factures_du_mois().filtered_domain(self._DOMAINE_FACTURES_PRELEVEMENT_DUES)
+
+    def action_preparer_prelevements(self):
+        """Bouton (#158) : ouvre la liste de TOUTES les factures prélèvement
+        dues, toutes périodes confondues (le batch mensuel embarque les
+        rattrapages, comme en prod) — pas seulement le mois de la campagne.
+        Le module ne crée ni paiement, ni batch, ni fichier (décision PRD
+        #183) : de là, le geste reste l'outillage comptable (sélection ->
+        « Enregistrer un paiement » SDD -> batch -> pain.008)."""
+        self.ensure_one()
+        self._verifier_gate('preparer_prelevements')
+        return {
+            'type': 'ir.actions.act_window',
+            'name': _('Préparer les prélèvements'),
+            'res_model': 'account.move',
+            'view_mode': 'list,form',
+            'domain': self._DOMAINE_FACTURES_PRELEVEMENT_DUES,
+        }
+
     # --- Boutons d'étape (#158) : délèguent aux actions déjà couvertes par
     # ailleurs (test_pull_meta_periodes.py, test_periode_facture.py...) —
     # aucune nouvelle couture réseau, `_ouvrir_flux`/`_tirer_prestations`
@@ -336,6 +386,9 @@ class SouscriptionCampagneFacturation(models.Model):
         self.ensure_one()
         self._verifier_gate('emettre_factures')
         self._factures_du_mois().filtered(lambda f: f.state == 'draft').action_post()
+
+    # action_preparer_prelevements (#186) : déclarée plus haut, aux côtés du
+    # domaine partagé avec le signal dérivé « fait ».
 
 
 class SouscriptionCampagneEtape(models.Model):
@@ -411,27 +464,34 @@ class SouscriptionCampagneEtape(models.Model):
             vals.setdefault('valide_le', fields.Datetime.now())
         return super().write(vals)
 
-    @api.depends('type_etape', 'campagne_id.mois')
+    @api.depends('type_etape', 'code', 'campagne_id.mois')
     def _compute_nb_reste_a_faire(self):
         """#157 : délègue à `campagne_id._reste_a_faire(code)` — recompté à
         chaque lecture (pas de relation ORM déclarée vers période/facture,
-        donc pas d'invalidation de cache automatique inter-modèles, ADR 0025)."""
+        donc pas d'invalidation de cache automatique inter-modèles, ADR 0025).
+
+        « Préparer les prélèvements » (#186) : même esprit dérivé, mais sur
+        les factures du mois plutôt que sur les souscriptions
+        (`_factures_prelevement_dues_du_mois`, pas `_reste_a_faire`)."""
         for etape in self:
-            if etape.type_etape == 'derive' and etape.campagne_id:
+            if etape.code == 'preparer_prelevements' and etape.campagne_id:
+                etape.nb_reste_a_faire = len(etape.campagne_id._factures_prelevement_dues_du_mois())
+            elif etape.type_etape == 'derive' and etape.campagne_id:
                 etape.nb_reste_a_faire = len(etape.campagne_id._reste_a_faire(etape.code))
             else:
                 etape.nb_reste_a_faire = 0
 
-    @api.depends('valide', 'type_etape', 'nb_reste_a_faire', 'lance')
+    @api.depends('valide', 'type_etape', 'code', 'nb_reste_a_faire', 'lance')
     def _compute_fait(self):
         for etape in self:
             if etape.type_etape == 'porte':
                 etape.fait = etape.valide
-            elif etape.type_etape == 'derive':
+            elif etape.type_etape == 'derive' or etape.code in self._CODES_ACTION_DERIVEE:
                 etape.fait = etape.nb_reste_a_faire == 0
             else:
-                # 'action' : pas de backlog dérivable (sync F15 tire tout,
-                # ADR 0009 §2) — « faite » une fois lancée pour la campagne.
+                # 'action' restante (sync F15) : pas de backlog dérivable
+                # (tire tout, ADR 0009 §2) — « faite » une fois lancée pour
+                # la campagne.
                 etape.fait = etape.lance
 
     @api.depends('code', 'valide', 'type_etape', 'campagne_id.etape_ids.fait')
@@ -475,7 +535,13 @@ class SouscriptionCampagneEtape(models.Model):
         'sync_f15': 'action_sync_f15',
         'creer_factures': 'action_creer_factures',
         'emettre_factures': 'action_emettre_factures',
+        'preparer_prelevements': 'action_preparer_prelevements',
     }
+
+    # Étapes 'action' dont le « fait » est un signal dérivé (#186) plutôt que
+    # le lancement (`lance`, cf. sync F15) — cf. _compute_fait/
+    # _compute_nb_reste_a_faire.
+    _CODES_ACTION_DERIVEE = ('preparer_prelevements',)
 
     def action_executer(self):
         self.ensure_one()

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -13,6 +13,7 @@ from . import (
     test_grille_prix,
     test_integration,
     test_mails_raccordement,
+    test_paiements_reglements_attente,
     test_periode_composition,
     test_periode_energie,
     test_periode_facture,

--- a/tests/test_campagne_etapes_actions.py
+++ b/tests/test_campagne_etapes_actions.py
@@ -314,3 +314,131 @@ class TestCampagneEtapeEmettreFactures(SouscriptionsTestCase):
         etape.action_executer()
 
         self.assertEqual(periode.facture_id.state, 'posted')
+
+
+@tagged('souscriptions', 'souscriptions_campagne', 'post_install', '-at_install')
+class TestCampagneEtapePreparerPrelevements(SouscriptionsTestCase):
+    """#186, PRD #183 : étape après « Émettre factures », son domaine
+    s'appuie sur `account.move.mode_paiement` porté par la Facture (#185,
+    slice 1 de cette même PR)."""
+
+    MOIS = date(2024, 3, 1)
+    FIN_MOIS = date(2024, 3, 31)
+
+    def setUp(self):
+        super().setUp()
+        # Comme TestCampagneEtapeEmettreFactures : seule souscription_base
+        # est RSC-acquise (en_service), donc seule facturable — hphc reste
+        # en_instance, hors du décompte « emettre_factures ».
+        self.souscription_base.with_context(rsc_automatisme=True).write(
+            {'ref_situation_contractuelle': 'RSC-CAMPAGNE-PRELEV'}
+        )
+        self.campagne = self.env['souscription.campagne.facturation'].create({'mois': self.MOIS})
+
+    def _etape(self):
+        return self.campagne.etape_ids.filtered(lambda e: e.code == 'preparer_prelevements')
+
+    def _emettre_factures_du_mois(self):
+        """Amène `emettre_factures` à « fait » (prérequis de l'étape testée)
+        en postant la facture du mois de souscription_base."""
+        periode = self.create_test_periode(self.souscription_base, date_debut=self.MOIS, date_fin=self.FIN_MOIS)
+        facture = periode._creer_facture()
+        facture.action_post()
+        self.campagne.etape_ids.invalidate_recordset()
+        return facture
+
+    def test_etape_apparait_apres_emettre_factures_avec_prerequis(self):
+        """AC : dans le DAG, après « Émettre factures », gated dessus."""
+        codes = list(self.env['souscription.campagne.etape']._selection_code())
+        codes_ordonnes = [c for c, _ in codes]
+        self.assertEqual(codes_ordonnes[-1], 'preparer_prelevements')
+        self.assertEqual(codes_ordonnes[-2], 'emettre_factures')
+
+        etape = self._etape()
+        self.assertEqual(etape.etat_prerequis, 'bloquee', 'emettre_factures pas encore faite')
+
+        self._emettre_factures_du_mois()
+        etape.invalidate_recordset()
+        self.assertEqual(etape.etat_prerequis, 'prete')
+
+    def test_action_bloquee_si_emettre_factures_pas_faite(self):
+        with self.assertRaises(UserError):
+            self.campagne.action_preparer_prelevements()
+
+    def test_bouton_retourne_une_liste_postees_residu_positif_mode_prelevement(self):
+        """AC : postées, résidu > 0, mode = prélèvement, TOUTES périodes
+        (pas seulement le mois de la campagne)."""
+        self.souscription_base.mode_paiement = 'prelevement'
+        facture_mois = self._emettre_factures_du_mois()
+
+        # Facture d'un mois antérieur, restée due : doit apparaître (le batch
+        # mensuel embarque les rattrapages, comme en prod).
+        periode_janvier = self.create_test_periode(
+            self.souscription_base, date_debut=date(2024, 1, 1), date_fin=date(2024, 1, 31)
+        )
+        facture_janvier = periode_janvier._creer_facture()
+        facture_janvier.action_post()
+
+        action = self.campagne.action_preparer_prelevements()
+        self.assertEqual(action['res_model'], 'account.move')
+        resultat = self.env['account.move'].search(
+            action['domain'] + [('id', 'in', (facture_mois | facture_janvier).ids)]
+        )
+        self.assertEqual(set(resultat.ids), {facture_mois.id, facture_janvier.id})
+
+    def test_facture_mode_vide_ou_soldee_jamais_dans_la_liste(self):
+        """AC : le mode vide n'entre jamais dans ce domaine (il relève de la
+        vue « Règlements en attente », #185) ; une facture soldée (chèque
+        énergie, 0 €) non plus."""
+        # mode_paiement vide (jamais mis à prélèvement) -> exclue malgré
+        # résidu > 0.
+        facture_mois = self._emettre_factures_du_mois()
+        self.assertFalse(self.souscription_base.mode_paiement)
+
+        action = self.campagne.action_preparer_prelevements()
+        resultat = self.env['account.move'].search(action['domain'] + [('id', '=', facture_mois.id)])
+        self.assertFalse(resultat, 'mode vide : jamais dans ce domaine')
+
+    def test_fait_reste_a_faire_tant_quun_residu_positif_sans_paiement(self):
+        """AC : « fait » dérivé des factures DU MOIS et de leurs paiements —
+        aucun champ de verrou. Reste à faire tant qu'une facture prélèvement
+        du mois a un résidu > 0 ; fait une fois le paiement enregistré."""
+        self.souscription_base.mode_paiement = 'prelevement'
+        facture_mois = self._emettre_factures_du_mois()
+        etape = self._etape()
+
+        self.assertGreater(facture_mois.amount_residual, 0.0)
+        self.assertFalse(etape.fait)
+        self.assertEqual(etape.nb_reste_a_faire, 1)
+
+        journal = self.env['account.journal'].search([('type', '=', 'bank')], limit=1)
+        wizard = (
+            self.env['account.payment.register']
+            .with_context(active_model='account.move', active_ids=facture_mois.ids)
+            .create({'journal_id': journal.id})
+        )
+        wizard._create_payments()
+        facture_mois.invalidate_recordset(['amount_residual'])
+        etape.invalidate_recordset()
+
+        self.assertAlmostEqual(facture_mois.amount_residual, 0.0, places=2)
+        self.assertTrue(etape.fait)
+        self.assertEqual(etape.nb_reste_a_faire, 0)
+
+    def test_bouton_generique_dispatch_vers_preparer_prelevements(self):
+        self.souscription_base.mode_paiement = 'prelevement'
+        self._emettre_factures_du_mois()
+        etape = self._etape()
+
+        action = etape.action_executer()
+
+        self.assertEqual(action['type'], 'ir.actions.act_window')
+        self.assertEqual(action['res_model'], 'account.move')
+
+    def test_aucun_champ_verrou_ajoute_sur_periode_ou_facture(self):
+        """AC (esprit ADR 0025) : aucun nouveau champ de verrou sur Période ni
+        sur account.move au-delà du related `mode_paiement` (#185, plomberie
+        dérivée, jamais un verrou)."""
+        for modele in ('souscription.periode', 'account.move'):
+            for nom_champ in self.env[modele]._fields:
+                self.assertNotIn('prelevement', nom_champ.lower(), f'{modele}.{nom_champ} : champ inattendu')

--- a/tests/test_paiements_reglements_attente.py
+++ b/tests/test_paiements_reglements_attente.py
@@ -1,0 +1,108 @@
+"""Tests de la vue « Règlements en attente » (#185, PRD #183).
+
+Le *Mode de paiement* est porté par la Souscription (source de vérité unique,
+CONTEXT.md) ; la Facture ne fait que le refléter en related stocké — jamais
+saisi sur la facture. L'action de menu liste les factures d'énergie postées à
+reste-à-payer > 0 dont le mode diffère de `prelevement`, groupe « (vide) »
+compris (souscription sans mode renseigné — à compléter, pas à deviner).
+"""
+
+import ast
+
+from odoo.tests.common import tagged
+
+from .common import SouscriptionsTestCase
+
+
+@tagged('souscriptions', 'souscriptions_paiements', 'post_install', '-at_install')
+class TestFactureModePaiementRelated(SouscriptionsTestCase):
+    def test_mode_paiement_suit_la_souscription(self):
+        """related stocké : reflète le mode courant de la Souscription."""
+        self.souscription_base.mode_paiement = 'virement'
+        periode, facture = self.create_test_invoice(self.souscription_base)
+        self.assertEqual(facture.mode_paiement, 'virement')
+
+    def test_mode_paiement_suit_les_changements_ulterieurs(self):
+        """Un related stocké se recalcule quand la source change (pas une
+        copie figée à la création)."""
+        self.souscription_base.mode_paiement = 'virement'
+        periode, facture = self.create_test_invoice(self.souscription_base)
+
+        self.souscription_base.mode_paiement = 'especes'
+
+        self.assertEqual(facture.mode_paiement, 'especes')
+
+    def test_facture_sans_souscription_mode_paiement_vide(self):
+        """Une facture hors énergie (pas de periode_id/souscription_id) a un
+        mode de paiement vide — pas de valeur devinée."""
+        facture = self.env['account.move'].create(
+            {
+                'move_type': 'out_invoice',
+                'partner_id': self.partner_test.id,
+            }
+        )
+        self.assertFalse(facture.mode_paiement)
+
+
+@tagged('souscriptions', 'souscriptions_paiements', 'post_install', '-at_install')
+class TestActionReglementsEnAttente(SouscriptionsTestCase):
+    def _facture_posted(self, mode_paiement, **periode_kwargs):
+        if mode_paiement is not None:
+            self.souscription_base.mode_paiement = mode_paiement
+        periode, facture = self.create_test_invoice(self.souscription_base, **periode_kwargs)
+        facture.action_post()
+        return facture
+
+    def _domaine_action(self):
+        action = self.env.ref('souscriptions_odoo.action_facture_reglements_attente')
+        return ast.literal_eval(action.domain)
+
+    def _dans_la_vue(self, facture):
+        domaine = self._domaine_action()
+        return facture in self.env['account.move'].search(domaine + [('id', '=', facture.id)])
+
+    def test_facture_prelevement_exclue(self):
+        facture = self._facture_posted('prelevement')
+        self.assertFalse(self._dans_la_vue(facture), 'le prélèvement a son propre circuit (#186)')
+
+    def test_facture_virement_incluse(self):
+        facture = self._facture_posted('virement')
+        self.assertTrue(self._dans_la_vue(facture))
+
+    def test_facture_mode_vide_incluse_groupe_vide(self):
+        """Souscription sans mode renseigné : apparaît (groupe « (vide) »,
+        à compléter par la facturiste, jamais deviné)."""
+        facture = self._facture_posted(None)
+        self.assertFalse(facture.souscription_id.mode_paiement)
+        self.assertTrue(self._dans_la_vue(facture))
+
+    def test_facture_brouillon_exclue(self):
+        self.souscription_base.mode_paiement = 'virement'
+        periode, facture = self.create_test_invoice(self.souscription_base)
+        self.assertEqual(facture.state, 'draft')
+        self.assertFalse(self._dans_la_vue(facture))
+
+    def test_facture_soldee_exclue(self):
+        """Reste-à-payer nul (ex. chèque énergie couvrant tout) : sort du
+        domaine d'elle-même — pas de code dédié pour cette exigence."""
+        facture = self._facture_posted('virement')
+        self.assertGreater(facture.amount_residual, 0.0)
+
+        journal = self.env['account.journal'].search([('type', '=', 'bank')], limit=1)
+        wizard = (
+            self.env['account.payment.register']
+            .with_context(active_model='account.move', active_ids=facture.ids)
+            .create({'journal_id': journal.id})
+        )
+        wizard._create_payments()
+        facture.invalidate_recordset(['amount_residual'])
+
+        self.assertAlmostEqual(facture.amount_residual, 0.0, places=2)
+        self.assertFalse(self._dans_la_vue(facture), 'un paiement natif enregistré fait sortir la facture de la vue')
+
+    def test_menu_reglements_en_attente(self):
+        menu = self.env.ref('souscriptions_odoo.menu_facture_reglements_attente')
+        self.assertEqual(menu.parent_id, self.env.ref('souscriptions_odoo.menu_souscription_root'))
+        action = self.env.ref('souscriptions_odoo.action_facture_reglements_attente')
+        self.assertEqual(menu.action.id, action.id)
+        self.assertEqual(action.res_model, 'account.move')

--- a/views/core/account_move_views.xml
+++ b/views/core/account_move_views.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <!-- « Règlements en attente » (#185, PRD #183) : l'endroit unique où la
+         facturiste voit ce qui reste à encaisser hors prélèvement — postées,
+         reste-à-payer > 0, mode ≠ prélèvement, groupe « (vide) » compris
+         (souscription sans mode renseigné, à compléter, jamais deviné). Une
+         facture soldée (chèque énergie, 0 €) sort du domaine d'elle-même.
+         Aucune vue dédiée : les vues liste/formulaire natives de la
+         Facturation portent déjà l'action « Enregistrer un paiement » sur la
+         sélection — aucun wizard maison. -->
+    <record id="action_facture_reglements_attente" model="ir.actions.act_window">
+        <field name="name">Règlements en attente</field>
+        <field name="res_model">account.move</field>
+        <field name="view_mode">list,form</field>
+        <field name="domain">[('is_facture_energie', '=', True), ('state', '=', 'posted'), ('amount_residual', '>', 0), '|', ('mode_paiement', '!=', 'prelevement'), ('mode_paiement', '=', False)]</field>
+        <field name="context">{'group_by': 'mode_paiement'}</field>
+    </record>
+
+    <menuitem
+        id="menu_facture_reglements_attente"
+        name="Règlements en attente"
+        parent="menu_souscription_root"
+        action="action_facture_reglements_attente"
+        sequence="45"/>
+</odoo>

--- a/views/core/souscription_campagne_views.xml
+++ b/views/core/souscription_campagne_views.xml
@@ -34,7 +34,8 @@
                                     <field name="valide" widget="boolean_toggle" invisible="type_etape != 'porte'"/>
                                     <field name="valide_par_id" readonly="1" invisible="not valide"/>
                                     <field name="valide_le" readonly="1" invisible="not valide"/>
-                                    <field name="nb_reste_a_faire" invisible="type_etape != 'derive'"/>
+                                    <field name="nb_reste_a_faire"
+                                           invisible="type_etape != 'derive' and code != 'preparer_prelevements'"/>
                                     <field name="fait" widget="boolean" readonly="1"/>
                                     <!-- Étapes dérivées/action (#158) : un seul bouton générique qui
                                          dispatche vers l'action de la Campagne (pull/sync/créer/émettre).


### PR DESCRIPTION
## Résumé

Gestion des paiements (PRD #183), première tranche : la Facture porte
désormais le Mode de paiement de sa Souscription (related stocké, jamais
saisi), et deux points d'entrée outillent la facturiste — la vue
« Règlements en attente » pour le hors-prélèvement, et l'étape de campagne
« Préparer les prélèvements » pour le SDD. Aucun wizard maison, aucun champ
de verrou : les deux domaines s'appuient sur `account.move.amount_residual`
et le natif « Enregistrer un paiement ».

Closes #185
Closes #186

🤖 Generated with [Claude Code](https://claude.com/claude-code)