### PR TITLE
chore(docs): versionner la story map et les artefacts sota-scan

### DIFF
--- a/.sota/last-scan.json
+++ b/.sota/last-scan.json
@@ -1,0 +1,38 @@
+{
+  "date": "2026-07-03",
+  "mode": "exhaustive",
+  "domains": ["electricity-retail-subscription-billing-odoo-addon"],
+  "rubric_version": 1,
+  "field": [
+    { "repo": "OCA/contract", "type": "canonical", "stars": 215, "pushed": "2026-07-02" },
+    { "repo": "getlago/lago", "type": "technically advanced", "stars": 10168, "pushed": "2026-06-29" },
+    { "repo": "killbill/killbill", "type": "canonical", "stars": 5612, "pushed": "2026-07-01" },
+    { "repo": "odoo/odoo", "type": "canonical", "stars": 52799, "pushed": "2026-07-03" },
+    { "repo": "openmeterio/openmeter", "type": "technically advanced", "stars": 2090, "pushed": "2026-07-03" },
+    { "repo": "FOSSBilling/FOSSBilling", "type": "popular", "stars": 1623, "pushed": "2026-07-03" },
+    { "repo": "navariltd/utility-billing", "type": "niche-relevant", "stars": 56, "pushed": "2026-07-03" }
+  ],
+  "matrix": [
+    { "id": "recurring-invoice-generation", "us": "met", "tier": "table-stakes" },
+    { "id": "time-varying-historical-pricing", "us": "met", "tier": "table-stakes" },
+    { "id": "mid-cycle-plan-change", "us": "met", "tier": "table-stakes" },
+    { "id": "proration", "us": "partial", "tier": "table-stakes" },
+    { "id": "cancellation-termination", "us": "missing", "tier": "table-stakes" },
+    { "id": "dunning-collections", "us": "missing", "tier": "table-stakes" },
+    { "id": "self-service-portal", "us": "met", "tier": "table-stakes" },
+    { "id": "online-payment-portal", "us": "missing", "tier": "table-stakes" },
+    { "id": "tax-compliant-invoicing", "us": "partial", "tier": "table-stakes" },
+    { "id": "credit-notes-refunds", "us": "partial", "tier": "table-stakes" },
+    { "id": "invoice-pdf-templating", "us": "met", "tier": "table-stakes" },
+    { "id": "leveled-smoothed-billing", "us": "met", "tier": "edge" },
+    { "id": "onboarding-provisioning-workflow", "us": "met", "tier": "edge" },
+    { "id": "gdpr-consent-audit-trail", "us": "met", "tier": "edge" },
+    { "id": "revenue-analytics-mrr", "us": "partial", "tier": "edge" },
+    { "id": "webhooks-events-api", "us": "missing", "tier": "edge" },
+    { "id": "coupons-discounts", "us": "partial", "tier": "edge" },
+    { "id": "test-suite-ci", "us": "met", "tier": "edge" }
+  ],
+  "coverage": { "met": 5, "total": 11, "pct": 45 },
+  "tier": "LAGGING",
+  "gaps_total": 6
+}

--- a/.sota/rubric.electricity-retail-subscription-billing-odoo-addon.json
+++ b/.sota/rubric.electricity-retail-subscription-billing-odoo-addon.json
@@ -1,0 +1,25 @@
+{
+  "domain": "electricity-retail-subscription-billing-odoo-addon",
+  "version": 1,
+  "note": "In-scope axis for an Odoo 19 addon owning contract/subscription mgmt, price grids, legal invoicing, customer portal, and connection (raccordement) onboarding. Usage metering / Enedis flux / TURPE are delegated to electricore and deliberately EXCLUDED from this rubric.",
+  "capabilities": [
+    { "id": "recurring-invoice-generation", "tier": "table-stakes", "test": "generate legal invoices from a contract on a recurring schedule" },
+    { "id": "time-varying-historical-pricing", "tier": "table-stakes", "test": "bill/rebill a past period at the price that was in effect during that period" },
+    { "id": "mid-cycle-plan-change", "tier": "table-stakes", "test": "change price/plan/tariff during the contract lifecycle" },
+    { "id": "proration", "tier": "table-stakes", "test": "prorate partial billing periods (days) on entry/exit/change" },
+    { "id": "cancellation-termination", "tier": "table-stakes", "test": "cleanly terminate/cancel a contract with final billing" },
+    { "id": "dunning-collections", "tier": "table-stakes", "test": "automated reminders / payment retries / collections on unpaid invoices" },
+    { "id": "self-service-portal", "tier": "table-stakes", "test": "customer portal to view contracts, invoices, consumption history" },
+    { "id": "online-payment-portal", "tier": "table-stakes", "test": "customer pays an invoice / manages payment method online in the portal" },
+    { "id": "tax-compliant-invoicing", "tier": "table-stakes", "test": "correct VAT + legally compliant invoice; for FR: Factur-X / e-reporting" },
+    { "id": "credit-notes-refunds", "tier": "table-stakes", "test": "issue credit notes / refunds / negative adjustments" },
+    { "id": "invoice-pdf-templating", "tier": "table-stakes", "test": "branded invoice PDF generation" },
+    { "id": "leveled-smoothed-billing", "tier": "edge", "test": "budget/levelized (lissage) billing with retroactive true-up/regularization" },
+    { "id": "onboarding-provisioning-workflow", "tier": "edge", "test": "onboarding/provisioning pipeline (connection request) driving contract creation" },
+    { "id": "gdpr-consent-audit-trail", "tier": "edge", "test": "append-only consent journal with timestamp + text version + withdrawal" },
+    { "id": "revenue-analytics-mrr", "tier": "edge", "test": "revenue/MRR/margin analytics dashboards" },
+    { "id": "webhooks-events-api", "tier": "edge", "test": "emit outbound events/webhooks or an integration API for downstream systems" },
+    { "id": "coupons-discounts", "tier": "edge", "test": "general coupon/discount/promotion engine" },
+    { "id": "test-suite-ci", "tier": "edge", "test": "automated test suite + CI" }
+  ]
+}

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -1,0 +1,60 @@
+# Story map — souscriptions_odoo
+
+Journeys de capacités (`REQ-XXX-nn`), chacune avec un statut (✅ Proven · ⚠️ Contested · 🕳️ Hole) et un pointeur de preuve. Maintenu par le skill `story-map`.
+
+## Parcours : demande de raccordement → mise en service
+
+- REQ-RAC-01 ✅ demande kanban : routage particulier/pro à la création — preuve: tests/test_raccordement_kanban_faits.py::test_routage_creation_particulier_vers_nouveau · #100
+- REQ-RAC-02 ✅ validation IBAN (mod 97) et SIRET à la saisie — preuve: tests/test_raccordement.py::test_iban_modulo97_algorithm
+- REQ-RAC-03 ✅ garde d'identité : partner existant réutilisé sans écrasement — preuve: tests/test_raccordement.py::test_existing_partner_reused_without_identity_overwrite · #75
+- REQ-RAC-04 ✅ naissance de la souscription à l'acceptation (garde IBAN, coeff pro) — preuve: tests/test_raccordement_kanban_faits.py::test_naissance_a_laccepte_iban_verifie · #101
+- REQ-RAC-05 ✅ étapes pilotées par les faits : auto-move id_affaire/RSC, drag-in interdit — preuve: tests/test_raccordement_kanban_faits.py::test_auto_move_vers_f120_mes · #90
+- REQ-RAC-06 ✅ mails de rassurage à l'entrée des branches F120/F130 — preuve: tests/test_mails_raccordement.py::test_entree_f120_envoie_mail_rassurage · #102
+- REQ-RAC-07 ✅ pack de bienvenue automatique à « Abonnement Validé » — preuve: tests/test_mails_raccordement.py::test_drag_en_abonnement_valide_envoie_pack_bienvenue_avec_cp_en_piece_jointe · #103
+- REQ-RAC-08 ✅ poll quotidien des affaires Enedis, alertes sans spam — preuve: tests/test_poll_affaires_enedis.py · #89
+- REQ-RAC-09 ✅ résolution RSC à la demande via electricore — preuve: tests/test_rsc_service.py · #88
+- REQ-RAC-10 ✅ état du contrat calculé : en instance / en service / résiliée — preuve: tests/test_souscription_etat.py::test_bascule_en_service_a_lecriture_de_la_rsc · #87
+
+## Parcours : contrat & documents
+
+- REQ-SOU-01 ✅ souscription base ou HP/HC avec provisions par cadran — preuve: tests/test_souscription.py::test_souscription_creation
+- REQ-SOU-02 ✅ tarif solidaire et majoration pro — preuve: tests/test_souscription.py::test_tarif_solidaire
+- REQ-SOU-03 ✅ identité Enedis : RSC unique, id_affaire, recherche — preuve: tests/test_souscription_etat.py::test_rsc_dupliquee_refusee · #15
+- REQ-SOU-04 ✅ estimation automatique des provisions (electricore) — preuve: tests/test_estimation_provisions.py · #121
+- REQ-SOU-05 ✅ journal de consentement append-only — preuve: tests/test_documents_contractuels.py::test_journal_est_append_only_en_ecriture
+- REQ-SOU-06 ✅ conditions particulières et attestation PDF — preuve: tests/test_documents_contractuels.py, tests/test_ui.py::test_report_souscription_contrat
+- REQ-SOU-07 ✅ droits resserrés user/manager sur souscriptions et grilles — preuve: tests/test_security.py · #17
+
+## Parcours : grilles de prix & catalogue
+
+- REQ-GRI-01 ✅ grille active sélectionnée par date, chevauchement interdit — preuve: tests/test_grille_prix.py::test_get_grille_active_par_date · #16
+- REQ-GRI-02 ✅ abonnement affine : base 3 kVA + coefficient par kVA — preuve: tests/test_grille_prix.py::test_abonnement_affine_lineaire_dans_la_puissance · #66
+- REQ-GRI-03 ✅ régime de prix standard | Moulin par souscription — preuve: tests/test_grille_prix.py::test_get_grille_active_par_regime · #105
+- REQ-GRI-04 ✅ duplication en brouillon inactif sans périmer la grille en cours — preuve: tests/test_grille_prix.py::test_dupliquer_grille_ne_perime_pas_la_sœur
+- REQ-GRI-05 ✅ catalogue de produits résolu par univers (standard/solidaire) — preuve: tests/test_catalogue.py
+
+## Parcours : cycle mensuel de facturation
+
+- REQ-FAC-01 ✅ campagne mensuelle : DAG d'étapes + portes de vérification — preuve: tests/test_campagne_facturation.py · #156
+- REQ-FAC-02 ✅ signaux : statut par souscription, reste-à-faire, drill-down — preuve: tests/test_campagne_signaux.py · #157
+- REQ-FAC-03 ✅ boutons d'étape : pulls, créer puis émettre les factures — preuve: tests/test_campagne_etapes_actions.py · #158
+- REQ-FAC-04 ✅ notes de campagne reportées au mois suivant — preuve: tests/test_campagne_notes.py · #159
+- REQ-FAC-05 ✅ pull des méta-périodes electricore, idempotent — preuve: tests/test_pull_meta_periodes.py · #77
+- REQ-FAC-06 ✅ énergie par cadran en cascade selon le calendrier de comptage — preuve: tests/test_periode_energie.py · #26
+- REQ-FAC-07 ✅ période mensuelle unique, snapshot figé à la facturation — preuve: tests/test_periode_snapshot.py::test_periode_figee_des_la_facturation · #14
+- REQ-FAC-08 ✅ relevés d'index : verrou de facturation + bloc justificatif sur la facture — preuve: tests/test_releve.py · #54
+- REQ-FAC-09 ✅ composition des lignes : prorata, cadrans, TURPE, pro, solidaire, régime — preuve: tests/test_periode_composition.py · #74
+- REQ-FAC-10 ✅ facture d'énergie PDF sur template dédié — preuve: tests/test_invoice_template.py, tests/test_ui.py::test_facture_energie_pdf
+- REQ-FAC-11 ⚠️ prestations F15 synchronisées puis refacturées (TVA par nature) — preuve: tests/test_sync_prestations.py, tests/test_refacturation.py · #147
+- REQ-FAC-12 🕳️ chèques énergie : imputation FIFO à la facturation — preuve: (aucune) · #172
+
+## Parcours : espace usager (portail)
+
+- REQ-POR-01 ✅ accès sécurisé : login, token d'aperçu, cloisonnement entre usagers — preuve: tests/test_portal.py::test_securite_autre_usager
+- REQ-POR-02 ✅ historique de consommation inline (factures émises seulement) — preuve: tests/test_portal.py::test_detail_affiche_historique_inline_sans_bouton · #24
+- REQ-POR-03 ✅ bloc justificatif des relevés, brouillons non fuités — preuve: tests/test_portal.py::test_releves_periode_emise_visibles · #57
+
+## Parcours : reprise de l'existant
+
+- REQ-MIG-01 ✅ périodes d'ouverture backfillées liées aux factures legacy — preuve: tests/test_periode_ouverture.py · #107
+- REQ-MIG-02 ✅ champs d'atterrissage : adresse du PDL, blaze partenaire — preuve: tests/test_souscription.py::test_adresse_pdl_creation, tests/test_res_partner.py::test_blaze_creation · #106


### PR DESCRIPTION
Sorties des skills `story-map` (FEATURES.md) et `sota-scan` (.sota/), jusqu'ici non suivies dans le dépôt. Rescué par le repo-janitor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)