### PR TITLE
refonte(vues): formulaire souscription moderne et compact (#199)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -10,7 +10,7 @@ accise, CTA, périmètre, événements C15) est calculé par
 
 Le vocabulaire métier neutre — **PDL, RSC, affaire / id_Affaire, cadran, HP/HC/Base, FTA,
 TURPE, accise, CTA, méta-période, provision d'énergie, contrat lissé, facturation calendaire,
-régularisation** —
+régularisation, chronologie** —
 est défini dans le glossaire core d'electricore (`electricore/core/CONTEXT.md`). Ce fichier
 ne redéfinit aucun de ces termes ; il ne définit que les notions propres à la représentation
 Odoo et au rôle fournisseur.

--- a/models/core/souscription.py
+++ b/models/core/souscription.py
@@ -36,6 +36,7 @@ class Souscription(models.Model):
     facture_ids = fields.One2many(
         'account.move', compute='_compute_factures_via_periodes', string='Factures', store=False
     )
+    facture_count = fields.Integer(string='Nombre de factures', compute='_compute_facture_count')
     periode_ids = fields.One2many('souscription.periode', 'souscription_id', string='Périodes de facturation')
     refacturation_ids = fields.One2many('souscription.refacturation', 'souscription_id', string='Refacturations')
     consentement_ids = fields.One2many('souscription.consentement', 'souscription_id', string='Journal des actes')
@@ -298,6 +299,25 @@ class Souscription(models.Model):
             'type': 'ir.actions.act_url',
             'url': self.get_portal_url(),
             'target': 'new',
+        }
+
+    @api.depends('facture_ids')
+    def _compute_facture_count(self):
+        for sous in self:
+            sous.facture_count = len(sous.facture_ids)
+
+    def action_voir_factures(self):
+        """Bouton stat « N Factures » de la button box (#199) : ouvre la liste
+        des factures d'énergie liées à cette Souscription via ses Périodes
+        (`facture_ids`, ADR 0004 — la Période porte le lien unique vers la
+        Facture)."""
+        self.ensure_one()
+        return {
+            'type': 'ir.actions.act_window',
+            'name': 'Factures',
+            'res_model': 'account.move',
+            'view_mode': 'list,form',
+            'domain': [('id', 'in', self.facture_ids.ids)],
         }
 
     _MESSAGE_RSC_RESTREINTE = (

--- a/models/core/souscription.py
+++ b/models/core/souscription.py
@@ -134,6 +134,29 @@ class Souscription(models.Model):
         help='Majoration en % appliquée au tarif de base (0% pour les particuliers)',
         tracking=True,
     )
+
+    # Critère « pro » du repo (cf. _prix_engages) — exposé pour l'invisibilité
+    # de coeff_pro dans la vue formulaire.
+    partner_is_company = fields.Boolean(related='partner_id.is_company')
+
+    # Chèques énergie du·de la souscripteur·rice : rattachés au partner, pas à
+    # la Souscription (ADR 0026, l'imputation FIFO cherche par partner_id) —
+    # projection lecture seule pour la fiche.
+    cheque_energie_ids = fields.Many2many(
+        'souscription.cheque_energie',
+        string='Chèques énergie',
+        compute='_compute_cheque_energie_ids',
+        help='Chèques énergie du·de la souscripteur·rice (rattachés au partner, ADR 0026).',
+    )
+
+    @api.depends('partner_id')
+    def _compute_cheque_energie_ids(self):
+        Cheque = self.env['souscription.cheque_energie']
+        for souscription in self:
+            souscription.cheque_energie_ids = (
+                Cheque.search([('partner_id', '=', souscription.partner_id.id)]) if souscription.partner_id else Cheque
+            )
+
     ## Informations
     ref_compteur = fields.Char(string='Référence compteur')
     numero_depannage = fields.Char(string='Numéro de dépannage')

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -34,5 +34,6 @@ from . import (
     test_security,
     test_souscription,
     test_souscription_etat,
+    test_souscription_form,
     test_sync_prestations,
 )

--- a/tests/test_cheque_energie.py
+++ b/tests/test_cheque_energie.py
@@ -108,3 +108,11 @@ class TestChequeEnergieModel(SouscriptionsTestCase):
         self._new_cheque(numero='CHQ-DUP')
         with self.assertRaises(ValidationError):
             self._new_cheque(numero='CHQ-DUP')
+
+    def test_cheques_projetes_sur_la_souscription_par_partner(self):
+        """La fiche souscription projette les chèques de son partner, pas ceux
+        des autres (rattachement par partner_id, ADR 0026)."""
+        du_souscripteur = self._new_cheque(numero='CHQ-PROJ-1')
+        self._new_cheque(numero='CHQ-PROJ-2', partner_id=self.partner_company.id)
+
+        self.assertEqual(self.souscription_base.cheque_energie_ids, du_souscripteur)

--- a/tests/test_souscription.py
+++ b/tests/test_souscription.py
@@ -2,6 +2,8 @@ from datetime import date
 
 from odoo.tests.common import TransactionCase, tagged
 
+from .common import SouscriptionsTestCase
+
 
 @tagged('souscriptions', 'post_install', '-at_install')
 class TestSouscription(TransactionCase):
@@ -162,3 +164,24 @@ class TestSouscription(TransactionCase):
             ['prelevement', 'monnaie_locale', 'especes', 'virement', 'cheque'],
         )
         self.assertNotIn('cheque_energie', valeurs)
+
+
+@tagged('souscriptions', 'post_install', '-at_install')
+class TestSouscriptionFactureCount(SouscriptionsTestCase):
+    """Bouton stat « N Factures » de la button box (#199) : facture_count
+    compte les factures d'énergie liées via les Périodes (ADR 0004) et
+    action_voir_factures ouvre la liste filtrée sur ces factures."""
+
+    def test_facture_count_zero_sans_facture(self):
+        self.assertEqual(self.souscription_base.facture_count, 0)
+
+    def test_facture_count_compte_les_factures_liees(self):
+        periode, facture = self.create_test_invoice(self.souscription_base)
+        self.assertEqual(self.souscription_base.facture_count, 1)
+        self.assertEqual(self.souscription_base.facture_ids, facture)
+
+    def test_action_voir_factures_ouvre_la_liste_filtree(self):
+        periode, facture = self.create_test_invoice(self.souscription_base)
+        action = self.souscription_base.action_voir_factures()
+        self.assertEqual(action['res_model'], 'account.move')
+        self.assertEqual(action['domain'], [('id', 'in', facture.ids)])

--- a/tests/test_souscription_form.py
+++ b/tests/test_souscription_form.py
@@ -67,6 +67,18 @@ class TestSouscriptionFormRefonte(SouscriptionsTestCase):
         self.assertIsNotNone(groupe, 'Groupe « Point de livraison » absent (renommage de « Infos »)')
         self.assertTrue(groupe.findall(".//field[@name='pdl']"))
 
+    def test_majoration_pro_dans_caracteristiques_cachee_si_pas_pro(self):
+        caracteristiques = self.arch.find(".//group[@string='Caractéristiques facturantes']")
+        coeff = caracteristiques.find(".//field[@name='coeff_pro']")
+        self.assertIsNotNone(coeff, 'coeff_pro doit être dans « Caractéristiques facturantes »')
+        self.assertEqual(coeff.get('invisible'), 'not partner_is_company')
+        paiement = self.arch.find(".//group[@string='Paiement']")
+        self.assertIsNone(paiement.find(".//field[@name='coeff_pro']"))
+
+    def test_cheques_energie_dans_paiement(self):
+        paiement = self.arch.find(".//group[@string='Paiement']")
+        self.assertIsNotNone(paiement.find(".//field[@name='cheque_energie_ids']"))
+
     def test_onglet_electricore_porte_les_cinq_champs_identite(self):
         page = self.arch.find(".//page[@string='Électricore']")
         self.assertIsNotNone(page)

--- a/tests/test_souscription_form.py
+++ b/tests/test_souscription_form.py
@@ -75,9 +75,10 @@ class TestSouscriptionFormRefonte(SouscriptionsTestCase):
         paiement = self.arch.find(".//group[@string='Paiement']")
         self.assertIsNone(paiement.find(".//field[@name='coeff_pro']"))
 
-    def test_cheques_energie_dans_paiement(self):
-        paiement = self.arch.find(".//group[@string='Paiement']")
-        self.assertIsNotNone(paiement.find(".//field[@name='cheque_energie_ids']"))
+    def test_cheques_energie_dans_leur_onglet(self):
+        page = self.arch.find(".//page[@string='Chèques énergie']")
+        self.assertIsNotNone(page)
+        self.assertIsNotNone(page.find(".//field[@name='cheque_energie_ids']"))
 
     def test_onglet_electricore_porte_les_cinq_champs_identite(self):
         page = self.arch.find(".//page[@string='Électricore']")
@@ -99,7 +100,10 @@ class TestSouscriptionFormRefonte(SouscriptionsTestCase):
         notebook = self.arch.find('.//notebook')
         self.assertIsNotNone(notebook)
         libelles = [p.get('string') for p in notebook.findall('page')]
-        self.assertEqual(libelles, ['Périodes de facturation', 'Refacturations', 'Journal des actes', 'Électricore'])
+        self.assertEqual(
+            libelles,
+            ['Périodes de facturation', 'Refacturations', 'Journal des actes', 'Électricore', 'Chèques énergie'],
+        )
 
     def test_colonnes_periodes_masquees_par_defaut(self):
         periode_list = self.arch.find(".//field[@name='periode_ids']//list")

--- a/tests/test_souscription_form.py
+++ b/tests/test_souscription_form.py
@@ -1,0 +1,92 @@
+"""Tests du formulaire souscription refondu (#199) : statusbar readonly dans
+le header, button box (factures + aperçu portail), bloc oe_title, deux
+colonnes, onglet Électricore. Restructuration XML pure : assertions
+structurelles sur l'arch résolu (lxml), pas de comportement métier nouveau."""
+
+from lxml import etree
+from odoo.tests.common import tagged
+
+from .common import SouscriptionsTestCase
+
+
+@tagged('souscriptions', 'souscriptions_form', 'post_install', '-at_install')
+class TestSouscriptionFormRefonte(SouscriptionsTestCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        view = cls.env['souscription.souscription'].get_view(view_type='form')
+        cls.arch = etree.fromstring(view['arch'])
+
+    def test_etat_en_statusbar_readonly_dans_le_header_seulement(self):
+        header = self.arch.find('header')
+        self.assertIsNotNone(header)
+        etat_fields = header.findall(".//field[@name='etat']")
+        self.assertEqual(len(etat_fields), 1, "L'état doit apparaître une seule fois, dans le header")
+        self.assertEqual(etat_fields[0].get('widget'), 'statusbar')
+        self.assertEqual(etat_fields[0].get('readonly'), '1')
+
+        sheet = self.arch.find('sheet')
+        self.assertIsNotNone(sheet)
+        self.assertFalse(sheet.findall(".//field[@name='etat']"), 'etat ne doit plus figurer dans le corps de la fiche')
+
+    def test_header_ne_garde_que_resoudre_rsc(self):
+        header = self.arch.find('header')
+        noms = [b.get('name') for b in header.findall('button')]
+        self.assertEqual(noms, ['action_resoudre_rsc_maintenant'])
+
+        header_str = etree.tostring(header, encoding='unicode')
+        self.assertNotIn('action_souscription_conditions_particulieres', header_str)
+        self.assertNotIn('action_souscription_attestation', header_str)
+        self.assertNotIn('action_apercu_portail', header_str)
+
+    def test_button_box_montre_factures_et_apercu_portail(self):
+        button_box = self.arch.find(".//div[@name='button_box']")
+        self.assertIsNotNone(button_box)
+        box_str = etree.tostring(button_box, encoding='unicode')
+        self.assertIn('action_voir_factures', box_str)
+        self.assertIn('facture_count', box_str)
+        self.assertIn('action_apercu_portail', box_str)
+
+    def test_oe_title_h1_souscripteur_cotitulaires(self):
+        oe_title = self.arch.find(".//div[@class='oe_title']")
+        self.assertIsNotNone(oe_title)
+        self.assertIsNotNone(oe_title.find('h1'))
+        title_str = etree.tostring(oe_title, encoding='unicode')
+        self.assertIn('name="name"', title_str)
+        self.assertIn('name="partner_id"', title_str)
+        self.assertIn('name="cotitulaires"', title_str)
+
+    def test_pdl_dans_le_groupe_point_de_livraison(self):
+        groupe = self.arch.find(".//group[@string='Point de livraison']")
+        self.assertIsNotNone(groupe, 'Groupe « Point de livraison » absent (renommage de « Infos »)')
+        self.assertTrue(groupe.findall(".//field[@name='pdl']"))
+
+    def test_onglet_electricore_porte_les_cinq_champs_identite(self):
+        page = self.arch.find(".//page[@string='Électricore']")
+        self.assertIsNotNone(page)
+        page_str = etree.tostring(page, encoding='unicode')
+        for champ in (
+            'ref_situation_contractuelle',
+            'id_affaire',
+            'id_affaire_date_saisie',
+            'motif_resolution_rsc',
+            'date_derniere_resolution_rsc',
+        ):
+            self.assertIn(f'name="{champ}"', page_str, f'Champ {champ} absent de l’onglet Électricore')
+
+    def test_plus_de_groupe_identite_electricore_hors_onglet(self):
+        self.assertIsNone(self.arch.find(".//group[@string='Identité électricore']"))
+
+    def test_onglet_electricore_quatrieme_apres_journal_des_actes(self):
+        notebook = self.arch.find('.//notebook')
+        self.assertIsNotNone(notebook)
+        libelles = [p.get('string') for p in notebook.findall('page')]
+        self.assertEqual(libelles, ['Périodes de facturation', 'Refacturations', 'Journal des actes', 'Électricore'])
+
+    def test_colonnes_periodes_masquees_par_defaut(self):
+        periode_list = self.arch.find(".//field[@name='periode_ids']//list")
+        self.assertIsNotNone(periode_list)
+        for champ in ('type_tarif_periode', 'facture_legacy_ref'):
+            field_el = periode_list.find(f".//field[@name='{champ}']")
+            self.assertIsNotNone(field_el, f'Colonne {champ} absente de la liste des périodes')
+            self.assertEqual(field_el.get('optional'), 'hide')

--- a/tests/test_souscription_form.py
+++ b/tests/test_souscription_form.py
@@ -27,7 +27,13 @@ class TestSouscriptionFormRefonte(SouscriptionsTestCase):
 
         sheet = self.arch.find('sheet')
         self.assertIsNotNone(sheet)
-        self.assertFalse(sheet.findall(".//field[@name='etat']"), 'etat ne doit plus figurer dans le corps de la fiche')
+        # Les listes embarquées (refacturations, journal des actes) portent leur
+        # propre champ `etat` : on ne compte que ceux du modèle souscription,
+        # hors sous-vues (non descendants d'un <field>).
+        etat_souscription = [
+            f for f in sheet.findall(".//field[@name='etat']") if not any(a.tag == 'field' for a in f.iterancestors())
+        ]
+        self.assertFalse(etat_souscription, 'etat ne doit plus figurer dans le corps de la fiche')
 
     def test_header_ne_garde_que_resoudre_rsc(self):
         header = self.arch.find('header')

--- a/views/core/souscription_views.xml
+++ b/views/core/souscription_views.xml
@@ -6,70 +6,63 @@
         <field name="arch" type="xml">
             <form string="Souscription">
                 <header>
-                    <button name="%(action_souscription_conditions_particulieres)d"
-                            string="Conditions particulières"
-                            type="action"
-                            class="btn-primary"/>
-                    <button name="%(action_souscription_attestation)d"
-                            string="Attestation de fourniture"
-                            type="action"/>
                     <button name="action_resoudre_rsc_maintenant"
                             string="Résoudre la RSC maintenant"
                             type="object"
                             invisible="etat == 'en_service'"/>
-                    <button name="action_apercu_portail"
-                            string="Aperçu portail"
-                            type="object"
-                            icon="fa-external-link"/>
+                    <field name="etat" widget="statusbar" readonly="1"/>
                 </header>
                 <sheet>
                     <widget name="web_ribbon" title="Archivée" bg_color="text-bg-danger" invisible="active"/>
                     <field name="active" invisible="1"/>
-                    <group>
-                        <field name="name" />
-                        <field name="partner_id" />
+                    <div class="oe_button_box" name="button_box">
+                        <button class="oe_stat_button" type="object" name="action_voir_factures" icon="fa-pencil-square-o">
+                            <field name="facture_count" widget="statinfo" string="Factures"/>
+                        </button>
+                        <button class="oe_stat_button" type="object" name="action_apercu_portail" icon="fa-globe">
+                            <div class="o_stat_info">
+                                <span class="o_stat_text">Aperçu portail</span>
+                            </div>
+                        </button>
+                    </div>
+                    <div class="oe_title">
+                        <h1>
+                            <field name="name"/>
+                        </h1>
+                        <field name="partner_id"/>
                         <field name="cotitulaires" widget="many2many_tags" options="{'no_create': True}"/>
-                        <field name="etat" widget="badge"
-                               decoration-warning="etat == 'en_instance'"
-                               decoration-success="etat == 'en_service'"
-                               decoration-danger="etat == 'resiliee'"/>
+                    </div>
+                    <group>
                         <field name="date_debut"/>
                         <field name="date_fin"/>
                     </group>
-                    <group string="Caractéristiques facturantes">
-                        <field name="pdl"/>
-                        <field name="puissance_souscrite"/>
-                        <field name="type_tarif"/>
-                        <field name="config_cadrans"/>
-                        <field name="lisse"/>
-                        <field name="provision_mensuelle_kwh" invisible="not lisse or type_tarif != 'base'" string="Provision mensuelle Base (kWh)"/>
-                        <field name="provision_hp_kwh" invisible="not lisse or type_tarif != 'hphc'" string="Provision HP (kWh)"/>
-                        <field name="provision_hc_kwh" invisible="not lisse or type_tarif != 'hphc'" string="Provision HC (kWh)"/>
-                        <field name="tarif_solidaire"/>
-                        <field name="regime_prix"/>
-                    </group>
-                    <group string="Paiement">
-                        <field name="mode_paiement"/>
-                        <field name="coeff_pro" string="Majoration PRO (%)"/>
-                    </group>
-
-                    <group string="Infos">
-                        <field name="ref_compteur"/>
-                        <field name="numero_depannage" widget="phone"/>
-                        <field name="adresse_pdl"/>
-                    </group>
-
-                    <!-- Identité electricore (ADR 0010/0020/0021) : RSC = clé d'articulation
-                         du pull de méta-périodes, acquise par le poll quotidien ou l'action
-                         manuelle (#88/#89) ; id_affaire = amorce de réconciliation, recopié
-                         du raccordement, corrigeable (rattrapage de typo). -->
-                    <group string="Identité électricore">
-                        <field name="ref_situation_contractuelle"/>
-                        <field name="id_affaire"/>
-                        <field name="id_affaire_date_saisie"/>
-                        <field name="motif_resolution_rsc" invisible="not motif_resolution_rsc"/>
-                        <field name="date_derniere_resolution_rsc" invisible="not date_derniere_resolution_rsc"/>
-                    </group>
+                    <div class="row">
+                        <div class="col-lg-6">
+                            <group string="Caractéristiques facturantes">
+                                <field name="puissance_souscrite"/>
+                                <field name="type_tarif"/>
+                                <field name="config_cadrans"/>
+                                <field name="lisse"/>
+                                <field name="provision_mensuelle_kwh" invisible="not lisse or type_tarif != 'base'" string="Provision mensuelle Base (kWh)"/>
+                                <field name="provision_hp_kwh" invisible="not lisse or type_tarif != 'hphc'" string="Provision HP (kWh)"/>
+                                <field name="provision_hc_kwh" invisible="not lisse or type_tarif != 'hphc'" string="Provision HC (kWh)"/>
+                                <field name="tarif_solidaire"/>
+                                <field name="regime_prix"/>
+                            </group>
+                        </div>
+                        <div class="col-lg-6">
+                            <group string="Point de livraison">
+                                <field name="pdl"/>
+                                <field name="adresse_pdl"/>
+                                <field name="ref_compteur"/>
+                                <field name="numero_depannage" widget="phone"/>
+                            </group>
+                            <group string="Paiement">
+                                <field name="mode_paiement"/>
+                                <field name="coeff_pro" string="Majoration PRO (%)"/>
+                            </group>
+                        </div>
+                    </div>
 
                     <notebook>
                         <page string="Périodes de facturation">
@@ -77,7 +70,7 @@
                                 <list editable="bottom" decoration-info="facture_legacy_ref and not facture_id">
                                     <field name="mois_annee"/>
                                     <field name="type_periode"/>
-                                    <field name="type_tarif_periode"/>
+                                    <field name="type_tarif_periode" optional="hide"/>
                                     <field name="energie_base_kwh" invisible="type_tarif_periode != 'base'"/>
                                     <field name="provision_base_kwh" invisible="type_tarif_periode != 'base'"/>
                                     <field name="energie_hp_kwh" invisible="type_tarif_periode == 'base'"/>
@@ -90,7 +83,7 @@
                                     <field name="facture_id"/>
                                     <!-- Période d'ouverture (#107) : backfill lié à une
                                          facture legacy plutôt qu'à un account.move. -->
-                                    <field name="facture_legacy_ref"/>
+                                    <field name="facture_legacy_ref" optional="hide"/>
                                 </list>
                             </field>
                         </page>
@@ -123,6 +116,19 @@
                                     <field name="date_retrait"/>
                                 </list>
                             </field>
+                        </page>
+                        <!-- Identité electricore (ADR 0010/0020/0021) : RSC = clé d'articulation
+                             du pull de méta-périodes, acquise par le poll quotidien ou l'action
+                             manuelle (#88/#89) ; id_affaire = amorce de réconciliation, recopié
+                             du raccordement, corrigeable (rattrapage de typo). -->
+                        <page string="Électricore" name="electricore">
+                            <group>
+                                <field name="ref_situation_contractuelle"/>
+                                <field name="id_affaire"/>
+                                <field name="id_affaire_date_saisie"/>
+                                <field name="motif_resolution_rsc" invisible="not motif_resolution_rsc"/>
+                                <field name="date_derniere_resolution_rsc" invisible="not date_derniere_resolution_rsc"/>
+                            </group>
                         </page>
                     </notebook>
                 </sheet>

--- a/views/core/souscription_views.xml
+++ b/views/core/souscription_views.xml
@@ -48,6 +48,8 @@
                                 <field name="provision_hc_kwh" invisible="not lisse or type_tarif != 'hphc'" string="Provision HC (kWh)"/>
                                 <field name="tarif_solidaire"/>
                                 <field name="regime_prix"/>
+                                <field name="partner_is_company" invisible="1"/>
+                                <field name="coeff_pro" string="Majoration PRO (%)" invisible="not partner_is_company"/>
                             </group>
                         </div>
                         <div class="col-lg-6">
@@ -59,7 +61,18 @@
                             </group>
                             <group string="Paiement">
                                 <field name="mode_paiement"/>
-                                <field name="coeff_pro" string="Majoration PRO (%)"/>
+                                <separator string="Chèques énergie" colspan="2"/>
+                                <field name="cheque_energie_ids" nolabel="1" colspan="2" readonly="1">
+                                    <list>
+                                        <field name="numero"/>
+                                        <field name="montant"/>
+                                        <field name="date_expiration"/>
+                                        <field name="state" widget="badge"
+                                               decoration-success="state == 'valide'"
+                                               decoration-danger="state in ('rejete', 'expire')"/>
+                                        <field name="solde"/>
+                                    </list>
+                                </field>
                             </group>
                         </div>
                     </div>

--- a/views/core/souscription_views.xml
+++ b/views/core/souscription_views.xml
@@ -61,18 +61,6 @@
                             </group>
                             <group string="Paiement">
                                 <field name="mode_paiement"/>
-                                <separator string="Chèques énergie" colspan="2"/>
-                                <field name="cheque_energie_ids" nolabel="1" colspan="2" readonly="1">
-                                    <list>
-                                        <field name="numero"/>
-                                        <field name="montant"/>
-                                        <field name="date_expiration"/>
-                                        <field name="state" widget="badge"
-                                               decoration-success="state == 'valide'"
-                                               decoration-danger="state in ('rejete', 'expire')"/>
-                                        <field name="solde"/>
-                                    </list>
-                                </field>
                             </group>
                         </div>
                     </div>
@@ -142,6 +130,24 @@
                                 <field name="motif_resolution_rsc" invisible="not motif_resolution_rsc"/>
                                 <field name="date_derniere_resolution_rsc" invisible="not date_derniere_resolution_rsc"/>
                             </group>
+                        </page>
+                        <page string="Chèques énergie" name="cheque_energie">
+                            <field name="cheque_energie_ids" readonly="1">
+                                <list default_order="date_expiration">
+                                    <field name="numero"/>
+                                    <field name="montant" sum="Total"/>
+                                    <field name="date_reception"/>
+                                    <field name="date_expiration"/>
+                                    <field name="state" widget="badge"
+                                           decoration-success="state == 'valide'"
+                                           decoration-danger="state in ('rejete', 'expire')"/>
+                                    <field name="etat_solde" widget="badge"
+                                           decoration-success="etat_solde == 'non_entame'"
+                                           decoration-warning="etat_solde == 'en_cours'"
+                                           decoration-danger="etat_solde == 'epuise'"/>
+                                    <field name="solde" sum="Solde restant"/>
+                                </list>
+                            </field>
                         </page>
                     </notebook>
                 </sheet>


### PR DESCRIPTION
Closes #199

Refonte du formulaire souscription : état en statusbar readonly dans le header (un seul bouton, « Résoudre la RSC maintenant »), les deux rapports rejoignent le menu Imprimer (binding_model_id déjà posé — seule la suppression des boutons header était nécessaire), button box avec « N Factures » (nouveau compute facture_count + action_voir_factures) et « Aperçu portail ». Corps en oe_title (h1 + souscripteur·rice + cotitulaires) puis deux colonnes (Caractéristiques facturantes | Point de livraison + Paiement, pdl déplacé) ; nouvel onglet Électricore absorbant l'identité RSC/id_Affaire. Colonnes legacy des Périodes masquées par défaut (optional="hide").

Le mail de bienvenue reste couvert par le test existant (report_template_ids indépendant du binding).

Suite complète verte : 0 failed, 0 error(s) of 454 tests (9 nouveaux tests structurels get_view + lxml).

🤖 Generated with [Claude Code](https://claude.com/claude-code)