### PR TITLE
feat(releve): justificatif — colonnes = union des familles réellement relevées (#138)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -208,6 +208,16 @@ tarif** fournisseur (qui ne fait que *regrouper* en cadrans **facturés**) : un 
 `type_tarif` HP/HC peut correspondre à un compteur 2 registres *ou* 4 cadrans, que seul le
 calendrier de comptage distingue.
 
+**Calendrier distributeur** :
+L'identifiant **autoritatif** côté electricore du *calendrier de comptage* d'un PDL (source C15,
+propriété de la *Configuration Enedis*) — distinct de `config_cadrans`, sa copie **snapshottée à
+la main** côté Odoo tant que le contrat d'intégration manque (#12, ADR 0005). Consommé **à terme**
+pour remplacer la saisie manuelle par un pull ; en attendant, le justificatif des *Relevés*
+**infère** les familles de cadrans réellement présentes depuis les index saisis, avec repli sur
+`config_cadrans` déclaré si aucun index n'est renseigné (ADR 0015 amendé, #138).
+_Éviter_ : confondre avec `config_cadrans` (la copie Odoo, aujourd'hui déclarative et sujette à
+repli, pas encore reliée à ce calendrier autoritatif).
+
 **Configuration fournisseur** :
 La configuration *commerciale* portée par la *Souscription* : formule tarifaire fournisseur
 (cadrans **facturés** : Base, ou HP/HC), lissage, provisions, mode de paiement. **Orthogonale

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -42,7 +42,7 @@ Journeys de capacités (`REQ-XXX-nn`), chacune avec un statut (✅ Proven · ⚠
 - REQ-FAC-05 ✅ pull des méta-périodes electricore, idempotent — preuve: tests/test_pull_meta_periodes.py · #77
 - REQ-FAC-06 ✅ énergie par cadran en cascade selon le calendrier de comptage — preuve: tests/test_periode_energie.py · #26
 - REQ-FAC-07 ✅ période mensuelle unique, snapshot figé à la facturation — preuve: tests/test_periode_snapshot.py::test_periode_figee_des_la_facturation · #14
-- REQ-FAC-08 ✅ relevés d'index : verrou de facturation + bloc justificatif sur la facture — preuve: tests/test_releve.py · #54
+- REQ-FAC-08 ✅ relevés d'index : verrou de facturation + bloc justificatif (colonnes = union des familles réellement relevées) — preuve: tests/test_releve.py · #54, #138
 - REQ-FAC-09 ✅ composition des lignes : prorata, cadrans, TURPE, pro, solidaire, régime — preuve: tests/test_periode_composition.py · #74
 - REQ-FAC-10 ✅ facture d'énergie PDF sur template dédié — preuve: tests/test_invoice_template.py, tests/test_ui.py::test_facture_energie_pdf
 - REQ-FAC-11 ⚠️ prestations F15 synchronisées puis refacturées (TVA par nature) — preuve: tests/test_sync_prestations.py, tests/test_refacturation.py · #147

--- a/demo/souscriptions_demo.xml
+++ b/demo/souscriptions_demo.xml
@@ -153,6 +153,24 @@
             <field name="turpe_variable">13.75</field>
         </record>
 
+        <!-- Période juin 2026 - Particulier BASE, SWAP DE COMPTEUR (#138). Facturée
+             Base (config_cadrans hérité 'base'), mais le compteur est remplacé en
+             cours de mois par un compteur 4 cadrans : le relevé de début ne porte
+             qu'un index_base, celui de fin porte les 4 cadrans (index_base resté à
+             0, non renseigné sur ce compteur). Non-régression #138 : le justificatif
+             doit afficher l'UNION (Base + HPH/HPB/HCH/HCB), pas seulement Base — cf.
+             les relevés plus bas, `demo_releve_juin_2026_*`. -->
+        <record id="demo_periode_juin_2026_swap_compteur" model="souscription.periode">
+            <field name="souscription_id" ref="demo_souscription_particulier_base"/>
+            <field name="date_debut">2026-06-01</field>
+            <field name="date_fin">2026-06-30</field>
+            <field name="type_periode">mensuelle</field>
+            <field name="provision_base_kwh">280</field>
+            <field name="energie_base_kwh">270</field>
+            <field name="turpe_fixe">8.50</field>
+            <field name="turpe_variable">13.10</field>
+        </record>
+
         <!-- Période mars 2024 - Particulier HP/HC -->
         <record id="demo_periode_mars_hphc" model="souscription.periode">
             <field name="souscription_id" ref="demo_souscription_particulier_hphc"/>
@@ -351,6 +369,28 @@
             <field name="date">2024-02-29</field>
             <field name="nature">reel</field>
             <field name="index_base">135</field>
+        </record>
+
+        <!-- Période NON facturée — juin 2026, SWAP DE COMPTEUR ENTRE FAMILLES
+             (#138, non-régression). Base facturée (config_cadrans 'base'), mais le
+             1er relevé vient de l'ancien compteur mono-index (index_base) et le 2e
+             du nouveau compteur 4 cadrans (index_hph/hpb/hch/hcb) — index_base y
+             reste à 0 : c'est le diff visuel de la transition. Le justificatif doit
+             afficher Base ET HPH/HPB/HCH/HCB (union), pas Base seule. -->
+        <record id="demo_releve_juin_2026_avant_swap" model="souscription.releve">
+            <field name="periode_id" ref="demo_periode_juin_2026_swap_compteur"/>
+            <field name="date">2026-06-01</field>
+            <field name="nature">reel</field>
+            <field name="index_base">20000</field>
+        </record>
+        <record id="demo_releve_juin_2026_apres_swap" model="souscription.releve">
+            <field name="periode_id" ref="demo_periode_juin_2026_swap_compteur"/>
+            <field name="date">2026-06-30</field>
+            <field name="nature">reel</field>
+            <field name="index_hph">100</field>
+            <field name="index_hpb">80</field>
+            <field name="index_hch">60</field>
+            <field name="index_hcb">40</field>
         </record>
 
         <!-- Période FACTURÉE & POSTÉE — Admin janvier (4 cadrans). Visible sur le

--- a/docs/adr/0028-releve-colonnes-union-familles-relevees.md
+++ b/docs/adr/0028-releve-colonnes-union-familles-relevees.md
@@ -1,0 +1,74 @@
+# Colonnes du justificatif des relevés : union des familles réellement relevées, pas `config_cadrans`
+
+[ADR-0015](0015-releves-index-enfant-fige-periode-projete-facture.md) fixait : « les colonnes
+affichées suivent `config_cadrans` » ([ADR-0005](0005-granularite-energie-calendrier-comptage.md)).
+En pratique, un changement de compteur **en cours de période** fait cohabiter deux familles de
+cadrans dans les mêmes `releve_ids` (l'ancien compteur relève une famille, le nouveau une autre) —
+`config_cadrans`, valeur **unique** figée à la création de la Période, ne peut en représenter
+qu'une seule. Suivre `config_cadrans` produit alors soit une colonne **parasite** à zéro (famille
+déclarée mais jamais relevée), soit une famille **manquante** (relevée mais pas déclarée) — dans
+les deux cas le justificatif légal ne montre pas fidèlement « tous les index qu'electricore a
+utilisés ». Cet ADR amende ADR-0015 sur ce seul point (le reste — enfant figé, cardinalité
+variable, rendu par projection — est inchangé).
+
+## Décision
+
+1. **`releve_colonnes()` lit les relevés, pas `config_cadrans`.** Nouvelle méthode
+   `_familles_relevees()` : pour chaque famille de `_FAMILLES = ['base', 'hp_hc', '4_cadrans']`
+   (ordre **superficiel → profond**), retient celles dont au moins un `releve_ids` porte un index
+   non nul. `releve_colonnes()` concatène les colonnes (`_RELEVE_COLONNES`, dict inchangé) des
+   familles retenues, dans cet ordre.
+2. **Une famille présente → cette famille seule.** Plus de colonne parasite à zéro pour une
+   famille déclarée mais jamais relevée.
+3. **Deux familles présentes → l'union ordonnée.** Le changement de compteur en cours de période
+   (~2–4 relevés, cf. ADR-0015) donne un **diff visuel** naturel : chaque relevé ne remplit que les
+   registres de son propre compteur, les autres colonnes restent à 0 sur sa ligne.
+4. **Repli sur `config_cadrans` déclaré si aucun relevé ne porte le moindre index** — `releve_ids`
+   vide, ou relevés présents mais sans aucun index renseigné. Préserve la saisie manuelle (#12) :
+   le·la facturiste doit garder des colonnes où écrire avant d'avoir des données à afficher.
+5. **`column_invisible` ne peut pas appeler de méthode**, et l'union peut rendre **plusieurs**
+   familles vraies simultanément — irreprésentable par la Selection `config_cadrans` seule. Le
+   formulaire backend expose trois booléens **calculés** sur la Période — `releve_show_base`,
+   `releve_show_hphc`, `releve_show_4cadrans` — lisant `_familles_relevees()`, que le sous-formulaire
+   `releve_ids` référence en `parent.releve_show_*`.
+6. **Source unique inchangée** : PDF, portail et formulaire backend appellent tous
+   `periode.releve_colonnes()` (PDF/portail) ou les booléens dérivés de la même méthode (backend) —
+   aucune des trois surfaces ne relit `config_cadrans` pour décider des colonnes.
+
+## Conséquences
+
+- `souscription.periode` gagne `_FAMILLES`, `_famille_non_vide()`, `_familles_relevees()` et trois
+  champs `Boolean` calculés non stockés (`releve_show_*`). `_RELEVE_COLONNES` (le mapping
+  cadran→colonne) et la signature de `releve_colonnes()` sont inchangés — seule la clé qui pilote
+  la sélection change (familles relevées, plus `config_cadrans` directement).
+- La vue formulaire (`views/core/souscriptions_periode_views.xml`) remplace
+  `column_invisible="parent.config_cadrans != '…'"` par `column_invisible="not parent.releve_show_…"`
+  sur les 7 colonnes d'index de `releve_ids`.
+- `config_cadrans` garde son rôle de **repli** (aucun index relevé) et continue de piloter la
+  saisie de l'énergie (ADR 0005, inchangé) : cet amendement ne concerne que l'affichage du
+  justificatif des relevés.
+- Non-régression démo : la période « Juin 2026 » (Base facturée, compteur remplacé en cours de
+  mois) illustre le cas à deux familles — le justificatif affiche Base **et** HPH/HPB/HCH/HCB.
+
+## Raison
+
+L'obligation légale (ADR-0015) est d'afficher **tous** les index utilisés, pas ceux qu'un champ de
+configuration figé au premier jour de la période *prévoyait*. Un changement de compteur est
+exactement le cas où le·la souscripteur·rice a le plus besoin de vérifier — le diff visuel entre
+deux familles rend la transition lisible plutôt que de la masquer derrière une colonne unique.
+L'inférence depuis les données réelles (`releve_ids`) est strictement plus fidèle qu'une
+déclaration a priori, tout en gardant un repli sûr pour la saisie manuelle tant que #12 n'est pas
+comblé.
+
+## Options écartées
+
+- **Ajouter une valeur « mixte » à `config_cadrans`** : quelle famille afficher en premier ? dans
+  quel ordre ? Le champ redeviendrait un fourre-tout recalculé, alors que l'information vit déjà,
+  précisément, dans `releve_ids`.
+- **Un champ `config_cadrans` par relevé plutôt que par Période** : existe déjà (`releve.config_cadrans`,
+  related, ADR 0015) mais ne résout pas l'agrégation — il faudrait quand même une méthode d'union
+  côté Période pour piloter l'affichage.
+- **Consommer directement le `calendrier distributeur` electricore** (identifiant autoritatif du
+  calendrier de comptage, cf. `CONTEXT.md`) plutôt que d'inférer depuis les relevés : dépend d'un
+  pull non encore construit (#12) ; l'inférence est une étape intermédiaire correcte, à remplacer
+  le jour où ce pull existe — pas avant.

--- a/models/core/souscription_periode.py
+++ b/models/core/souscription_periode.py
@@ -188,6 +188,14 @@ class SouscriptionPeriode(models.Model):
     # la main par le·la facturiste tant que le pull electricore manque (#12).
     releve_ids = fields.One2many('souscription.releve', 'periode_id', string="Relevés d'index utilisés")
 
+    # Gating XML des colonnes du formulaire backend (#138) : `column_invisible`
+    # ne peut pas appeler une méthode, et l'union des familles (_familles_relevees)
+    # exige plusieurs booléens vrais simultanément — impossible avec une seule
+    # Selection. Calculés, jamais stockés (source unique : releve_colonnes()).
+    releve_show_base = fields.Boolean(compute='_compute_releve_show_familles')
+    releve_show_hphc = fields.Boolean(compute='_compute_releve_show_familles')
+    releve_show_4cadrans = fields.Boolean(compute='_compute_releve_show_familles')
+
     # Lien Période ↔ Facture : `account.move.periode_id` est l'unique source de
     # vérité (ADR 0004). `facture_id` en est dérivé — calculé/stocké, non écrit.
     move_ids = fields.One2many('account.move', 'periode_id', string='Documents liés', readonly=True)
@@ -355,8 +363,8 @@ class SouscriptionPeriode(models.Model):
         return super().write(vals)
 
     # Mapping cadran réseau → colonne d'index, source unique pour le justificatif
-    # PDF (#55) et portail (#57) — ADR 0015. Suit le calendrier de comptage
-    # (ADR 0005) ; point d'extension nommé pour Tempo/EJP (hors périmètre).
+    # PDF (#55), portail (#57) et formulaire backend (#138) — ADR 0015 (amendé
+    # #138). Point d'extension nommé pour Tempo/EJP (hors périmètre).
     _RELEVE_COLONNES = {
         'base': [{'label': 'Base', 'field': 'index_base'}],
         'hp_hc': [{'label': 'HP', 'field': 'index_hp'}, {'label': 'HC', 'field': 'index_hc'}],
@@ -368,13 +376,56 @@ class SouscriptionPeriode(models.Model):
         ],
     }
 
+    # Ordre superficiel → profond, pour l'union ordonnée quand plusieurs
+    # familles cohabitent (changement de compteur en cours de période).
+    _FAMILLES = ['base', 'hp_hc', '4_cadrans']
+
+    def _famille_non_vide(self, releve, famille):
+        """Un relevé `releve` porte-t-il au moins un index non nul de `famille` ?"""
+        return any(releve[champ['field']] for champ in self._RELEVE_COLONNES[famille])
+
+    def _familles_relevees(self):
+        """Familles de cadrans (`base`/`hp_hc`/`4_cadrans`) réellement portées
+        par les relevés de cette Période, ordonnées superficiel → profond
+        (#138). Un changement de compteur en cours de période peut faire
+        cohabiter deux familles ; chaque relevé ne remplit que les registres de
+        *son* compteur. Repli sur le `config_cadrans` déclaré si aucun relevé ne
+        porte le moindre index (saisie manuelle #12, qui doit garder des
+        colonnes où écrire)."""
+        self.ensure_one()
+        presentes = [f for f in self._FAMILLES if any(self._famille_non_vide(r, f) for r in self.releve_ids)]
+        return presentes or [self.config_cadrans or 'base']
+
     def releve_colonnes(self):
         """Colonnes d'index réseau (`label`, `field`) à afficher pour le
-        justificatif des relevés de cette Période, selon son calendrier de
-        comptage. Itérées par les rendus PDF et portail — un seul endroit où vit
-        le mapping cadran→colonne (ADR 0015)."""
+        justificatif des relevés de cette Période : l'**union** des familles de
+        cadrans réellement présentes dans `releve_ids` (#138, amende ADR 0015 —
+        ne suit plus `config_cadrans` directement). Itérées par les rendus PDF,
+        portail et formulaire backend — un seul endroit où vit le mapping
+        cadran→colonne."""
         self.ensure_one()
-        return self._RELEVE_COLONNES.get(self.config_cadrans, [])
+        return [colonne for famille in self._familles_relevees() for colonne in self._RELEVE_COLONNES[famille]]
+
+    @api.depends(
+        'config_cadrans',
+        'releve_ids.index_base',
+        'releve_ids.index_hp',
+        'releve_ids.index_hc',
+        'releve_ids.index_hph',
+        'releve_ids.index_hpb',
+        'releve_ids.index_hch',
+        'releve_ids.index_hcb',
+    )
+    def _compute_releve_show_familles(self):
+        """Booléens calculés pour le gating XML du formulaire backend (#138) :
+        `column_invisible` ne peut pas appeler une méthode, et l'union peut
+        rendre **plusieurs** familles vraies simultanément — impossible à
+        représenter par une Selection unique."""
+        for periode in self:
+            familles = periode._familles_relevees()
+            periode.releve_show_base = 'base' in familles
+            periode.releve_show_hphc = 'hp_hc' in familles
+            periode.releve_show_4cadrans = '4_cadrans' in familles
 
     @api.depends('date_debut', 'date_fin')
     def _compute_jours(self):

--- a/tests/test_releve.py
+++ b/tests/test_releve.py
@@ -110,6 +110,109 @@ class TestReleveModel(SouscriptionsTestCase):
 
 
 @tagged('souscriptions', 'souscriptions_releve', 'post_install', '-at_install')
+class TestReleveColonnesUnionFamilles(SouscriptionsTestCase):
+    """`releve_colonnes()` = union des familles de cadrans réellement relevées
+    (#138, amende ADR 0015) — plus une lecture directe de `config_cadrans`."""
+
+    def test_une_seule_famille_ignore_config_cadrans_declare(self):
+        """Période déclarée hp_hc dont l'unique relevé porte les 4 cadrans
+        (compteur remplacé) : seules les colonnes 4 cadrans apparaissent —
+        aucune colonne HP/HC parasite à zéro."""
+        self.souscription_hphc.config_cadrans = 'hp_hc'
+        periode = self.create_test_periode(self.souscription_hphc)
+        self.env['souscription.releve'].create(
+            {
+                'periode_id': periode.id,
+                'date': date(2024, 1, 1),
+                'nature': 'reel',
+                'index_hph': 1000,
+                'index_hpb': 2000,
+                'index_hch': 3000,
+                'index_hcb': 4000,
+            }
+        )
+
+        self.assertEqual(
+            [c['field'] for c in periode.releve_colonnes()],
+            ['index_hph', 'index_hpb', 'index_hch', 'index_hcb'],
+        )
+
+    def test_deux_familles_union_ordonnee_superficiel_a_profond(self):
+        """Changement de compteur HP/HC → 4 cadrans en cours de période : union
+        ordonnée [HP, HC, HPH, HPB, HCH, HCB], chaque relevé ne remplissant que
+        les registres de son propre compteur (diff visuel de la transition)."""
+        self.souscription_hphc.config_cadrans = 'hp_hc'
+        periode = self.create_test_periode(self.souscription_hphc)
+        Releve = self.env['souscription.releve']
+        Releve.create(
+            {'periode_id': periode.id, 'date': date(2024, 1, 1), 'nature': 'reel', 'index_hp': 8000, 'index_hc': 4000}
+        )
+        Releve.create(
+            {
+                'periode_id': periode.id,
+                'date': date(2024, 1, 31),
+                'nature': 'reel',
+                'index_hph': 10,
+                'index_hpb': 20,
+                'index_hch': 30,
+                'index_hcb': 40,
+            }
+        )
+
+        self.assertEqual(
+            [c['field'] for c in periode.releve_colonnes()],
+            ['index_hp', 'index_hc', 'index_hph', 'index_hpb', 'index_hch', 'index_hcb'],
+        )
+
+    def test_aucun_relevé_replie_sur_config_cadrans_declare(self):
+        """Aucun relevé du tout : repli sur le config_cadrans déclaré — la
+        saisie manuelle (#12) garde des colonnes où écrire."""
+        self.souscription_hphc.config_cadrans = 'hp_hc'
+        periode = self.create_test_periode(self.souscription_hphc)
+        self.assertFalse(periode.releve_ids)
+
+        self.assertEqual([c['field'] for c in periode.releve_colonnes()], ['index_hp', 'index_hc'])
+
+    def test_releves_sans_aucun_index_replie_sur_config_cadrans_declare(self):
+        """Des relevés existent mais aucun n'a d'index renseigné (tous à 0) :
+        même repli sur config_cadrans que l'absence totale de relevé."""
+        self.souscription_hphc.config_cadrans = '4_cadrans'
+        periode = self.create_test_periode(self.souscription_hphc)
+        self.env['souscription.releve'].create({'periode_id': periode.id, 'date': date(2024, 1, 1), 'nature': 'estime'})
+
+        self.assertEqual(
+            [c['field'] for c in periode.releve_colonnes()],
+            ['index_hph', 'index_hpb', 'index_hch', 'index_hcb'],
+        )
+
+    def test_booleens_releve_show_gatent_le_formulaire_backend(self):
+        """`releve_show_base/hphc/4cadrans` (gating XML, `column_invisible` ne
+        pouvant appeler une méthode) reflètent l'union — plusieurs peuvent être
+        vrais simultanément, impossible à représenter par une Selection."""
+        self.souscription_hphc.config_cadrans = 'hp_hc'
+        periode = self.create_test_periode(self.souscription_hphc)
+        Releve = self.env['souscription.releve']
+        Releve.create(
+            {'periode_id': periode.id, 'date': date(2024, 1, 1), 'nature': 'reel', 'index_hp': 100, 'index_hc': 50}
+        )
+        Releve.create(
+            {
+                'periode_id': periode.id,
+                'date': date(2024, 1, 31),
+                'nature': 'reel',
+                'index_hph': 10,
+                'index_hpb': 20,
+                'index_hch': 30,
+                'index_hcb': 40,
+            }
+        )
+
+        self.assertFalse(periode.releve_show_base)
+        self.assertTrue(periode.releve_show_hphc)
+        self.assertTrue(periode.releve_show_4cadrans)
+
+
+@tagged('souscriptions', 'souscriptions_releve', 'post_install', '-at_install')
 class TestReleveVerrou(SouscriptionsTestCase):
     """Verrou de facturation étendu à l'enfant (#56 / ADR 0014-0015) : dès qu'une
     Période est facturée, create / write / unlink d'un relevé sont rejetés."""

--- a/tests/test_releve.py
+++ b/tests/test_releve.py
@@ -355,6 +355,38 @@ class TestReleveFacturePDF(SouscriptionsTestCase):
         for jalon in ('01/01/2024', '15/01/2024', '31/01/2024'):
             self.assertIn(jalon, html)
 
+    def test_swap_compteur_deux_familles_affiche_union_sur_le_pdf(self):
+        """Facturée Base mais relevée par deux familles (swap de compteur en
+        cours de période, #138) : le PDF affiche l'union des colonnes — Base ET
+        HPH/HPB/HCH/HCB — pas seulement Base comme le ferait config_cadrans lu
+        directement. Même source (releve_colonnes()) que le portail et le
+        formulaire backend."""
+        periode = self.create_test_periode(self.souscription_base)
+        self.assertEqual(periode.config_cadrans, 'base')
+        Releve = self.env['souscription.releve']
+        Releve.create({'periode_id': periode.id, 'date': date(2024, 1, 1), 'nature': 'reel', 'index_base': 88801})
+        Releve.create(
+            {
+                'periode_id': periode.id,
+                'date': date(2024, 1, 31),
+                'nature': 'reel',
+                'index_hph': 711,
+                'index_hpb': 622,
+                'index_hch': 533,
+                'index_hcb': 444,
+            }
+        )
+        facture = periode._creer_facture()
+
+        html = self._render_facture(facture)
+        # Les deux familles sont rendues : la valeur d'index_base (relevé avant
+        # swap) ET les 4 index HPH/HPB/HCH/HCB (relevé après swap) apparaissent
+        # — l'ancienne lecture directe de config_cadrans n'aurait affiché que
+        # la colonne Base, jamais ces 4 valeurs.
+        self.assertIn('88801', html)
+        for valeur in ('711', '622', '533', '444'):
+            self.assertIn(valeur, html)
+
 
 @tagged('souscriptions', 'souscriptions_releve', 'post_install', '-at_install')
 class TestMigrationIndexInteger(SouscriptionsTestCase):

--- a/tests/test_releve_demo.py
+++ b/tests/test_releve_demo.py
@@ -68,3 +68,24 @@ class TestReleveDemoLive(TransactionCase):
     def test_changement_compteur_trois_releves(self):
         periode = self._ref('demo_periode_fevrier_base')
         self.assertEqual(len(periode.releve_ids), 3)
+
+    def test_juin_2026_swap_compteur_affiche_union_base_et_4_cadrans(self):
+        """Non-régression #138 : période démo « Juin 2026 » — Base facturée
+        (config_cadrans hérité 'base'), mais relevée par deux familles (swap de
+        compteur en cours de mois). Le justificatif doit afficher l'union
+        (Base + HPH/HPB/HCH/HCB), pas Base seule comme le ferait l'ancienne
+        lecture directe de config_cadrans."""
+        periode = self._ref('demo_periode_juin_2026_swap_compteur')
+        if not periode:
+            self.skipTest('Données de démo non chargées sur cette base')
+        self.assertEqual(periode.config_cadrans, 'base')
+
+        self.assertEqual(
+            [c['field'] for c in periode.releve_colonnes()],
+            ['index_base', 'index_hph', 'index_hpb', 'index_hch', 'index_hcb'],
+        )
+        # Diff visuel de la transition : le relevé post-swap ne renseigne pas
+        # index_base, qui reste donc à 0 sur cette ligne.
+        releve_apres_swap = periode.releve_ids.sorted('date')[-1]
+        self.assertEqual(releve_apres_swap.index_base, 0)
+        self.assertEqual(releve_apres_swap.index_hph, 100)

--- a/views/core/souscriptions_periode_views.xml
+++ b/views/core/souscriptions_periode_views.xml
@@ -56,6 +56,13 @@
                         </group>
                         <group string="Contrat (historisé)">
                             <field name="config_cadrans"/>
+                            <!-- Gating des colonnes du justificatif de relevés
+                                 (#138) : booléens calculés, jamais affichés
+                                 tels quels, juste chargés pour parent.X plus
+                                 bas dans le sous-formulaire releve_ids. -->
+                            <field name="releve_show_base" invisible="1"/>
+                            <field name="releve_show_hphc" invisible="1"/>
+                            <field name="releve_show_4cadrans" invisible="1"/>
                             <field name="type_tarif_periode"/>
                             <field name="puissance_souscrite_periode"/>
                             <field name="lisse_periode"/>
@@ -115,30 +122,31 @@
                         </group>
                     </group>
 
-                    <!-- Relevés d'index utilisés (ADR 0015) : justificatif légal du
-                         calcul d'énergie, saisi à la main par le·la facturiste.
-                         Forme large par cadran réseau ; les colonnes d'index
-                         suivent le calendrier de comptage (config_cadrans). -->
+                    <!-- Relevés d'index utilisés (ADR 0015, amendé #138) : justificatif
+                         légal du calcul d'énergie, saisi à la main par le·la facturiste.
+                         Forme large par cadran réseau ; les colonnes affichées suivent
+                         l'UNION des familles réellement relevées (releve_show_*,
+                         calculés depuis _familles_relevees()) — pas config_cadrans
+                         directement, qui ne sert plus que de repli (aucun index saisi). -->
                     <group string="Relevés d'index utilisés">
                         <field name="releve_ids" nolabel="1" colspan="2">
                             <list editable="bottom">
-                                <field name="config_cadrans" column_invisible="1"/>
                                 <field name="date"/>
                                 <field name="nature"/>
                                 <field name="index_base"
-                                       column_invisible="parent.config_cadrans != 'base'"/>
+                                       column_invisible="not parent.releve_show_base"/>
                                 <field name="index_hp"
-                                       column_invisible="parent.config_cadrans != 'hp_hc'"/>
+                                       column_invisible="not parent.releve_show_hphc"/>
                                 <field name="index_hc"
-                                       column_invisible="parent.config_cadrans != 'hp_hc'"/>
+                                       column_invisible="not parent.releve_show_hphc"/>
                                 <field name="index_hph"
-                                       column_invisible="parent.config_cadrans != '4_cadrans'"/>
+                                       column_invisible="not parent.releve_show_4cadrans"/>
                                 <field name="index_hpb"
-                                       column_invisible="parent.config_cadrans != '4_cadrans'"/>
+                                       column_invisible="not parent.releve_show_4cadrans"/>
                                 <field name="index_hch"
-                                       column_invisible="parent.config_cadrans != '4_cadrans'"/>
+                                       column_invisible="not parent.releve_show_4cadrans"/>
                                 <field name="index_hcb"
-                                       column_invisible="parent.config_cadrans != '4_cadrans'"/>
+                                       column_invisible="not parent.releve_show_4cadrans"/>
                                 <field name="releve_externe_id"/>
                                 <field name="origine"/>
                             </list>


### PR DESCRIPTION
Closes #138

Le justificatif « Relevés d'index utilisés » (facture PDF, portail, formulaire backend) affiche
désormais l'union des familles de cadrans réellement présentes dans les Relevés d'une Période,
au lieu de suivre config_cadrans. Une seule famille relevée → colonnes de cette famille
uniquement ; deux familles (changement de compteur en cours de période) → union ordonnée
superficiel → profond, avec repli sur le calendrier déclaré si aucun index n'est saisi. Le
formulaire backend gate ses colonnes via trois booléens calculés (releve_show_base/hphc/4cadrans),
column_invisible ne pouvant pas appeler de méthode. Amende ADR 0015 (ADR 0028) et ajoute le
glossaire « calendrier distributeur ».

Suite complète verte en local : 0 failed, 0 error(s) of 475 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)