### PR TITLE
refonte(prix): grille = moteur de prix unique — composants(), projections Facture/CP (ADR 0029)

### DIFF
--- a/docs/adr/0018-abonnement-affine-base-3kva-plus-coefficient-kva.md
+++ b/docs/adr/0018-abonnement-affine-base-3kva-plus-coefficient-kva.md
@@ -1,5 +1,9 @@
 # Tarif d'abonnement affine (base 3 kVA + coefficient par kVA) au lieu d'un prix par palier
 
+*Note (juillet 2026) : amendé par [ADR-0029](0029-grille-moteur-prix-unique-composants-projections.md) —
+la majoration PRO quitte la formule ci-dessous (elle n'a plus qu'un site, `grille.composants()`) ;
+la forme affine et ses deux paramètres restent inchangés.*
+
 La *Grille de prix* tarifait l'abonnement par un **prix indépendant par palier de puissance**
 (9 valeurs/univers, invariant verrouillé par `test_prix_independant_par_puissance`). On le remplace
 par un **tarif affine** : `prix_base_3kva + coef_kva × (puissance − 3)`, soit **2 paramètres** par

--- a/docs/adr/0029-grille-moteur-prix-unique-composants-projections.md
+++ b/docs/adr/0029-grille-moteur-prix-unique-composants-projections.md
@@ -1,0 +1,84 @@
+# Grille de prix = moteur de prix unique : composants prixés, projetés par la Facture et les Conditions particulières
+
+*Statut : accepté (2026-07-11). Issu de la revue d'architecture de juillet 2026 : la règle
+« prixer une configuration » était implémentée deux fois — `_composer_lignes` (Facture) et
+`_prix_documents` (Conditions particulières) — avec le facteur de *Majoration PRO* en trois
+exemplaires et deux cartes de cadrans parallèles. Ne re-décide ni la grille **tout-compris**
+([ADR-0002](0002-deux-sources-de-verite-marge-en-analytique.md)), ni le snapshot de la
+*Période* ([ADR-0006](0006-snapshot-periode-fait-autorite-facturation.md)), ni la CP comme
+**projection** ([ADR-0016](0016-documents-contractuels-projection-souscription-consentements-raccordement.md)),
+ni l'abonnement **affine** ([ADR-0018](0018-abonnement-affine-base-3kva-plus-coefficient-kva.md)) :
+il fixe **où vit la règle d'assemblage des prix** et **ce qui a le droit de diverger**.
+CONTEXT.md (« Grille de prix ») porte déjà le vocabulaire.*
+
+## Décision
+
+1. **Une seule implémentation de la règle d'assemblage, portée par la grille.**
+   `grille.prix` expose `composants(type_tarif, puissance, coeff_pro, tarif_solidaire)` :
+   partition du tarif en cadrans **facturés** (codes + libellés), prix de l'énergie par
+   cadran, abonnement **affine**, application de la *Majoration PRO*, résolution du *Produit
+   de facturation* (standard / solidaire). Sortie en **données pures** — produits résolus et
+   prix unitaires HT — sans effet de bord.
+
+2. **La grille est un paramètre de l'appelant, jamais résolue dans le moteur.** La *Facture*
+   prixe avec la grille **historique** (active à `date_fin` de la *Période*) ; les
+   *Conditions particulières* avec la grille **engagée** (active à `date_debut`). Les
+   **valeurs divergent donc dans le temps — c'est le domaine** (régularisation aux prix
+   historiques) ; l'invariant défendu est l'unicité de la **règle**, pas l'égalité des
+   montants.
+
+3. **Entrées en valeurs plates, jamais un recordset `souscription`.** Le chemin Facture
+   nourrit le moteur avec les valeurs **figées** du snapshot de la Période (ADR-0006), la CP
+   avec la Souscription vivante : une interface en valeurs rend le re-couplage de la facture
+   aux données vivantes impossible par construction.
+
+4. **Prix manquant : échec bruyant dans le moteur.** Une grille incapable de prixer une
+   configuration lève une `UserError` actionnable (produit + grille nommés). Le défaut
+   silencieux `0,0` du chemin CP disparaît : un prix nul sur un document opposable est pire
+   que l'erreur qu'il évitait.
+
+5. **L'interface publique de la grille rétrécit.** `get_prix_dict` et `get_prix_abonnement`
+   deviennent internes ; `get_prix_abonnement` **perd son paramètre `coeff_pro`** — la
+   Majoration PRO n'a plus qu'un site (dans `composants`). Les deux cartes parallèles
+   `_CADRANS_FACTURES` (periode) et `_CADRANS_DOCUMENTS` (souscription) fusionnent en une
+   carte unique dans le moteur.
+
+6. **Les appelants gardent leur présentation.** Quantités (jours, kWh mesurés ou provision —
+   déjà locales, ADR-0008), TVA d'affichage (HT société / TTC particulier via le produit),
+   sections, notes TURPE et mensualité estimée restent chez chaque projection.
+
+## Conséquences
+
+- **Localité** : le facteur PRO passe de 3 sites à 1 ; la partition des cadrans de 2 cartes
+  à 1 ; un nouveau type de tarif (p. ex. Tempo) s'ajoute dans **un** fichier.
+- **Testabilité** : la règle PRO × solidaire × cadrans × affine se teste sur l'interface du
+  moteur, en données, sans facture postée ni `compute_all`.
+- **Changement de comportement assumé** : générer une CP sur une grille incomplète échoue au
+  lieu d'imprimer 0,0000 €/kWh — l'erreur arrive à la génération, là où la grille se complète.
+- **Uniformisation du coefficient négatif** : l'ancienne garde `if coeff_pro > 0` de l'abonnement
+  ignorait un coefficient négatif, que l'énergie appliquait déjà sans garde ; `composants()`
+  applique le facteur uniformément. `coeff_pro < 0` n'est pas un cas métier (la *Majoration PRO*
+  est un surcoût) — l'incohérence disparaît avec la duplication.
+- **Garde-fou pour une future revue** : constater que la CP et les factures affichent des
+  prix différents n'est **pas** un bug à corriger (relire §2) ; « aligner » les valeurs ou
+  adoucir l'échec bruyant en défaut régresserait cet ADR.
+
+## Options écartées
+
+- **Statu quo (deux implémentations).** La convention seule gardait les règles égales ; la
+  dérive était silencieuse — le 0,0 de la CP en était déjà un symptôme.
+- **Lignes prêtes-à-facturer en sortie.** Élargit l'interface pour absorber les quantités,
+  qui ne sont pas dupliquées ; la CP re-décomposerait des lignes qu'elle n'affiche pas.
+- **Nouveau modèle « moteur de prix ».** Au deletion test, il coordonnerait grille +
+  catalogue sans rien posséder ; la grille resterait à moitié vidée à côté.
+- **Défaut (0 / None) sur prix manquant, au choix de l'appelant.** Re-duplique une politique
+  par appelant — exactement la dérive que l'ADR ferme.
+- **Passer la Souscription en entrée.** Recouple silencieusement la facture aux données
+  vivantes, contre le snapshot (ADR-0006).
+
+## Raison
+
+Deux documents opposables projetaient chacun leur propre assemblage de prix ; rien d'autre
+que la discipline ne les gardait sous la même règle. Concentrer la règle dans le module qui
+possède déjà les prix — la grille — et paramétrer par la grille rend la divergence *voulue*
+(valeurs, dans le temps) structurellement distincte de la divergence *interdite* (règle).

--- a/models/core/grille_prix.py
+++ b/models/core/grille_prix.py
@@ -146,40 +146,87 @@ class GrillePrix(models.Model):
                         f'(régime {grille.regime_prix}).'
                     )
 
-    def get_prix_dict(self):
-        """Retourne un dict {product_id: prix_interne} pour toute la grille"""
+    # Cadrans facturés par type de tarif : (code, libellé). Carte unique de la
+    # partition (ADR 0029) — Base : un seul cadran ; HP/HC : toujours les deux,
+    # même à 0. Pilote la Facture (periode._composer_lignes) comme les documents
+    # (souscription._prix_documents).
+    _CADRANS_FACTURES = {
+        'base': [('base', 'Base')],
+        'hphc': [('hp', 'Heures pleines'), ('hc', 'Heures creuses')],
+    }
+
+    def composants(self, type_tarif, puissance_kva, coeff_pro=0.0, tarif_solidaire=False):
+        """Composants prixés de la grille pour une configuration (ADR 0029).
+
+        L'unique implémentation de la règle d'assemblage : partition en cadrans
+        facturés, prix de l'énergie par cadran, abonnement affine (ADR 0018 —
+        à terme pricé sur la puissance moyenne, #78), majoration PRO (#67,
+        toute la fourniture, jamais la Refacturation — pur transit Enedis),
+        résolution du Produit de facturation standard /
+        solidaire (ADR 0013). Rend des données pures HT — produits résolus et
+        prix unitaires. Quantités, TVA d'affichage et mise en page restent aux
+        projections (Facture, conditions particulières), qui appellent chacune
+        avec **sa** grille (historique à la fin de Période ↔ engagée à la date
+        de début) : les valeurs divergent dans le temps, la règle jamais.
+        Prix manquant → ``UserError`` — jamais un prix nul par défaut sur un
+        document.
+        """
+        self.ensure_one()
+        produit = self.env['souscription.produit']
+        majoration_pro = 1 + coeff_pro / 100.0
+        prix_dict = self._get_prix_dict()
+
+        abonnement = {
+            'produit': produit.produit_abonnement(tarif_solidaire),
+            'prix_jour': self._get_prix_abonnement(puissance_kva, tarif_solidaire) * majoration_pro,
+        }
+
+        energies = []
+        for cadran, libelle in self._CADRANS_FACTURES[type_tarif]:
+            produit_energie = produit.produit_energie(cadran, tarif_solidaire)
+            prix_kwh = prix_dict.get(produit_energie.id)
+            if prix_kwh is None:
+                raise UserError(f'Prix non trouvé dans la grille {self.name} pour le produit : {produit_energie.name}')
+            energies.append(
+                {
+                    'cadran': cadran,
+                    'libelle': libelle,
+                    'produit': produit_energie,
+                    'prix_kwh': prix_kwh * majoration_pro,
+                }
+            )
+
+        return {'abonnement': abonnement, 'energies': energies}
+
+    def _get_prix_dict(self):
+        """{product_id: prix_interne} pour toute la grille — interne, servi via
+        ``composants()`` (ADR 0029)."""
         self.ensure_one()
         return {ligne.product_id.id: ligne.prix_interne for ligne in self.ligne_ids if ligne.product_id}
 
-    def get_prix_abonnement(self, puissance_kva, coeff_pro=0.0, is_solidaire=False):
-        """Retourne le prix d'abonnement journalier (€/jour) pour une puissance.
+    def _get_prix_abonnement(self, puissance_kva, tarif_solidaire=False):
+        """Prix d'abonnement journalier (€/jour) pour une puissance — interne.
 
         Tarif affine (ADR 0018) : la grille porte deux paramètres par univers,
         ``prix_base_3kva`` (€/an à 3 kVA) et ``coef_kva`` (€/an par kVA
         supplémentaire). Le prix journalier vaut
-        ``(prix_base_3kva + coef_kva x (puissance_kva - 3)) / 365``, puis la
-        majoration PRO ``x (1 + coeff_pro / 100)`` est appliquée.
-
-        L'univers (standard / solidaire) est porté par le produit du catalogue
-        (ADR 0013), jamais ré-encodé dans la grille.
+        ``(prix_base_3kva + coef_kva x (puissance_kva - 3)) / 365``. La
+        majoration PRO est l'affaire de ``composants()`` — un seul site
+        (ADR 0029). L'univers (standard / solidaire) est porté par le produit
+        du catalogue (ADR 0013), jamais ré-encodé dans la grille.
         """
         self.ensure_one()
 
-        product = self.env['souscription.produit'].produit_abonnement(is_solidaire)
+        product = self.env['souscription.produit'].produit_abonnement(tarif_solidaire)
 
         ligne_abo = self.ligne_ids.filtered(lambda l: l.product_id == product and l.type_produit == 'abonnement')
         if not ligne_abo:
-            type_abo = 'solidaire' if is_solidaire else 'standard'
+            type_abo = 'solidaire' if tarif_solidaire else 'standard'
             raise UserError(f"Aucun tarif d'abonnement {type_abo} dans la grille {self.name}.")
 
         ligne = ligne_abo[0]
         prix_annuel = ligne.prix_base_3kva + ligne.coef_kva * (float(puissance_kva) - PUISSANCE_BASE_KVA)
-        prix_journalier = prix_annuel / JOURS_PAR_AN
-
-        if coeff_pro > 0:
-            prix_journalier = prix_journalier * (1 + coeff_pro / 100.0)
-
-        return prix_journalier
+        return prix_annuel / JOURS_PAR_AN
 
     def dupliquer_cette_grille(self):
         """Action pour dupliquer cette grille avec toutes ses lignes.
@@ -300,7 +347,7 @@ class GrillePrixLigne(models.Model):
         for ligne in self:
             if ligne.type_produit == 'abonnement':
                 # Prix indicatif (€/jour) à la puissance de base ; le prix facturé
-                # est calculé par get_prix_abonnement (affine, ADR 0018).
+                # est calculé par _get_prix_abonnement (affine, ADR 0018).
                 ligne.prix_interne = ligne.prix_base_3kva / JOURS_PAR_AN if ligne.prix_base_3kva else 0.0
             else:
                 # Énergies : prix interne = prix saisi.

--- a/models/core/souscription.py
+++ b/models/core/souscription.py
@@ -523,12 +523,6 @@ class Souscription(models.Model):
         for sous in self:
             sous.facture_ids = sous.periode_ids.mapped('facture_id')
 
-    # Cadrans facturés par type de tarif : (code grille, libellé document).
-    _CADRANS_DOCUMENTS = {
-        'base': [('base', 'Base')],
-        'hphc': [('hp', 'Heures pleines'), ('hc', 'Heures creuses')],
-    }
-
     def _provisions_cadrans(self):
         """Provision mensuelle par cadran facturé ('base'/'hp'/'hc') — source
         unique (#73). HP/HC explicites (`provision_hp_kwh`/`provision_hc_kwh`)
@@ -551,21 +545,28 @@ class Souscription(models.Model):
     def _prix_documents(self, a_date=None):
         """Prix engagés à projeter sur les *Conditions particulières* (ADR 0016).
 
-        Résout les tarifs depuis la *Grille de prix* en vigueur à ``a_date``
-        (défaut : ``date_debut``) : abonnement de la puissance souscrite et
-        énergie des cadrans facturés. Rendus **TTC pour un particulier** (la TVA
-        est portée par le *Produit de facturation*), **HT pour une société** —
-        choix piloté par ``partner_id.is_company``. Pour un contrat lissé, calcule
-        la mensualité estimée. Le rapport ne fait que projeter ce dict, il ne
-        recalcule aucun prix (module profond, interface étroite).
+        Résout les tarifs via ``grille.composants()`` — l'unique règle
+        d'assemblage (ADR 0029) — sur la *Grille de prix* en vigueur à
+        ``a_date`` (défaut : ``date_debut``, la grille **engagée** ; la facture
+        prixe, elle, avec la grille historique de chaque Période — les valeurs
+        divergent dans le temps, la règle jamais). Rendus **TTC pour un
+        particulier** (la TVA est portée par le *Produit de facturation*),
+        **HT pour une société** — choix piloté par ``partner_id.is_company``.
+        Pour un contrat lissé, calcule la mensualité estimée. Le rapport ne
+        fait que projeter ce dict, il ne recalcule aucun prix (module profond,
+        interface étroite).
         """
         self.ensure_one()
-        produit = self.env['souscription.produit']
         a_date = a_date or self.date_debut or fields.Date.today()
         grille = self.env['grille.prix'].get_grille_active(a_date, regime=self.regime_prix)
         is_company = bool(self.partner_id.is_company)
-        is_sol = self.tarif_solidaire
-        prix_grille = grille.get_prix_dict()
+
+        composants = grille.composants(
+            self.type_tarif,
+            self.puissance_souscrite,
+            coeff_pro=self.coeff_pro,
+            tarif_solidaire=self.tarif_solidaire,
+        )
 
         def affiche(product, montant_ht):
             """HT tel quel pour une société ; TTC via la TVA du produit sinon."""
@@ -580,14 +581,9 @@ class Souscription(models.Model):
             )
             return taxes['total_included']
 
-        # Majoration PRO appliquée à toute la fourniture — abonnement ET énergie
-        # (#67, ADR 0018) ; même facteur que la facture (souscription_periode.py),
-        # jamais à la refacturation. L'abonnement l'absorbe via get_prix_abonnement.
-        majoration_pro = 1 + self.coeff_pro / 100.0
-
         # Abonnement (€/an et €/mois) pour la puissance souscrite.
-        abo_product = produit.produit_abonnement(is_sol)
-        abo_jour_ht = grille.get_prix_abonnement(self.puissance_souscrite, self.coeff_pro, is_sol)
+        abo_product = composants['abonnement']['produit']
+        abo_jour_ht = composants['abonnement']['prix_jour']
         abo_an = affiche(abo_product, abo_jour_ht * 365.0)
         abo_mois = affiche(abo_product, abo_jour_ht * 365.0 / 12.0)
 
@@ -597,11 +593,10 @@ class Souscription(models.Model):
 
         energies = []
         mensualite = abo_mois
-        for code, libelle in self._CADRANS_DOCUMENTS[self.type_tarif]:
-            energie_product = produit.produit_energie(code, is_sol)
-            prix_kwh = affiche(energie_product, prix_grille.get(energie_product.id, 0.0) * majoration_pro)
-            energies.append({'code': code, 'label': libelle, 'prix_kwh': prix_kwh})
-            mensualite += provisions.get(code, 0.0) * prix_kwh
+        for composant in composants['energies']:
+            prix_kwh = affiche(composant['produit'], composant['prix_kwh'])
+            energies.append({'code': composant['cadran'], 'label': composant['libelle'], 'prix_kwh': prix_kwh})
+            mensualite += provisions.get(composant['cadran'], 0.0) * prix_kwh
 
         return {
             'grille': grille,

--- a/models/core/souscription_periode.py
+++ b/models/core/souscription_periode.py
@@ -500,18 +500,9 @@ class SouscriptionPeriode(models.Model):
     # La Période compose ses lignes de facture à partir de son snapshot figé
     # (puissance, tarif, coeff PRO, solidaire, quantités) et de la grille passée
     # en paramètre. Aucun repli sur l'état live de la souscription : le snapshot
-    # fait autorité (ADR 0006). Les prix restent l'affaire de la grille (ADR 0002,
-    # « référencer, pas recopier »).
-
-    # Cadrans facturés par type de tarif (snapshot `type_tarif_periode`) : pilote
-    # la boucle de composition des lignes d'énergie (#74, prefactoring en vue de
-    # l'abonnement pricé sur la puissance moyenne, #78). Même partition que
-    # `souscription._CADRANS_DOCUMENTS` (Conditions particulières) : Base = un
-    # seul cadran ; HP/HC = toujours les deux, même à 0.
-    _CADRANS_FACTURES = {
-        'base': ['base'],
-        'hphc': ['hp', 'hc'],
-    }
+    # fait autorité (ADR 0006). Les prix restent l'affaire de la grille — la
+    # règle d'assemblage vit dans grille.composants(), la Période n'en est
+    # qu'une projection (ADR 0002 « référencer, pas recopier », ADR 0029).
 
     def _quantite_facturee(self, cadran):
         """Quantité d'énergie à facturer pour un cadran facturé ('base'/'hp'/'hc').
@@ -537,36 +528,34 @@ class SouscriptionPeriode(models.Model):
     def _composer_lignes(self, grille):
         """Compose les lignes de facture (``[(0, 0, vals)]``) de cette période.
 
-        Lit le snapshot figé de la période et la ``grille`` passée pour les prix.
-        Ne crée aucun ``account.move`` : la liste renvoyée est la surface de test
-        des règles de facturation.
+        Lit le snapshot figé de la période, résout les prix via
+        ``grille.composants()`` — l'unique règle d'assemblage (ADR 0029) — et
+        ne garde que la projection : quantités du snapshot, sections, notes.
+        Ne crée aucun ``account.move``.
         """
         self.ensure_one()
-        prix_dict = grille.get_prix_dict()
 
         # Snapshot figé typé — ADR 0006 (pas de repli sur la souscription live)
         # et #14 (valeurs typées : aucun parsing à la facturation).
         puissance_kva = self.puissance_souscrite_periode
-        tarif_solidaire = self.tarif_solidaire_periode
-        type_tarif = self.type_tarif_periode
+        coeff_pro_historise = self.coeff_pro_periode
 
         if not puissance_kva:
             raise UserError(f'Aucune puissance définie pour la période {self.mois_annee}')
+
+        composants = grille.composants(
+            self.type_tarif_periode,
+            puissance_kva,
+            coeff_pro=coeff_pro_historise,
+            tarif_solidaire=self.tarif_solidaire_periode,
+        )
 
         lines_vals = []
 
         # Section Abonnement
         lines_vals.append((0, 0, {'display_type': 'line_section', 'name': 'Abonnement'}))
 
-        coeff_pro_historise = self.coeff_pro_periode
-        # Majoration PRO appliquée à toute la fourniture — abonnement ET énergie
-        # (#67, ADR 0018) ; jamais à la refacturation (pur transit Enedis).
-        majoration_pro = 1 + coeff_pro_historise / 100.0
-        produit_abo = self.env['souscription.produit'].produit_abonnement(tarif_solidaire)
-        prix_abo_journalier = grille.get_prix_abonnement(
-            puissance_kva, coeff_pro=coeff_pro_historise, is_solidaire=tarif_solidaire
-        )
-
+        produit_abo = composants['abonnement']['produit']
         type_client = 'PRO' if coeff_pro_historise > 0 else 'PART'
         puissance_desc = f'{puissance_kva:g} kVA'  # :g supprime les .0 inutiles
 
@@ -578,7 +567,7 @@ class SouscriptionPeriode(models.Model):
                     'product_id': produit_abo.id,
                     'name': f'{produit_abo.name} {puissance_desc} {type_client}',
                     'quantity': self.jours,
-                    'price_unit': prix_abo_journalier,
+                    'price_unit': composants['abonnement']['prix_jour'],
                 },
             )
         )
@@ -590,23 +579,16 @@ class SouscriptionPeriode(models.Model):
         # Section Énergie
         lines_vals.append((0, 0, {'display_type': 'line_section', 'name': 'Énergie'}))
 
-        # type_tarif historisé typé (#14) : clé de sélection, comparaison directe.
-        # Un seul bloc générique, piloté par les cadrans facturés du type de tarif
-        # (#74) — Base : un cadran ; HP/HC : toujours les deux, même à 0.
-        for cadran in self._CADRANS_FACTURES[type_tarif]:
-            produit_energie = self.env['souscription.produit'].produit_energie(cadran, tarif_solidaire)
-            prix_cadran = prix_dict.get(produit_energie.id)
-            if prix_cadran is None:
-                raise UserError(f'Prix non trouvé dans la grille pour le produit : {produit_energie.name}')
+        for composant in composants['energies']:
             lines_vals.append(
                 (
                     0,
                     0,
                     {
-                        'product_id': produit_energie.id,
-                        'name': produit_energie.name,
-                        'quantity': self._quantite_facturee(cadran),
-                        'price_unit': prix_cadran * majoration_pro,
+                        'product_id': composant['produit'].id,
+                        'name': composant['produit'].name,
+                        'quantity': self._quantite_facturee(composant['cadran']),
+                        'price_unit': composant['prix_kwh'],
                     },
                 )
             )

--- a/tests/test_grille_prix.py
+++ b/tests/test_grille_prix.py
@@ -75,43 +75,52 @@ class TestGrillePrix(TransactionCase):
             self.grille,
         )
 
-    def test_get_prix_dict(self):
-        prix_dict = self.grille.get_prix_dict()
-        produit_base = self.env.ref('souscriptions_odoo.souscriptions_product_energie_base')
+    # === composants() — l'unique règle d'assemblage des prix (ADR 0029) ===
+
+    def _prix_energie(self, composants, cadran):
+        return next(c['prix_kwh'] for c in composants['energies'] if c['cadran'] == cadran)
+
+    def test_composants_prix_energie_par_cadran(self):
+        """Chaque cadran facturé sort avec son produit résolu et son prix grille."""
+        base = self.grille.composants('base', 6.0)
+        self.assertEqual(self._prix_energie(base, 'base'), 0.2276)
+
+        hphc = self.grille.composants('hphc', 6.0)
+        self.assertEqual([c['cadran'] for c in hphc['energies']], ['hp', 'hc'])
+        self.assertEqual(self._prix_energie(hphc, 'hp'), 0.2516)
+        self.assertEqual(self._prix_energie(hphc, 'hc'), 0.2032)
         produit_hp = self.env.ref('souscriptions_odoo.souscriptions_product_energie_hp')
-        produit_hc = self.env.ref('souscriptions_odoo.souscriptions_product_energie_hc')
-        self.assertEqual(prix_dict[produit_base.id], 0.2276)
-        self.assertEqual(prix_dict[produit_hp.id], 0.2516)
-        self.assertEqual(prix_dict[produit_hc.id], 0.2032)
+        self.assertEqual(hphc['energies'][0]['produit'], produit_hp)
 
     def test_abonnement_affine_a_3kva(self):
         """À 3 kVA, le tarif vaut exactement la base (terme coef nul)."""
-        prix_journalier = self.grille.get_prix_abonnement(puissance_kva=3.0, coeff_pro=0.0, is_solidaire=False)
-        self.assertAlmostEqual(prix_journalier, ABO_BASE_3KVA_STD / 365.0, places=4)
+        composants = self.grille.composants('base', 3.0)
+        self.assertAlmostEqual(composants['abonnement']['prix_jour'], ABO_BASE_3KVA_STD / 365.0, places=4)
 
     def test_abonnement_affine_puissance_non_3kva(self):
         """Au-dessus de 3 kVA : base + coef * (P - 3), proratisé au jour."""
-        prix_journalier = self.grille.get_prix_abonnement(puissance_kva=9.0, coeff_pro=0.0, is_solidaire=False)
+        composants = self.grille.composants('base', 9.0)
         attendu_annuel = ABO_BASE_3KVA_STD + ABO_COEF_KVA_STD * (9.0 - 3.0)
-        self.assertAlmostEqual(prix_journalier, attendu_annuel / 365.0, places=4)
+        self.assertAlmostEqual(composants['abonnement']['prix_jour'], attendu_annuel / 365.0, places=4)
 
     def test_abonnement_affine_lineaire_dans_la_puissance(self):
         """L'écart entre deux puissances vaut coef * Δkva / 365 (forme affine)."""
-        prix_6 = self.grille.get_prix_abonnement(6.0)
-        prix_9 = self.grille.get_prix_abonnement(9.0)
+        prix_6 = self.grille.composants('base', 6.0)['abonnement']['prix_jour']
+        prix_9 = self.grille.composants('base', 9.0)['abonnement']['prix_jour']
         self.assertAlmostEqual(prix_9 - prix_6, ABO_COEF_KVA_STD * 3.0 / 365.0, places=6)
 
-    def test_abonnement_affine_pro(self):
-        """La majoration PRO s'applique au tarif affine journalier."""
-        prix_journalier = self.grille.get_prix_abonnement(puissance_kva=9.0, coeff_pro=15.0, is_solidaire=False)
+    def test_composants_pro_majore_abonnement_et_energie(self):
+        """La majoration PRO s'applique à toute la fourniture — un seul site (ADR 0029)."""
+        composants = self.grille.composants('base', 9.0, coeff_pro=15.0)
         attendu_annuel = ABO_BASE_3KVA_STD + ABO_COEF_KVA_STD * (9.0 - 3.0)
-        self.assertAlmostEqual(prix_journalier, (attendu_annuel / 365.0) * 1.15, places=4)
+        self.assertAlmostEqual(composants['abonnement']['prix_jour'], (attendu_annuel / 365.0) * 1.15, places=4)
+        self.assertAlmostEqual(self._prix_energie(composants, 'base'), 0.2276 * 1.15, places=6)
 
     def test_abonnement_affine_solidaire(self):
         """Le solidaire lit sa propre ligne (base + coef) via le produit du catalogue."""
-        prix_journalier = self.grille.get_prix_abonnement(puissance_kva=12.0, coeff_pro=0.0, is_solidaire=True)
+        composants = self.grille.composants('base', 12.0, tarif_solidaire=True)
         attendu_annuel = ABO_BASE_3KVA_SOL + ABO_COEF_KVA_SOL * (12.0 - 3.0)
-        self.assertAlmostEqual(prix_journalier, attendu_annuel / 365.0, places=4)
+        self.assertAlmostEqual(composants['abonnement']['prix_jour'], attendu_annuel / 365.0, places=4)
 
     def test_abonnement_sans_ligne(self):
         """Sans ligne d'abonnement pour l'univers, l'erreur est claire."""
@@ -119,7 +128,14 @@ class TestGrillePrix(TransactionCase):
             lambda l: l.type_produit == 'abonnement' and 'solidaire' not in l.product_id.name.lower()
         ).unlink()
         with self.assertRaises(UserError):
-            self.grille.get_prix_abonnement(6.0, is_solidaire=False)
+            self.grille.composants('base', 6.0)
+
+    def test_composants_prix_energie_manquant_leve(self):
+        """Grille incomplète → échec bruyant, jamais un prix nul par défaut (ADR 0029)."""
+        produit_hc = self.env.ref('souscriptions_odoo.souscriptions_product_energie_hc')
+        self.grille.ligne_ids.filtered(lambda l: l.product_id == produit_hc).unlink()
+        with self.assertRaises(UserError):
+            self.grille.composants('hphc', 6.0)
 
     def test_chevauchement_grilles_interdit(self):
         """Deux grilles aux périodes qui se chevauchent sont refusées."""

--- a/tests/test_periode_ouverture.py
+++ b/tests/test_periode_ouverture.py
@@ -61,9 +61,15 @@ class TestPeriodeOuverture(SouscriptionsTestCase):
         self.assertEqual(periode.jours, 30)
 
         grille = self.env['grille.prix'].get_grille_active(periode.date_fin, regime=periode.regime_prix_periode)
-        prix = grille.get_prix_dict()
-        produit_base = self.env['souscription.produit'].produit_energie('base', periode.tarif_solidaire_periode)
-        self.assertIn(produit_base.id, prix, 'Le prix appliqué se résout via la grille, comme toute Période')
+        composants = grille.composants(
+            periode.type_tarif_periode,
+            periode.puissance_souscrite_periode,
+            tarif_solidaire=periode.tarif_solidaire_periode,
+        )
+        self.assertTrue(
+            any(c['cadran'] == 'base' for c in composants['energies']),
+            'Le prix appliqué se résout via la grille, comme toute Période',
+        )
 
     def test_porte_provision_hp_hc(self):
         """AC2 (HP/HC) : provision facturée par cadran, HP et HC."""


### PR DESCRIPTION
## Quoi

Issu de la revue d'architecture du 11/07 (candidat n° 1, grillé en session). La règle d'assemblage des prix — partition en cadrans facturés, abonnement affine, majoration PRO, résolution du produit standard/solidaire — était implémentée **deux fois** (`_composer_lignes` pour la Facture, `_prix_documents` pour les Conditions particulières), avec le facteur PRO en **trois** exemplaires et deux cartes de cadrans parallèles.

Elle vit désormais dans **`grille.composants(type_tarif, puissance, coeff_pro, tarif_solidaire)`** — données pures HT, produits résolus — et les deux documents n'en sont plus que des projections (quantités, TVA d'affichage, mise en page).

## Invariant (ADR 0029)

La grille reste un **paramètre de l'appelant** : historique (`date_fin` de la Période) pour la Facture, engagée (`date_debut`) pour la CP. **Les valeurs divergent dans le temps — c'est le domaine ; la règle, jamais.**

## Changements de comportement assumés

- Prix manquant dans la grille → `UserError` partout, **y compris côté CP** qui imprimait silencieusement `0,0 €/kWh` sur un document opposable.
- Coefficient PRO négatif : appliqué uniformément (l'ancienne garde `> 0` de l'abonnement était incohérente avec l'énergie ; pas un cas métier).

## Détail

- `get_prix_dict`/`get_prix_abonnement` internalisés (`_`) ; `coeff_pro` retiré de l'affine — la majoration PRO n'a plus qu'un site ; ADR 0018 amendée d'une note
- `_CADRANS_FACTURES` (periode) et `_CADRANS_DOCUMENTS` (souscription) fusionnés en une carte unique (codes + libellés) dans la grille
- tests migrés sur l'interface du moteur + 2 checks nouveaux (PRO majore aussi l'énergie ; grille incomplète lève)
- ADR 0029 (renumérotée : collision 0028 avec #204) ; le glossaire (« moteur de prix », CONTEXT.md) arrive par `chore/wip-docs-catch-up`

## Revue deux axes (Standards / Spec)

Passée en revue par sous-agents avant push final : collision ADR corrigée, invariant « jamais la Refacturation » et pointeur #78 restaurés en docstring, `is_solidaire` → `tarif_solidaire`, uniformisation du coeff négatif documentée dans l'ADR. Byte-compatibilité des lignes de facture et du dict `_prix_documents` vérifiée contre `origin/main`.

## Vérification

Suite docker complète (avant et après correctifs de revue) : **0 failed, 0 error(s) of 476 tests**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)