### PR TITLE
refonte(test): faux electricore partagé — exceptions ré-exportées par la fabrique + helpers communs (tranche 2 du PRD #219)

### DIFF
--- a/models/core/electricore_client_fabrique.py
+++ b/models/core/electricore_client_fabrique.py
@@ -42,6 +42,11 @@ try:
 except ImportError:  # pragma: no cover - exercé par test_electricore_client_fabrique
     ELECTRICORE_CLIENT_DISPONIBLE = False
 
+    # Même repli que les exceptions : le symbole existe dans les deux mondes
+    # (patchable par les tests), la garde ELECTRICORE_CLIENT_DISPONIBLE
+    # échoue avant toute construction réelle.
+    ElectricoreClient = None
+
     class ContractVersionError(Exception):
         """Repli si `electricore_client` est absent : jamais levée en pratique — la fabrique
         (`souscription.electricore.client`) échoue avant tout appel qui pourrait la lever."""

--- a/models/core/electricore_client_fabrique.py
+++ b/models/core/electricore_client_fabrique.py
@@ -18,6 +18,13 @@ Chaque appelant garde son propre appel d'endpoint (`resoudre_rsc` en lot ↔
 `meta_periodes` en flux) et son propre mapping d'exceptions : cette fabrique
 s'arrête à « rends-moi un client configuré » (ADR 0024 §4, option écartée
 « fabrique de transport complète »).
+
+Ré-export des exceptions du contrat (#222, tranche 2 du PRD #219) : les
+quatre appelants (résolution RSC, pull méta-périodes, refacturation F15,
+chronologie) important `ContractVersionError`/`IngestionEnCours`/
+`PreconditionNonRemplie` depuis **ce** module plutôt que de porter chacun sa
+propre garde d'import + ses propres stubs de repli — un seul point d'origine,
+réel si le paquet est présent, stub sinon.
 """
 
 from __future__ import annotations
@@ -28,11 +35,22 @@ from odoo import models
 from odoo.exceptions import UserError
 
 try:
-    from electricore_client import ElectricoreClient
+    from electricore_client import ContractVersionError, ElectricoreClient, IngestionEnCours
+    from electricore_client.exceptions import PreconditionNonRemplie
 
     ELECTRICORE_CLIENT_DISPONIBLE = True
 except ImportError:  # pragma: no cover - exercé par test_electricore_client_fabrique
     ELECTRICORE_CLIENT_DISPONIBLE = False
+
+    class ContractVersionError(Exception):
+        """Repli si `electricore_client` est absent : jamais levée en pratique — la fabrique
+        (`souscription.electricore.client`) échoue avant tout appel qui pourrait la lever."""
+
+    class IngestionEnCours(Exception):
+        """Repli si `electricore_client` est absent : jamais levée en pratique."""
+
+    class PreconditionNonRemplie(Exception):
+        """Repli si `electricore_client` est absent : jamais levée en pratique."""
 
 
 class SouscriptionElectricoreClient(models.AbstractModel):

--- a/models/core/electricore_rsc_service.py
+++ b/models/core/electricore_rsc_service.py
@@ -5,7 +5,7 @@ Le client electricore est acquis auprès de la fabrique unique
 `souscription.electricore.client` (ADR 0024) : ce module ne porte plus ni
 garde d'import, ni drapeau de disponibilité, ni lecture de config — seul son
 propre appel d'endpoint (`resoudre_rsc` en lot) et son mapping d'exception
-(`ContractVersionError`).
+(`ContractVersionError`, ré-exportée par la fabrique — #222).
 
 C'est l'unique point du module qui parle réseau pour la résolution RSC ; le
 pull des périodes (#12) s'y branchera plus tard.
@@ -16,13 +16,7 @@ from __future__ import annotations
 from odoo import models
 from odoo.exceptions import UserError
 
-try:
-    from electricore_client import ContractVersionError
-except ImportError:  # pragma: no cover - paquet optionnel (ADR 0024) ; la fabrique lève avant tout mapping
-
-    class ContractVersionError(Exception):
-        """Repli si `electricore_client` est absent : jamais levée en pratique — la fabrique
-        (`souscription.electricore.client`) échoue avant tout appel qui pourrait la lever."""
+from .electricore_client_fabrique import ContractVersionError
 
 
 class SouscriptionRscService(models.AbstractModel):

--- a/models/core/souscription_chronologie.py
+++ b/models/core/souscription_chronologie.py
@@ -8,9 +8,9 @@ Pas de persistance métier : electricore reste autoritaire, on ne re-mirroire
 aucune donnée réseau (CONTEXT.md, ADR 0001/0019).
 
 Grain `rsc` uniquement (pas de repli `pdl` — une seconde action dédiée
-pourrait un jour exposer la vue point, hors périmètre ici). Garde d'import +
-mapping d'exceptions locaux à ce module, même posture que le wizard de pull
-des méta-périodes (`souscription_pull_meta_periodes_wizard.py`, ADR 0024) :
+pourrait un jour exposer la vue point, hors périmètre ici). Exceptions du
+mapping ré-exportées par la fabrique (ADR 0024, #222), même posture que le
+wizard de pull des méta-périodes (`souscription_pull_meta_periodes_wizard.py`) :
 la fabrique s'arrête à « rends-moi un client configuré », chaque appelant
 garde son appel d'endpoint et son propre mapping.
 """
@@ -20,23 +20,7 @@ from __future__ import annotations
 from odoo import api, fields, models
 from odoo.exceptions import UserError
 
-# Garde d'import minimale (ADR 0024) : seules les exceptions du mapping de ce
-# module sont importées ici — la construction du client (garde + drapeau +
-# config) vit dans la fabrique. Si le paquet est absent, la fabrique lève
-# avant qu'aucune de ces exceptions ne puisse être levée.
-try:
-    from electricore_client import ContractVersionError, IngestionEnCours
-    from electricore_client.exceptions import PreconditionNonRemplie
-except ImportError:  # pragma: no cover - paquet optionnel ; la fabrique lève avant tout mapping
-
-    class ContractVersionError(Exception):
-        """Repli si `electricore_client` est absent : jamais levée en pratique."""
-
-    class IngestionEnCours(Exception):
-        """Repli si `electricore_client` est absent : jamais levée en pratique."""
-
-    class PreconditionNonRemplie(Exception):
-        """Repli si `electricore_client` est absent : jamais levée en pratique."""
+from .electricore_client_fabrique import ContractVersionError, IngestionEnCours, PreconditionNonRemplie
 
 
 class SouscriptionChronologieLigne(models.Model):

--- a/models/core/souscription_refacturation.py
+++ b/models/core/souscription_refacturation.py
@@ -3,24 +3,10 @@ import logging
 from odoo import _, api, fields, models
 from odoo.exceptions import UserError
 
-# Garde d'import minimale (ADR 0024) : seules les exceptions du mapping de ce
-# module sont importées ici — la construction du client (garde + drapeau +
-# config) vit dans la fabrique. Si le paquet est absent, la fabrique lève
-# avant qu'aucune de ces exceptions ne puisse être levée.
-try:
-    from electricore_client import ContractVersionError, IngestionEnCours
-    from electricore_client.exceptions import PreconditionNonRemplie
-except ImportError:  # pragma: no cover - paquet optionnel ; la fabrique lève avant tout mapping
-
-    class ContractVersionError(Exception):
-        """Repli si `electricore_client` est absent : jamais levée en pratique."""
-
-    class IngestionEnCours(Exception):
-        """Repli si `electricore_client` est absent : jamais levée en pratique."""
-
-    class PreconditionNonRemplie(Exception):
-        """Repli si `electricore_client` est absent : jamais levée en pratique."""
-
+# Exceptions du mapping de ce module, ré-exportées par la fabrique unique
+# (ADR 0024, #222) : la construction du client (garde + drapeau + config) vit
+# dans la fabrique, seule la correspondance d'exceptions reste ici.
+from .electricore_client_fabrique import ContractVersionError, IngestionEnCours, PreconditionNonRemplie
 
 _logger = logging.getLogger(__name__)
 

--- a/models/wizard/souscription_pull_meta_periodes_wizard.py
+++ b/models/wizard/souscription_pull_meta_periodes_wizard.py
@@ -6,7 +6,7 @@ Brancher le seam décidé : l'addon consomme le paquet `electricore-client`
 la fabrique unique `souscription.electricore.client` (ADR 0024) : ce module
 ne porte plus ni garde d'import du client, ni drapeau de disponibilité, ni
 lecture de config — seuls son propre appel d'endpoint (`meta_periodes` en
-flux) et son mapping d'exceptions.
+flux) et son mapping d'exceptions, ré-exportées par la fabrique (#222).
 """
 
 from __future__ import annotations
@@ -16,23 +16,7 @@ from datetime import timedelta
 from odoo import api, fields, models
 from odoo.exceptions import UserError
 
-# Garde d'import minimale (ADR 0024) : seules les exceptions du mapping de ce
-# wizard sont importées ici — la construction du client (garde + drapeau +
-# config) vit dans la fabrique. Si le paquet est absent, la fabrique lève
-# avant qu'aucune de ces exceptions ne puisse être levée.
-try:
-    from electricore_client import ContractVersionError, IngestionEnCours
-    from electricore_client.exceptions import PreconditionNonRemplie
-except ImportError:  # pragma: no cover - paquet optionnel ; la fabrique lève avant tout mapping
-
-    class ContractVersionError(Exception):
-        """Repli si `electricore_client` est absent : jamais levée en pratique."""
-
-    class IngestionEnCours(Exception):
-        """Repli si `electricore_client` est absent : jamais levée en pratique."""
-
-    class PreconditionNonRemplie(Exception):
-        """Repli si `electricore_client` est absent : jamais levée en pratique."""
+from ..core.electricore_client_fabrique import ContractVersionError, IngestionEnCours, PreconditionNonRemplie
 
 
 class SouscriptionPullMetaPeriodesWizard(models.TransientModel):

--- a/tests/common.py
+++ b/tests/common.py
@@ -2,9 +2,64 @@
 Helpers et mixins communs pour les tests du module souscriptions.
 """
 
+from contextlib import contextmanager
 from datetime import date
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
 
+from odoo.addons.souscriptions_odoo.models.core import electricore_client_fabrique as _fabrique_module
 from odoo.tests.common import TransactionCase
+
+# --- Couture de test electricore (ADR 0024 §6, #222) ---
+#
+# Aucun faux transport complet : on patche soit la méthode de transport
+# NOMMÉE de l'appelant (`_appeler`, `_tirer_prestations`...), soit — pour les
+# endpoints en flux (meta_periodes/chronologie) — le client rendu par la
+# fabrique unique. Partagé par toutes les suites d'endpoint (résolution RSC,
+# pull méta-périodes, sync F15, chronologie).
+
+
+def patcher_transport(model_cls, method_name, *, return_value=None, side_effect=None):
+    """Patch de la méthode de transport nommée d'un appelant — la couture de
+    test décidée par ADR 0024 §6. Seul le point qui parle réseau est
+    remplacé ; mapping et écriture restent réels."""
+    return patch.object(model_cls, method_name, return_value=return_value, side_effect=side_effect)
+
+
+def patcher_client_fabrique(client):
+    """Patch la fabrique unique (`souscription.electricore.client`, ADR 0024)
+    pour qu'elle rende `client` sans construire de vrai client ni lire la
+    config — la garde paquet/config est testée une fois dans
+    test_electricore_client_fabrique.py, jamais re-testée par les suites
+    d'endpoint."""
+    return patch.object(_fabrique_module.SouscriptionElectricoreClient, 'client', return_value=client)
+
+
+@contextmanager
+def flux_electricore(items):
+    """Mime un `JsonlStream` electricore : context manager itérable à usage
+    unique (cf. electricore_client.streaming.JsonlStream)."""
+    yield iter(items)
+
+
+def client_flux_factice(endpoint, items=(), *, leve=None):
+    """Client electricore factice dont l'unique endpoint en flux (`meta_periodes`
+    ou `chronologie`) rend `items`, ou lève `leve` — à l'ouverture, à chaque
+    appel (`side_effect`, jamais `return_value` : un flux est à usage unique,
+    un `MagicMock` en `return_value` casse un 2ᵉ appel, #158)."""
+    client = MagicMock()
+    method = getattr(client, endpoint)
+    if leve is not None:
+        method.side_effect = leve
+    else:
+        method.side_effect = lambda *args, **kwargs: flux_electricore(items)
+    return client
+
+
+def resultat_rsc(id_affaire, rsc=None, error=None):
+    """Stub duck-typé de `ResultatResolutionRsc` (contrat RSC, xor rsc/error)."""
+    return SimpleNamespace(id_affaire=id_affaire, ref_situation_contractuelle=rsc, error=error)
+
 
 # Tarif d'abonnement affine (ADR 0018) : base 3 kVA + coefficient par kVA.
 # prix_an(P) = base + coef * (P - 3)

--- a/tests/test_campagne_etapes_actions.py
+++ b/tests/test_campagne_etapes_actions.py
@@ -9,17 +9,15 @@ exactement comme dans ces suites. Créer/émettre factures délèguent à
 Dates dans la couverture de la grille de prix fixture (2024, tests/common.py).
 """
 
-from contextlib import contextmanager
 from datetime import date
 from types import SimpleNamespace
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
-from odoo.addons.souscriptions_odoo.models.core import electricore_client_fabrique as fabrique_module
 from odoo.addons.souscriptions_odoo.models.core import souscription_refacturation as refacturation_module
 from odoo.exceptions import UserError
 from odoo.tests.common import tagged
 
-from .common import SouscriptionsTestCase
+from .common import SouscriptionsTestCase, client_flux_factice, patcher_client_fabrique, patcher_transport
 
 
 def _periode_meta(**kwargs):
@@ -50,21 +48,6 @@ def _periode_meta(**kwargs):
     return SimpleNamespace(**base)
 
 
-@contextmanager
-def _stream(metas):
-    yield iter(metas)
-
-
-def _fake_electricore_client(metas=()):
-    client = MagicMock()
-    # Un @contextmanager est à usage unique. Le vrai client rend un flux frais à
-    # chaque appel de meta_periodes() ; on le mime avec side_effect (rappelé par
-    # appel) et non return_value (une seule instance réutilisée → le 2e run du
-    # test d'idempotence ré-entrait un CM déjà consommé → AttributeError, #158).
-    client.meta_periodes.side_effect = lambda *args, **kwargs: _stream(metas)
-    return client
-
-
 @tagged('souscriptions', 'souscriptions_campagne', 'post_install', '-at_install')
 class TestCampagneEtapePullMetaPeriodes(SouscriptionsTestCase):
     MOIS = date(2024, 3, 1)
@@ -80,8 +63,8 @@ class TestCampagneEtapePullMetaPeriodes(SouscriptionsTestCase):
         """AC #176 : le bouton n'ouvre plus de fenêtre — il tire directement
         (Périmètre de campagne du mois) et retourne un toast, pas une
         ouverture de fenêtre."""
-        client = _fake_electricore_client([_periode_meta()])
-        with patch.object(fabrique_module.SouscriptionElectricoreClient, 'client', return_value=client):
+        client = client_flux_factice('meta_periodes', [_periode_meta()])
+        with patcher_client_fabrique(client):
             action = self.campagne.action_pull_meta_periodes()
 
         self.assertEqual(action['type'], 'ir.actions.client')
@@ -103,8 +86,8 @@ class TestCampagneEtapePullMetaPeriodes(SouscriptionsTestCase):
         n'interrompt pas le lot, apparaît au compteur d'erreurs, et rend le
         toast sticky."""
         meta_invalide = _periode_meta(debut=None)  # déclenche une erreur de mapping (Date invalide)
-        client = _fake_electricore_client([meta_invalide])
-        with patch.object(fabrique_module.SouscriptionElectricoreClient, 'client', return_value=client):
+        client = client_flux_factice('meta_periodes', [meta_invalide])
+        with patcher_client_fabrique(client):
             action = self.campagne.action_pull_meta_periodes()
 
         params = action['params']
@@ -115,9 +98,9 @@ class TestCampagneEtapePullMetaPeriodes(SouscriptionsTestCase):
     def test_pull_idempotent_via_la_campagne(self):
         """AC #176 : rejouer le pull deux fois ne double pas la période
         (create-missing-only préservé, #77/#158)."""
-        client = _fake_electricore_client([_periode_meta()])
+        client = client_flux_factice('meta_periodes', [_periode_meta()])
         for _run in range(2):
-            with patch.object(fabrique_module.SouscriptionElectricoreClient, 'client', return_value=client):
+            with patcher_client_fabrique(client):
                 self.campagne.action_pull_meta_periodes()
 
         periode = self.env['souscription.periode'].search(
@@ -129,8 +112,8 @@ class TestCampagneEtapePullMetaPeriodes(SouscriptionsTestCase):
         """`action_executer` de la ligne d'étape « pull » délègue à
         `campagne.action_pull_meta_periodes` — un seul point de dispatch (#158)."""
         etape = self.campagne.etape_ids.filtered(lambda e: e.code == 'pull_meta_periodes')
-        client = _fake_electricore_client([])
-        with patch.object(fabrique_module.SouscriptionElectricoreClient, 'client', return_value=client):
+        client = client_flux_factice('meta_periodes', [])
+        with patcher_client_fabrique(client):
             action = etape.action_executer()
         self.assertEqual(action['tag'], 'display_notification')
 
@@ -138,8 +121,8 @@ class TestCampagneEtapePullMetaPeriodes(SouscriptionsTestCase):
         """Non-régression : le wizard « Récupérer les périodes du mois » et
         son bouton d'en-tête restent inchangés (chemin secondaire, #176)."""
         wizard = self.env['souscription.pull.meta.periodes.wizard'].create({'mois': self.MOIS})
-        client = _fake_electricore_client([_periode_meta()])
-        with patch.object(fabrique_module.SouscriptionElectricoreClient, 'client', return_value=client):
+        client = client_flux_factice('meta_periodes', [_periode_meta()])
+        with patcher_client_fabrique(client):
             action = wizard.action_lancer()
 
         self.assertEqual(action['type'], 'ir.actions.act_window')
@@ -154,7 +137,7 @@ class TestCampagneEtapeSyncF15(SouscriptionsTestCase):
     def setUp(self):
         super().setUp()
         self.fake_client = MagicMock(url='https://electricore.example.test', api_key='fake-api-key')
-        patcher = patch.object(fabrique_module.SouscriptionElectricoreClient, 'client', return_value=self.fake_client)
+        patcher = patcher_client_fabrique(self.fake_client)
         patcher.start()
         self.addCleanup(patcher.stop)
         self.souscription_base.with_context(rsc_automatisme=True).write(
@@ -175,7 +158,9 @@ class TestCampagneEtapeSyncF15(SouscriptionsTestCase):
             'prix_unitaire': 30.37,
             'quantite': 1.0,
         }
-        with patch.object(refacturation_module.SouscriptionRefacturation, '_tirer_prestations', return_value=[ligne]):
+        with patcher_transport(
+            refacturation_module.SouscriptionRefacturation, '_tirer_prestations', return_value=[ligne]
+        ):
             self.campagne.action_sync_f15()
 
         presta = self.env['souscription.refacturation'].search([('reference', '=', 'F15-CAMPAGNE-001')])
@@ -183,7 +168,7 @@ class TestCampagneEtapeSyncF15(SouscriptionsTestCase):
 
     def test_bouton_generique_dispatch_vers_sync_f15(self):
         etape = self.campagne.etape_ids.filtered(lambda e: e.code == 'sync_f15')
-        with patch.object(refacturation_module.SouscriptionRefacturation, '_tirer_prestations', return_value=[]):
+        with patcher_transport(refacturation_module.SouscriptionRefacturation, '_tirer_prestations', return_value=[]):
             action = etape.action_executer()
         self.assertEqual(action['type'], 'ir.actions.client')
 
@@ -195,7 +180,7 @@ class TestCampagneEtapeSyncF15(SouscriptionsTestCase):
         self.assertFalse(sync.fait)
         self.assertEqual(verif.etat_prerequis, 'bloquee')
 
-        with patch.object(refacturation_module.SouscriptionRefacturation, '_tirer_prestations', return_value=[]):
+        with patcher_transport(refacturation_module.SouscriptionRefacturation, '_tirer_prestations', return_value=[]):
             sync.action_executer()
         self.campagne.etape_ids.invalidate_recordset()
 

--- a/tests/test_chronologie.py
+++ b/tests/test_chronologie.py
@@ -11,16 +11,13 @@ Deux tranches, même découpage que `test_pull_meta_periodes.py` :
 Fixtures RSC/PDL : identifiants factices (jamais des vrais échantillons).
 """
 
-from contextlib import contextmanager
 from types import SimpleNamespace
-from unittest.mock import MagicMock, patch
 
-from odoo.addons.souscriptions_odoo.models.core import electricore_client_fabrique as fabrique_module
 from odoo.addons.souscriptions_odoo.models.core import souscription_chronologie as chronologie_module
 from odoo.exceptions import UserError
 from odoo.tests.common import tagged
 
-from .common import SouscriptionsTestCase
+from .common import SouscriptionsTestCase, client_flux_factice, patcher_client_fabrique
 
 
 def _ligne_evenement(**kwargs):
@@ -147,68 +144,30 @@ class TestValsDepuisLigne(SouscriptionsTestCase):
 
 # === Bouton « Chronologie » : client mocké ===
 #
-# Exceptions factices mirant exactement les noms/sémantiques d'
-# electricore_client.exceptions (le paquet réel peut être absent du sandbox
-# d'exécution des tests ; le module ne les utilise que par leur nom importé,
-# patché ci-dessous).
-
-
-class _FakeIngestionEnCours(Exception):
-    pass
-
-
-class _FakePreconditionNonRemplie(Exception):
-    pass
-
-
-class _FakeContractVersionError(Exception):
-    pass
-
-
-@contextmanager
-def _stream(lignes):
-    """Mime `JsonlStream` : context manager itérable."""
-    yield iter(lignes)
-
-
-def _fake_client(lignes=(), *, leve=None):
-    """Client factice : `.chronologie(rsc=)` renvoie un flux (context
-    manager) qui itère `lignes`, ou lève `leve` à l'ouverture."""
-    client = MagicMock()
-    if leve is not None:
-        client.chronologie.side_effect = leve
-    else:
-        client.chronologie.return_value = _stream(lignes)
-    return client
+# Les exceptions levées sont les vraies classes du module chronologie
+# (réelles si electricore_client est présent, stubs de la fabrique sinon,
+# ADR 0024/#222) : aucun échange de symbole par patch.
 
 
 @tagged('souscriptions', 'souscriptions_chronologie', 'post_install', '-at_install')
 class TestActionOuvrirChronologie(SouscriptionsTestCase):
     def setUp(self):
         super().setUp()
-        patcher_exc = patch.multiple(
-            chronologie_module,
-            IngestionEnCours=_FakeIngestionEnCours,
-            PreconditionNonRemplie=_FakePreconditionNonRemplie,
-            ContractVersionError=_FakeContractVersionError,
-        )
-        patcher_exc.start()
-        self.addCleanup(patcher_exc.stop)
         self.souscription_base.ref_situation_contractuelle = 'RSC-00000000000001'
 
     def _cliquer_avec_client(self, client, souscription=None):
         """Clique le bouton avec un client factice fourni directement par la
         fabrique (ADR 0024) : la garde paquet/config de la fabrique est
         testée une fois dans test_electricore_client_fabrique.py, pas ici."""
-        with patch.object(fabrique_module.SouscriptionElectricoreClient, 'client', return_value=client):
+        with patcher_client_fabrique(client):
             return (souscription or self.souscription_base).action_ouvrir_chronologie()
 
     def test_sans_rsc_leve_userror_actionnable(self):
         """AC : sans RSC, UserError actionnable renvoyant vers la résolution
         RSC — pas de repli pdl (aucun appel au client)."""
         self.souscription_base.ref_situation_contractuelle = False
-        client = _fake_client([])
-        with patch.object(fabrique_module.SouscriptionElectricoreClient, 'client', return_value=client):
+        client = client_flux_factice('chronologie', [])
+        with patcher_client_fabrique(client):
             with self.assertRaises(UserError) as cm:
                 self.souscription_base.action_ouvrir_chronologie()
         self.assertIn('RSC', str(cm.exception))
@@ -218,7 +177,7 @@ class TestActionOuvrirChronologie(SouscriptionsTestCase):
         """AC : les 3 types de lignes sont créés, scopés sur la souscription,
         au grain RSC (jamais pdl)."""
         lignes = [_ligne_evenement(), _ligne_releve(), _ligne_periode_energie()]
-        client = _fake_client(lignes)
+        client = client_flux_factice('chronologie', lignes)
 
         action = self._cliquer_avec_client(client)
 
@@ -236,7 +195,7 @@ class TestActionOuvrirChronologie(SouscriptionsTestCase):
         """AC : chaque clic purge et recrée les lignes de la souscription —
         pas de doublons, l'ancien contenu disparaît."""
         premier_lot = [_ligne_evenement(date='2024-01-01')]
-        self._cliquer_avec_client(_fake_client(premier_lot))
+        self._cliquer_avec_client(client_flux_factice('chronologie', premier_lot))
         premiere_ligne = self.env['souscription.chronologie.ligne'].search(
             [('souscription_id', '=', self.souscription_base.id)]
         )
@@ -244,7 +203,7 @@ class TestActionOuvrirChronologie(SouscriptionsTestCase):
         premier_id = premiere_ligne.id
 
         second_lot = [_ligne_releve(date='2024-02-01'), _ligne_periode_energie(date='2024-02-01')]
-        self._cliquer_avec_client(_fake_client(second_lot))
+        self._cliquer_avec_client(client_flux_factice('chronologie', second_lot))
 
         apres = self.env['souscription.chronologie.ligne'].search([('souscription_id', '=', self.souscription_base.id)])
         self.assertEqual(len(apres), 2, 'Le premier lot doit avoir été purgé, pas cumulé')
@@ -256,13 +215,13 @@ class TestActionOuvrirChronologie(SouscriptionsTestCase):
         autre = self.souscription_hphc
         autre.ref_situation_contractuelle = 'RSC-00000000000099'
         self._cliquer_avec_client(
-            _fake_client([_ligne_evenement(ref_situation_contractuelle='RSC-00000000000099')]),
+            client_flux_factice('chronologie', [_ligne_evenement(ref_situation_contractuelle='RSC-00000000000099')]),
             souscription=autre,
         )
         ligne_autre = self.env['souscription.chronologie.ligne'].search([('souscription_id', '=', autre.id)])
         self.assertEqual(len(ligne_autre), 1)
 
-        self._cliquer_avec_client(_fake_client([_ligne_releve()]))
+        self._cliquer_avec_client(client_flux_factice('chronologie', [_ligne_releve()]))
 
         self.assertEqual(
             self.env['souscription.chronologie.ligne'].search_count([('souscription_id', '=', autre.id)]),
@@ -271,19 +230,23 @@ class TestActionOuvrirChronologie(SouscriptionsTestCase):
         )
 
     def test_ingestion_en_cours_mappee_en_userror_reessayable(self):
-        client = _fake_client(leve=_FakeIngestionEnCours('verrou'))
+        client = client_flux_factice('chronologie', leve=chronologie_module.IngestionEnCours('verrou'))
         with self.assertRaises(UserError) as cm:
             self._cliquer_avec_client(client)
         self.assertIn('plus tard', str(cm.exception))
 
     def test_precondition_non_remplie_mappee_en_userror_actionnable(self):
-        client = _fake_client(leve=_FakePreconditionNonRemplie('réconciliez les RSC avant de facturer'))
+        client = client_flux_factice(
+            'chronologie', leve=chronologie_module.PreconditionNonRemplie('réconciliez les RSC avant de facturer')
+        )
         with self.assertRaises(UserError) as cm:
             self._cliquer_avec_client(client)
         self.assertIn('réconciliez les RSC', str(cm.exception))
 
     def test_contract_version_error_mappee_en_userror(self):
-        client = _fake_client(leve=_FakeContractVersionError('serveur v2 < attendu v3'))
+        client = client_flux_factice(
+            'chronologie', leve=chronologie_module.ContractVersionError('serveur v2 < attendu v3')
+        )
         with self.assertRaises(UserError) as cm:
             self._cliquer_avec_client(client)
         self.assertIn('v2', str(cm.exception))
@@ -291,14 +254,16 @@ class TestActionOuvrirChronologie(SouscriptionsTestCase):
     def test_erreur_ne_purge_pas_les_lignes_dun_clic_precedent(self):
         """Le flux est matérialisé avant toute écriture (#200) : une erreur
         réseau/contrat n'efface jamais un affichage déjà réussi."""
-        self._cliquer_avec_client(_fake_client([_ligne_evenement()]))
+        self._cliquer_avec_client(client_flux_factice('chronologie', [_ligne_evenement()]))
         avant = self.env['souscription.chronologie.ligne'].search_count(
             [('souscription_id', '=', self.souscription_base.id)]
         )
         self.assertEqual(avant, 1)
 
         with self.assertRaises(UserError):
-            self._cliquer_avec_client(_fake_client(leve=_FakeIngestionEnCours('verrou')))
+            self._cliquer_avec_client(
+                client_flux_factice('chronologie', leve=chronologie_module.IngestionEnCours('verrou'))
+            )
 
         apres = self.env['souscription.chronologie.ligne'].search_count(
             [('souscription_id', '=', self.souscription_base.id)]

--- a/tests/test_poll_affaires_enedis.py
+++ b/tests/test_poll_affaires_enedis.py
@@ -2,19 +2,17 @@
 motifs, grâce de 3 jours, alertes sans spam, résolution en cours de vie,
 échec réseau silencieux (ADR 0021 §3-4).
 
-Réutilise la couture de #88 : on patche `_appeler`, la méthode transport du
-service RSC, avec des réponses en boîte. La grâce est testée en antidatant
-`id_affaire_date_saisie` — pas de mock du temps.
+Réutilise la couture de #88 (socle commun #222) : on patche `_appeler`, la
+méthode transport du service RSC, avec des réponses en boîte. La grâce est
+testée en antidatant `id_affaire_date_saisie` — pas de mock du temps.
 """
 
 from datetime import date, timedelta
-from types import SimpleNamespace
-from unittest.mock import patch
 
 from odoo.addons.souscriptions_odoo.models.core import electricore_rsc_service as service_module
 from odoo.tests.common import tagged
 
-from .common import SouscriptionsTestCase
+from .common import SouscriptionsTestCase, patcher_transport, resultat_rsc
 
 _SERVICE = service_module.SouscriptionRscService
 
@@ -23,15 +21,12 @@ _MOTIF_SANS_C15 = (
 )
 
 
-def _resultat(id_affaire, rsc=None, error=None):
-    return SimpleNamespace(id_affaire=id_affaire, ref_situation_contractuelle=rsc, error=error)
+def _patch_appeler(return_value=None, side_effect=None):
+    return patcher_transport(_SERVICE, '_appeler', return_value=return_value, side_effect=side_effect)
 
 
 @tagged('souscriptions', 'souscriptions_poll_rsc', 'post_install', '-at_install')
 class TestPollAffairesEnedis(SouscriptionsTestCase):
-    def _patch_appeler(self, return_value=None, side_effect=None):
-        return patch.object(_SERVICE, '_appeler', return_value=return_value, side_effect=side_effect)
-
     def create_demande_avec_souscription(self, id_affaire=None, email='poll-rsc@example.com'):
         """Demande complète menée jusqu'à « Accepté et IBAN vérifié » (#101 —
         naissance de la Souscription) : mode virement, pas de garde IBAN à
@@ -91,10 +86,10 @@ class TestPollAffairesEnedis(SouscriptionsTestCase):
             }
         )
 
-        with self._patch_appeler(
+        with _patch_appeler(
             return_value=[
-                _resultat('AFF-CIBLE-1', error=_MOTIF_SANS_C15),
-                _resultat('AFF-CIBLE-2', error=_MOTIF_SANS_C15),
+                resultat_rsc('AFF-CIBLE-1', error=_MOTIF_SANS_C15),
+                resultat_rsc('AFF-CIBLE-2', error=_MOTIF_SANS_C15),
             ]
         ) as mock_appeler:
             self.env['souscription.souscription']._cron_poll_affaires_enedis()
@@ -109,7 +104,7 @@ class TestPollAffairesEnedis(SouscriptionsTestCase):
     def test_lot_vide_naboutit_pas_a_un_appel(self):
         self.assertFalse(self.souscription_base.id_affaire)
         self.assertFalse(self.souscription_hphc.id_affaire)
-        with self._patch_appeler() as mock_appeler:
+        with _patch_appeler() as mock_appeler:
             self.env['souscription.souscription']._cron_poll_affaires_enedis()
         mock_appeler.assert_not_called()
 
@@ -120,7 +115,7 @@ class TestPollAffairesEnedis(SouscriptionsTestCase):
         demande = self.create_demande_avec_souscription(id_affaire='AFF-SILENCE')
         souscription = demande.souscription_id
 
-        with self._patch_appeler(return_value=[_resultat('AFF-SILENCE', error=_MOTIF_SANS_C15)]):
+        with _patch_appeler(return_value=[resultat_rsc('AFF-SILENCE', error=_MOTIF_SANS_C15)]):
             self.env['souscription.souscription']._cron_poll_affaires_enedis()
 
         self.assertEqual(souscription.motif_resolution_rsc, _MOTIF_SANS_C15)
@@ -133,7 +128,7 @@ class TestPollAffairesEnedis(SouscriptionsTestCase):
         demande = self.create_demande_avec_souscription(id_affaire='AFF-AMBIGUE')
         motif = "Résolution ambiguë : 2 situations contractuelles pour l'affaire AFF-AMBIGUE (X, Y)."
 
-        with self._patch_appeler(return_value=[_resultat('AFF-AMBIGUE', error=motif)]):
+        with _patch_appeler(return_value=[resultat_rsc('AFF-AMBIGUE', error=motif)]):
             self.env['souscription.souscription']._cron_poll_affaires_enedis()
 
         self.assertEqual(demande.kanban_state, 'blocked')
@@ -145,7 +140,7 @@ class TestPollAffairesEnedis(SouscriptionsTestCase):
         souscription = demande.souscription_id
         souscription.write({'id_affaire_date_saisie': date.today() - timedelta(days=3)})
 
-        with self._patch_appeler(return_value=[_resultat('AFF-GRACE', error='Affaire inconnue : AFF-GRACE')]):
+        with _patch_appeler(return_value=[resultat_rsc('AFF-GRACE', error='Affaire inconnue : AFF-GRACE')]):
             self.env['souscription.souscription']._cron_poll_affaires_enedis()
 
         self.assertEqual(demande.kanban_state, 'normal')
@@ -157,8 +152,8 @@ class TestPollAffairesEnedis(SouscriptionsTestCase):
         souscription = demande.souscription_id
         souscription.write({'id_affaire_date_saisie': date.today() - timedelta(days=4)})
 
-        with self._patch_appeler(
-            return_value=[_resultat('AFF-GRACE-EXPIREE', error='Affaire inconnue : AFF-GRACE-EXPIREE')]
+        with _patch_appeler(
+            return_value=[resultat_rsc('AFF-GRACE-EXPIREE', error='Affaire inconnue : AFF-GRACE-EXPIREE')]
         ):
             self.env['souscription.souscription']._cron_poll_affaires_enedis()
 
@@ -171,7 +166,7 @@ class TestPollAffairesEnedis(SouscriptionsTestCase):
         demande = self.create_demande_avec_souscription(id_affaire='AFF-SPAM')
         motif = "Résolution ambiguë : 2 situations contractuelles pour l'affaire AFF-SPAM (X, Y)."
 
-        with self._patch_appeler(return_value=[_resultat('AFF-SPAM', error=motif)]):
+        with _patch_appeler(return_value=[resultat_rsc('AFF-SPAM', error=motif)]):
             self.env['souscription.souscription']._cron_poll_affaires_enedis()
             self.env['souscription.souscription']._cron_poll_affaires_enedis()
 
@@ -184,12 +179,12 @@ class TestPollAffairesEnedis(SouscriptionsTestCase):
         souscription = demande.souscription_id
         motif = "Résolution ambiguë : 2 situations contractuelles pour l'affaire AFF-RESOUT (X, Y)."
 
-        with self._patch_appeler(return_value=[_resultat('AFF-RESOUT', error=motif)]):
+        with _patch_appeler(return_value=[resultat_rsc('AFF-RESOUT', error=motif)]):
             self.env['souscription.souscription']._cron_poll_affaires_enedis()
         self.assertEqual(demande.kanban_state, 'blocked')
         self.assertEqual(len(demande.activity_ids), 1)
 
-        with self._patch_appeler(return_value=[_resultat('AFF-RESOUT', rsc='RSC-RESOLUE')]):
+        with _patch_appeler(return_value=[resultat_rsc('AFF-RESOUT', rsc='RSC-RESOLUE')]):
             self.env['souscription.souscription']._cron_poll_affaires_enedis()
 
         self.assertEqual(souscription.ref_situation_contractuelle, 'RSC-RESOLUE')
@@ -208,7 +203,7 @@ class TestPollAffairesEnedis(SouscriptionsTestCase):
         )
         motif = "Résolution ambiguë : 2 situations contractuelles pour l'affaire AFF-SANS-DEMANDE (X, Y)."
 
-        with self._patch_appeler(return_value=[_resultat('AFF-SANS-DEMANDE', error=motif)]):
+        with _patch_appeler(return_value=[resultat_rsc('AFF-SANS-DEMANDE', error=motif)]):
             self.env['souscription.souscription']._cron_poll_affaires_enedis()
 
         self.assertEqual(len(souscription.activity_ids), 1)
@@ -219,7 +214,7 @@ class TestPollAffairesEnedis(SouscriptionsTestCase):
         demande = self.create_demande_avec_souscription(id_affaire='AFF-RESEAU')
         souscription = demande.souscription_id
 
-        with self._patch_appeler(side_effect=ConnectionError('timeout')):
+        with _patch_appeler(side_effect=ConnectionError('timeout')):
             self.env['souscription.souscription']._cron_poll_affaires_enedis()
 
         self.assertEqual(souscription.etat, 'en_instance')

--- a/tests/test_pull_meta_periodes.py
+++ b/tests/test_pull_meta_periodes.py
@@ -12,17 +12,15 @@ Fixtures RSC/PDL : identifiants factices (jamais des vrais échantillons).
 """
 
 import unittest
-from contextlib import contextmanager
 from datetime import date, timedelta
 from types import SimpleNamespace
-from unittest.mock import MagicMock, patch
 
 from odoo.addons.souscriptions_odoo.models.core import electricore_client_fabrique as fabrique_module
 from odoo.addons.souscriptions_odoo.models.wizard import souscription_pull_meta_periodes_wizard as wizard_module
 from odoo.exceptions import UserError
 from odoo.tests.common import tagged
 
-from .common import SouscriptionsTestCase
+from .common import SouscriptionsTestCase, client_flux_factice, patcher_client_fabrique
 
 
 def _objet_releve(**kwargs):
@@ -182,55 +180,14 @@ class TestAmorcerDepuisMeta(SouscriptionsTestCase):
 
 # === Wizard « Récupérer les périodes du mois » : client mocké ===
 #
-# Exceptions factices mirant exactement les noms/sémantiques d'
-# electricore_client.exceptions (le paquet réel peut être absent du sandbox
-# d'exécution des tests ; le module wizard ne les utilise que par leur nom
-# importé, patché ci-dessous).
-
-
-class _FakeIngestionEnCours(Exception):
-    pass
-
-
-class _FakePreconditionNonRemplie(Exception):
-    pass
-
-
-class _FakeContractVersionError(Exception):
-    pass
-
-
-@contextmanager
-def _stream(metas):
-    """Mime `JsonlStream` : context manager itérable, cf.
-    electricore_client.streaming.JsonlStream."""
-    yield iter(metas)
-
-
-def _fake_client(metas=(), *, leve=None):
-    """Client factice : `.meta_periodes(mois=, rsc=)` renvoie un flux
-    (context manager) qui itère `metas`, ou lève `leve` à l'ouverture."""
-    client = MagicMock()
-    if leve is not None:
-        client.meta_periodes.side_effect = leve
-    else:
-        client.meta_periodes.return_value = _stream(metas)
-    return client
+# Les exceptions levées sont les vraies classes du module wizard (réelles si
+# electricore_client est présent, stubs de la fabrique sinon, ADR 0024/#222) :
+# aucun échange de symbole par patch, `except IngestionEnCours` du wizard
+# attrape exactement ce qui est instancié ici.
 
 
 @tagged('souscriptions', 'souscriptions_pull_meta', 'post_install', '-at_install')
 class TestWizardPullMetaPeriodes(SouscriptionsTestCase):
-    def setUp(self):
-        super().setUp()
-        patcher_exc = patch.multiple(
-            wizard_module,
-            IngestionEnCours=_FakeIngestionEnCours,
-            PreconditionNonRemplie=_FakePreconditionNonRemplie,
-            ContractVersionError=_FakeContractVersionError,
-        )
-        patcher_exc.start()
-        self.addCleanup(patcher_exc.stop)
-
     def _wizard(self, mois=date(2024, 1, 1)):
         return self.env['souscription.pull.meta.periodes.wizard'].create({'mois': mois})
 
@@ -239,7 +196,7 @@ class TestWizardPullMetaPeriodes(SouscriptionsTestCase):
         fabrique (ADR 0024) : la garde paquet/config de la fabrique est
         testée une fois dans test_electricore_client_fabrique.py, pas ici."""
         wizard = self._wizard(mois)
-        with patch.object(fabrique_module.SouscriptionElectricoreClient, 'client', return_value=client):
+        with patcher_client_fabrique(client):
             wizard.action_lancer()
         return wizard
 
@@ -252,7 +209,7 @@ class TestWizardPullMetaPeriodes(SouscriptionsTestCase):
             debut='2024-01-01',
             fin='2024-02-01',
         )
-        client = _fake_client([meta])
+        client = client_flux_factice('meta_periodes', [meta])
 
         wizard = self._lancer_avec_client(client)
 
@@ -279,7 +236,7 @@ class TestWizardPullMetaPeriodes(SouscriptionsTestCase):
             fin='2024-02-01',
             cta_eur=999.0,
         )
-        wizard = self._lancer_avec_client(_fake_client([meta]))
+        wizard = self._lancer_avec_client(client_flux_factice('meta_periodes', [meta]))
 
         self.assertEqual(existante.cta_eur, 1.23)
         self.assertIn('Déjà existantes : 1', wizard.resultat)
@@ -288,7 +245,7 @@ class TestWizardPullMetaPeriodes(SouscriptionsTestCase):
     def test_resume_les_souscriptions_sans_rsc(self):
         """AC3 : résumé skip-and-report — souscriptions sans RSC comptées à part."""
         self.assertFalse(self.souscription_hphc.ref_situation_contractuelle)
-        wizard = self._lancer_avec_client(_fake_client([]))
+        wizard = self._lancer_avec_client(client_flux_factice('meta_periodes', []))
         self.assertIn('Sans RSC (ignorées) :', wizard.resultat)
         self.assertNotIn('Sans RSC (ignorées) : 0', wizard.resultat)
 
@@ -317,7 +274,7 @@ class TestWizardPullMetaPeriodes(SouscriptionsTestCase):
         self.assertTrue(souscription, "La Souscription devrait naître à l'acceptation")
         self.assertEqual(souscription.etat, 'en_instance')
 
-        wizard = self._lancer_avec_client(_fake_client([]))
+        wizard = self._lancer_avec_client(client_flux_factice('meta_periodes', []))
 
         self.assertIn(souscription.name, wizard.resultat)
         periode = self.env['souscription.periode'].search([('souscription_id', '=', souscription.id)])
@@ -332,7 +289,7 @@ class TestWizardPullMetaPeriodes(SouscriptionsTestCase):
             fin='2024-02-01',
             releves_utilises=[_objet_releve(releve_id='ELC-999', origine_releve='flux_R151')],
         )
-        self._lancer_avec_client(_fake_client([meta]))
+        self._lancer_avec_client(client_flux_factice('meta_periodes', [meta]))
 
         releve = self.env['souscription.releve'].search([('releve_externe_id', '=', 'ELC-999')])
         self.assertEqual(len(releve), 1)
@@ -347,13 +304,13 @@ class TestWizardPullMetaPeriodes(SouscriptionsTestCase):
             debut=None,  # déclenche une erreur de mapping (Date invalide)
             fin='2024-02-01',
         )
-        wizard = self._lancer_avec_client(_fake_client([meta_invalide]))
+        wizard = self._lancer_avec_client(client_flux_factice('meta_periodes', [meta_invalide]))
         self.assertIn('Erreurs : 1', wizard.resultat)
 
     def test_ingestion_en_cours_mappee_en_userror_reessayable(self):
         """AC5 : IngestionEnCours -> message « réessayer plus tard »."""
         self.souscription_base.ref_situation_contractuelle = 'RSC-00000000000001'
-        client = _fake_client(leve=_FakeIngestionEnCours('verrou'))
+        client = client_flux_factice('meta_periodes', leve=wizard_module.IngestionEnCours('verrou'))
         with self.assertRaises(UserError) as cm:
             self._lancer_avec_client(client)
         self.assertIn('plus tard', str(cm.exception))
@@ -361,7 +318,9 @@ class TestWizardPullMetaPeriodes(SouscriptionsTestCase):
     def test_precondition_non_remplie_mappee_en_userror_actionnable(self):
         """AC5 : PreconditionNonRemplie -> message actionnable du serveur conservé."""
         self.souscription_base.ref_situation_contractuelle = 'RSC-00000000000001'
-        client = _fake_client(leve=_FakePreconditionNonRemplie('réconciliez les RSC avant de facturer'))
+        client = client_flux_factice(
+            'meta_periodes', leve=wizard_module.PreconditionNonRemplie('réconciliez les RSC avant de facturer')
+        )
         with self.assertRaises(UserError) as cm:
             self._lancer_avec_client(client)
         self.assertIn('réconciliez les RSC', str(cm.exception))
@@ -369,7 +328,9 @@ class TestWizardPullMetaPeriodes(SouscriptionsTestCase):
     def test_contract_version_error_mappee_en_erreur_dure(self):
         """AC5 : ContractVersionError -> erreur dure (UserError, pas de retry implicite)."""
         self.souscription_base.ref_situation_contractuelle = 'RSC-00000000000001'
-        client = _fake_client(leve=_FakeContractVersionError('serveur v2 < attendu v3'))
+        client = client_flux_factice(
+            'meta_periodes', leve=wizard_module.ContractVersionError('serveur v2 < attendu v3')
+        )
         with self.assertRaises(UserError) as cm:
             self._lancer_avec_client(client)
         self.assertIn('v2', str(cm.exception))
@@ -378,7 +339,7 @@ class TestWizardPullMetaPeriodes(SouscriptionsTestCase):
         """Aucune RSC facturable -> aucun flux n'est ouvert (pas de round-trip
         réseau inutile), même si le client est acquis en tête (fast-fail,
         ADR 0024 §5 : la construction elle-même n'ouvre aucune socket)."""
-        client = _fake_client([])
+        client = client_flux_factice('meta_periodes', [])
         wizard = self._lancer_avec_client(client)
         client.meta_periodes.assert_not_called()
         self.assertIn('Sans RSC', wizard.resultat)

--- a/tests/test_rsc_service.py
+++ b/tests/test_rsc_service.py
@@ -2,32 +2,28 @@
 « résoudre la RSC maintenant » (ADR 0021 §3, contrat figé
 `docs/contrat-rsc.md`).
 
-Couture de test du module (réutilisée par #89) : on patche `_appeler`, la
-méthode transport du service, avec des réponses en boîte mirant les quatre
-motifs du contrat RSC. Rien d'autre n'est mocké : pas de mock
-d'`electricore_client` lui-même, pas de HTTP, pas de mock du temps.
+Couture de test du module (réutilisée par #89, socle commun #222) : on
+patche `_appeler`, la méthode transport du service, avec des réponses en
+boîte mirant les quatre motifs du contrat RSC. Rien d'autre n'est mocké :
+pas de mock d'`electricore_client` lui-même, pas de HTTP, pas de mock du
+temps.
 """
 
 from datetime import date
-from types import SimpleNamespace
-from unittest.mock import patch
 
 from odoo.addons.souscriptions_odoo.models.core import electricore_rsc_service as service_module
 from odoo.exceptions import UserError
 from odoo.tests.common import tagged
 
-from .common import SouscriptionsTestCase
+from .common import SouscriptionsTestCase, patcher_transport, resultat_rsc
 
 _SERVICE_MODEL = 'souscription.rsc.service'
 
 
-class _FakeContractVersionError(Exception):
-    pass
-
-
-def _resultat(id_affaire, rsc=None, error=None):
-    """Stub duck-typé de `ResultatResolutionRsc` (xor rsc/error)."""
-    return SimpleNamespace(id_affaire=id_affaire, ref_situation_contractuelle=rsc, error=error)
+def _patch_appeler(return_value=None, side_effect=None):
+    return patcher_transport(
+        service_module.SouscriptionRscService, '_appeler', return_value=return_value, side_effect=side_effect
+    )
 
 
 @tagged('souscriptions', 'souscriptions_rsc_service', 'post_install', '-at_install')
@@ -36,13 +32,8 @@ class TestServiceRscTransport(SouscriptionsTestCase):
     lot vide, version de contrat. La garde d'import/config de la fabrique
     (ADR 0024) est testée une fois dans test_electricore_client_fabrique.py."""
 
-    def _patch_appeler(self, return_value=None, side_effect=None):
-        return patch.object(
-            service_module.SouscriptionRscService, '_appeler', return_value=return_value, side_effect=side_effect
-        )
-
     def test_lot_vide_naboutit_pas_a_un_appel(self):
-        with self._patch_appeler() as mock_appeler:
+        with _patch_appeler() as mock_appeler:
             resultat = self.env[_SERVICE_MODEL].resoudre([])
         self.assertEqual(resultat, {})
         mock_appeler.assert_not_called()
@@ -51,10 +42,10 @@ class TestServiceRscTransport(SouscriptionsTestCase):
         """Le lot est apparié par id_affaire, jamais par position : la
         réponse renvoyée dans le désordre reste correctement appariée."""
         reponse_desordonnee = [
-            _resultat('B', rsc='RSC-B'),
-            _resultat('A', rsc='RSC-A'),
+            resultat_rsc('B', rsc='RSC-B'),
+            resultat_rsc('A', rsc='RSC-A'),
         ]
-        with self._patch_appeler(return_value=reponse_desordonnee):
+        with _patch_appeler(return_value=reponse_desordonnee):
             resultat = self.env[_SERVICE_MODEL].resoudre(['A', 'B'])
         self.assertEqual(resultat['A'].ref_situation_contractuelle, 'RSC-A')
         self.assertEqual(resultat['B'].ref_situation_contractuelle, 'RSC-B')
@@ -63,18 +54,18 @@ class TestServiceRscTransport(SouscriptionsTestCase):
         """Les quatre motifs du contrat RSC (succès + 3 erreurs) traversent
         le service sans traduction, xor rsc/error."""
         reponse = [
-            _resultat('OK', rsc='RSC-001'),
-            _resultat('INCONNUE', error='Affaire inconnue : INCONNUE'),
-            _resultat(
+            resultat_rsc('OK', rsc='RSC-001'),
+            resultat_rsc('INCONNUE', error='Affaire inconnue : INCONNUE'),
+            resultat_rsc(
                 'SANS-C15',
                 error='Affaire connue (X12) sans situation contractuelle C15 '
                 '(précurseur en cours ou affaire non contractuelle).',
             ),
-            _resultat(
+            resultat_rsc(
                 'AMBIGUE', error="Résolution ambiguë : 2 situations contractuelles pour l'affaire AMBIGUE (X, Y)."
             ),
         ]
-        with self._patch_appeler(return_value=reponse):
+        with _patch_appeler(return_value=reponse):
             resultat = self.env[_SERVICE_MODEL].resoudre(['OK', 'INCONNUE', 'SANS-C15', 'AMBIGUE'])
 
         self.assertEqual(resultat['OK'].ref_situation_contractuelle, 'RSC-001')
@@ -87,10 +78,9 @@ class TestServiceRscTransport(SouscriptionsTestCase):
         """AC2 : version de contrat inattendue -> signalée (UserError), le
         service n'écrit jamais de donnée (l'exception interrompt l'appel
         avant tout accès au résultat)."""
-        with patch.object(service_module, 'ContractVersionError', _FakeContractVersionError):
-            with self._patch_appeler(side_effect=_FakeContractVersionError('serveur v2 < attendu v3')):
-                with self.assertRaises(UserError) as cm:
-                    self.env[_SERVICE_MODEL].resoudre(['A'])
+        with _patch_appeler(side_effect=service_module.ContractVersionError('serveur v2 < attendu v3')):
+            with self.assertRaises(UserError) as cm:
+                self.env[_SERVICE_MODEL].resoudre(['A'])
         self.assertIn('Contrat electricore obsolète', str(cm.exception))
 
 
@@ -98,14 +88,9 @@ class TestServiceRscTransport(SouscriptionsTestCase):
 class TestActionResoudreRscMaintenant(SouscriptionsTestCase):
     """Le bouton « résoudre la RSC maintenant » sur la Souscription."""
 
-    def _patch_appeler(self, return_value=None, side_effect=None):
-        return patch.object(
-            service_module.SouscriptionRscService, '_appeler', return_value=return_value, side_effect=side_effect
-        )
-
     def test_succes_ecrit_la_rsc_et_trace_au_chatter(self):
         self.souscription_base.id_affaire = '38233180'
-        with self._patch_appeler(return_value=[_resultat('38233180', rsc='RSC-9001')]):
+        with _patch_appeler(return_value=[resultat_rsc('38233180', rsc='RSC-9001')]):
             self.souscription_base.action_resoudre_rsc_maintenant()
 
         self.assertEqual(self.souscription_base.ref_situation_contractuelle, 'RSC-9001')
@@ -117,7 +102,7 @@ class TestActionResoudreRscMaintenant(SouscriptionsTestCase):
 
     def test_affaire_inconnue_stocke_le_motif_et_la_date(self):
         self.souscription_base.id_affaire = 'ZZZ999'
-        with self._patch_appeler(return_value=[_resultat('ZZZ999', error='Affaire inconnue : ZZZ999')]):
+        with _patch_appeler(return_value=[resultat_rsc('ZZZ999', error='Affaire inconnue : ZZZ999')]):
             self.souscription_base.action_resoudre_rsc_maintenant()
 
         self.assertFalse(self.souscription_base.ref_situation_contractuelle)
@@ -135,11 +120,11 @@ class TestActionResoudreRscMaintenant(SouscriptionsTestCase):
             'Affaire connue (X12) sans situation contractuelle C15 (précurseur en cours ou affaire non contractuelle).'
         )
         reponse = [
-            _resultat('AFF-HPHC', error=motif_sans_c15),
-            _resultat('AFF-BASE', rsc='RSC-BASE-1'),
+            resultat_rsc('AFF-HPHC', error=motif_sans_c15),
+            resultat_rsc('AFF-BASE', rsc='RSC-BASE-1'),
         ]
         souscriptions = self.souscription_base + self.souscription_hphc
-        with self._patch_appeler(return_value=reponse) as mock_appeler:
+        with _patch_appeler(return_value=reponse) as mock_appeler:
             souscriptions.action_resoudre_rsc_maintenant()
 
         mock_appeler.assert_called_once_with(['AFF-BASE', 'AFF-HPHC'])
@@ -152,23 +137,22 @@ class TestActionResoudreRscMaintenant(SouscriptionsTestCase):
         self.souscription_base.with_context(rsc_automatisme=True).write({'ref_situation_contractuelle': 'RSC-DEJA'})
         self.assertEqual(self.souscription_base.etat, 'en_service')
 
-        with self._patch_appeler() as mock_appeler:
+        with _patch_appeler() as mock_appeler:
             self.souscription_base.action_resoudre_rsc_maintenant()
         mock_appeler.assert_not_called()
 
     def test_id_affaire_manquant_leve_userror_sans_appel(self):
         self.assertFalse(self.souscription_base.id_affaire)
-        with self._patch_appeler() as mock_appeler:
+        with _patch_appeler() as mock_appeler:
             with self.assertRaises(UserError):
                 self.souscription_base.action_resoudre_rsc_maintenant()
         mock_appeler.assert_not_called()
 
     def test_version_inattendue_naucune_ecriture(self):
         self.souscription_base.id_affaire = '38233180'
-        with patch.object(service_module, 'ContractVersionError', _FakeContractVersionError):
-            with self._patch_appeler(side_effect=_FakeContractVersionError('serveur v2 < attendu v3')):
-                with self.assertRaises(UserError):
-                    self.souscription_base.action_resoudre_rsc_maintenant()
+        with _patch_appeler(side_effect=service_module.ContractVersionError('serveur v2 < attendu v3')):
+            with self.assertRaises(UserError):
+                self.souscription_base.action_resoudre_rsc_maintenant()
 
         self.assertFalse(self.souscription_base.ref_situation_contractuelle)
         self.assertFalse(self.souscription_base.motif_resolution_rsc)

--- a/tests/test_sync_prestations.py
+++ b/tests/test_sync_prestations.py
@@ -1,24 +1,24 @@
 """Tests #147 — sync electricore des prestations : pull-tout, insert-si-absente.
 
-Couture de test : `_tirer_prestations` (transport JSONL) est patchée avec des
-lignes en boîte (contrat v1 `PrestationF15`, dicts plats) ; la fabrique client
-est patchée pour rendre un MagicMock (sa garde paquet/config est testée dans
-test_electricore_client_fabrique.py). Résolution RSC, mapping nature et
-insert-si-absente restent réels. Aucun HTTP.
+Couture de test (socle commun #222) : `_tirer_prestations` (transport JSONL)
+est patchée avec des lignes en boîte (contrat v1 `PrestationF15`, dicts
+plats) ; la fabrique client est patchée pour rendre un MagicMock (sa garde
+paquet/config est testée dans test_electricore_client_fabrique.py).
+Résolution RSC, mapping nature et insert-si-absente restent réels. Aucun
+HTTP.
 
 Décisions du grill 2026-07-08 (cf. issue #147) : résolution par RSC seule
 (pas de repli PDL, ADR 0010 §4), insert-si-absente (pas de chemin d'update —
 la *Référence de contenu* EST le contenu), `montant_ht` ignoré.
 """
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
-from odoo.addons.souscriptions_odoo.models.core import electricore_client_fabrique as fabrique_module
 from odoo.addons.souscriptions_odoo.models.core import souscription_refacturation as refacturation_module
 from odoo.exceptions import UserError
 from odoo.tests.common import tagged
 
-from .common import SouscriptionsTestCase
+from .common import SouscriptionsTestCase, patcher_client_fabrique, patcher_transport
 
 
 def _ligne(**overrides):
@@ -48,7 +48,7 @@ class TestSyncPrestations(SouscriptionsTestCase):
     def setUp(self):
         super().setUp()
         self.fake_client = MagicMock(url='https://electricore.example.test', api_key='fake-api-key')
-        patcher = patch.object(fabrique_module.SouscriptionElectricoreClient, 'client', return_value=self.fake_client)
+        patcher = patcher_client_fabrique(self.fake_client)
         patcher.start()
         self.addCleanup(patcher.stop)
         self.souscription_base.with_context(rsc_automatisme=True).write(
@@ -57,7 +57,9 @@ class TestSyncPrestations(SouscriptionsTestCase):
         self.Refacturation = self.env['souscription.refacturation']
 
     def _sync(self, lignes):
-        with patch.object(refacturation_module.SouscriptionRefacturation, '_tirer_prestations', return_value=lignes):
+        with patcher_transport(
+            refacturation_module.SouscriptionRefacturation, '_tirer_prestations', return_value=lignes
+        ):
             return self.Refacturation.synchroniser_depuis_electricore()
 
     def _prestas(self, reference):
@@ -193,7 +195,7 @@ class TestSyncPrestations(SouscriptionsTestCase):
     def test_contract_version_error_mappee_en_userror(self):
         """Contrat obsolète -> erreur dure actionnable (UserError), pas de
         traceback brut pour le·la facturiste."""
-        with patch.object(
+        with patcher_transport(
             refacturation_module.SouscriptionRefacturation,
             '_tirer_prestations',
             side_effect=refacturation_module.ContractVersionError('serveur v0 < attendu v1'),


### PR DESCRIPTION
Closes #222

*(Initialement empilée sur #225 ; celle-ci ayant été mergée, la branche a été rebasée sur main — PR autonome.)*

Ré-exporte les exceptions du contrat electricore (`ContractVersionError`,
`IngestionEnCours`, `PreconditionNonRemplie`) depuis la fabrique unique
(ADR 0024) : les quatre services consommateurs (résolution RSC, pull
méta-périodes, refacturation F15, chronologie) perdent leur bloc
`try/import` dupliqué au profit d'un import direct depuis la fabrique.
Le socle de tests commun (`tests/common.py`) gagne cinq aides de simulation
(`patcher_transport`, `patcher_client_fabrique`, `flux_electricore`,
`client_flux_factice`, `resultat_rsc`) ; les six fichiers de test d'endpoint
migrent dessus et suppriment leurs classes `_Fake*`/échanges de symboles
locaux. Aucun changement de comportement métier ; net −87 LOC.

ADR 0024 §6 respecté : chaque appelant garde son appel d'endpoint et son
mapping d'exceptions ; les tests patchent la couture nommée
(`_appeler`/`_ouvrir_flux`/`_tirer_prestations`/`_tirer_chronologie`),
jamais plus profond ; aucun faux transport complet.

Complément découvert par le critère « avec et sans » : la branche `except`
de la fabrique définit désormais aussi `ElectricoreClient = None` — la
surface du module est identique dans les deux mondes (préexistant :
`test_construit_le_client_configure` patchait un symbole inexistant sans
le paquet).

Suite complète verte en docker CI dans les deux mondes, sur le tip rebasé
(inclut #225 et #226) :
- **avec** `electricore-client` 0.4.0 (image construite) : `0 failed, 0 error(s) of 499 tests`
- **sans** (image stock `odoo:19.0`) : `0 failed, 0 error(s) of 499 tests`

🤖 Generated with [Claude Code](https://claude.com/claude-code)