### PR TITLE
fix: accord du verbe dans la docstring de la fabrique (quickfix de review #227)

### DIFF
--- a/models/core/electricore_client_fabrique.py
+++ b/models/core/electricore_client_fabrique.py
@@ -21,7 +21,7 @@ s'arrête à « rends-moi un client configuré » (ADR 0024 §4, option écarté
 
 Ré-export des exceptions du contrat (#222, tranche 2 du PRD #219) : les
 quatre appelants (résolution RSC, pull méta-périodes, refacturation F15,
-chronologie) important `ContractVersionError`/`IngestionEnCours`/
+chronologie) importent `ContractVersionError`/`IngestionEnCours`/
 `PreconditionNonRemplie` depuis **ce** module plutôt que de porter chacun sa
 propre garde d'import + ses propres stubs de repli — un seul point d'origine,
 réel si le paquet est présent, stub sinon.


### PR DESCRIPTION
Quickfix du gate de review de #227, arrivé après son merge : « les quatre appelants **importent** » (verbe), pas « important » (participe).

🤖 Generated with [Claude Code](https://claude.com/claude-code)