### PR TITLE
refonte(pull): propriétaire durable du pull méta-périodes — service extrait du wizard (tranche 1 du PRD #231)

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -40,7 +40,7 @@ Journeys de capacités (`REQ-XXX-nn`), chacune avec un statut (✅ Proven · ⚠
 - REQ-FAC-02 ✅ signaux : statut par souscription, reste-à-faire, drill-down — preuve: tests/test_campagne_signaux.py · #157
 - REQ-FAC-03 ✅ boutons d'étape : pulls, créer puis émettre les factures — preuve: tests/test_campagne_etapes_actions.py · #158
 - REQ-FAC-04 ✅ notes de campagne reportées au mois suivant — preuve: tests/test_campagne_notes.py · #159
-- REQ-FAC-05 ✅ pull des méta-périodes electricore, idempotent — preuve: tests/test_pull_meta_periodes.py · #77
+- REQ-FAC-05 ✅ pull des méta-périodes electricore, idempotent — propriétaire durable extrait en service (`souscription.pull.meta.periodes.service`), wizard/Campagne en coquilles minces — preuve: tests/test_pull_meta_periodes.py · #77, #233
 - REQ-FAC-06 ✅ énergie par cadran en cascade selon le calendrier de comptage — preuve: tests/test_periode_energie.py · #26
 - REQ-FAC-07 ✅ période mensuelle unique, snapshot figé à la facturation — preuve: tests/test_periode_snapshot.py::test_periode_figee_des_la_facturation · #14
 - REQ-FAC-08 ✅ relevés d'index : verrou de facturation + bloc justificatif (colonnes = union des familles réellement relevées) — preuve: tests/test_releve.py · #54, #138

--- a/models/core/__init__.py
+++ b/models/core/__init__.py
@@ -11,6 +11,7 @@ from . import (
     souscription_consentement,
     souscription_periode,
     souscription_produit,
+    souscription_pull_meta_periodes_service,
     souscription_refacturation,
     souscription_releve,
     souscription_sepa_mandat,

--- a/models/core/souscription_campagne.py
+++ b/models/core/souscription_campagne.py
@@ -338,17 +338,15 @@ class SouscriptionCampagneFacturation(models.Model):
     def action_pull_meta_periodes(self):
         """Lance le tirage en un clic (#176), sans fenêtre intermédiaire :
         cible le Périmètre de campagne (#175) pour `self.mois` — aucun mois
-        re-proposé, la scope est déjà celle de la campagne — et délègue la
-        boucle de tirage au point partagé avec le wizard ad-hoc
-        (`souscription.pull.meta.periodes.wizard._tirer_meta_periodes`, même
-        couture réseau `_ouvrir_flux`/fabrique client, ADR 0024). Retourne une
-        notification résumant créées/déjà présentes/erreurs — sticky si des
-        erreurs, auto-dismiss sinon — aucun résumé persisté."""
+        re-proposé, la scope est déjà celle de la campagne — et délègue au
+        propriétaire durable du pull, `souscription.pull.meta.periodes.service`
+        (#233, même couture réseau `_ouvrir_flux`/fabrique client, ADR 0024
+        — partagée avec le wizard ad-hoc). Retourne une notification résumant
+        créées/déjà présentes/erreurs — sticky si des erreurs, auto-dismiss
+        sinon — aucun résumé persisté."""
         self.ensure_one()
         cibles = self._souscriptions_facturables()
-        creees, existantes, erreurs = self.env['souscription.pull.meta.periodes.wizard']._tirer_meta_periodes(
-            cibles, self.mois
-        )
+        creees, existantes, erreurs = self.env['souscription.pull.meta.periodes.service'].pull(cibles, self.mois)
         return {
             'type': 'ir.actions.client',
             'tag': 'display_notification',

--- a/models/core/souscription_pull_meta_periodes_service.py
+++ b/models/core/souscription_pull_meta_periodes_service.py
@@ -1,0 +1,113 @@
+"""Propriétaire durable du pull des méta-périodes electricore (#233, tranche 1
+du PRD #231 — « le facturé gelé, le mesuré vivant », ADR 0030).
+
+Extrait du wizard transient `souscription.pull.meta.periodes.wizard` (#77),
+qui en était jusqu'ici le seul propriétaire : ce module porte désormais la
+méthode de transport nommée (couture de test, ADR 0024 §6), le mapping du
+contrat v3 (`souscription.periode._amorcer_depuis_meta`) et la politique
+d'écriture **actuelle** — create-missing-only, skip-and-report par savepoint
+(ADR 0011) — sur un `AbstractModel` durable, même motif que
+`souscription.rsc.service`. Le wizard mensuel et le bouton Campagne
+(`souscription.campagne.facturation.action_pull_meta_periodes`) en deviennent
+des coquilles minces qui délèguent à `pull()` et formatent le résultat :
+**zéro changement de comportement observable** (pur prefactor, carte
+« propriétaire durable du pull » de la revue d'architecture du 2026-07-12).
+
+La politique unifiée gardée par l'empreinte (ADR 0030 §1 : `source_hash`
+inchangé -> ne rien toucher, empreinte nouvelle + verdict réel/estimé ->
+écraser) arrive à la tranche suivante — ce service reste create-missing-only
+pour l'instant.
+"""
+
+from __future__ import annotations
+
+from odoo import fields, models
+from odoo.exceptions import UserError
+
+from .electricore_client_fabrique import ContractVersionError, IngestionEnCours, PreconditionNonRemplie
+
+
+class SouscriptionPullMetaPeriodesService(models.AbstractModel):
+    _name = 'souscription.pull.meta.periodes.service'
+    _description = 'Pull des méta-périodes electricore — propriétaire durable (ADR 0011/0024, #233)'
+
+    def pull(self, souscriptions, mois):
+        """Point d'entrée unique du pull (#233 AC1) : acquiert le client
+        (fabrique `souscription.electricore.client`, ADR 0024), ouvre le flux
+        `meta_periodes` pour `mois` sur les RSC de `souscriptions`, crée les
+        périodes manquantes (create-missing-only) avec savepoint par élément
+        (skip-and-report, ADR 0011) et mappe les exceptions typées electricore
+        en `UserError`.
+
+        Args:
+            souscriptions: le périmètre déjà voulu par l'appelant (toutes-RSC
+                pour le wizard ad-hoc, Périmètre de campagne du mois pour la
+                Campagne) — aucun filtre supplémentaire ici, seules les
+                souscriptions à RSC résolue participent au flux.
+            mois: n'importe quelle date du mois à tirer (année/mois seuls
+                comptent).
+
+        Returns:
+            tuple[list[str], list[str], list[str]] : `(creees, existantes,
+            erreurs)`, trois listes de libellés consommées par le résumé du
+            wizard ad-hoc et par le résultat/toast de la Campagne (#158/#176).
+        """
+        client = self.env['souscription.electricore.client'].client()
+        Periode = self.env['souscription.periode']
+        par_rsc = {s.ref_situation_contractuelle: s for s in souscriptions if s.ref_situation_contractuelle}
+
+        creees, existantes, erreurs = [], [], []
+
+        if par_rsc:
+            mois_str = fields.Date.to_string(mois)
+            try:
+                with self._ouvrir_flux(client, mois_str, list(par_rsc)) as stream:
+                    for meta in stream:
+                        souscription = par_rsc.get(meta.ref_situation_contractuelle)
+                        if souscription is None:
+                            continue  # RSC hors du filtre demandé, ignorée silencieusement
+                        try:
+                            # Savepoint par élément (skip-and-report, ADR 0011) :
+                            # un échec de mapping/contrainte sur une RSC ne doit
+                            # ni écrire de résultat partiel ni casser le curseur
+                            # pour les RSC suivantes du même lot.
+                            with self.env.cr.savepoint():
+                                self._amorcer_une(Periode, souscription, meta, creees, existantes)
+                        except Exception as exc:
+                            erreurs.append(f'{souscription.name} ({meta.ref_situation_contractuelle}) : {exc}')
+            except IngestionEnCours:
+                raise UserError("L'ingestion electricore est en cours (verrou base) : réessayez plus tard.")
+            except PreconditionNonRemplie as exc:
+                raise UserError(f'Précondition non remplie côté electricore : {exc}')
+            except ContractVersionError as exc:
+                raise UserError(f'Contrat electricore obsolète : {exc}')
+
+        return creees, existantes, erreurs
+
+    def _amorcer_une(self, Periode, souscription, meta, creees, existantes):
+        """Create-missing-only (ADR 0011) : un `(souscription, mois)` déjà
+        amorcé n'est jamais réécrit. Recherche explicite d'abord (lisible,
+        rapide) ; la contrainte unique mensuelle (ADR 0020 §2) reste le
+        garde-fou de dernier recours si deux amorçages se recouvraient malgré
+        tout — remontée comme une erreur normale, absorbée par le savepoint
+        appelant."""
+        mois_cle = fields.Date.to_date(meta.debut).replace(day=1)
+        existante = Periode.search(
+            [
+                ('souscription_id', '=', souscription.id),
+                ('mois', '=', mois_cle),
+                ('type_periode', '=', 'mensuelle'),
+            ],
+            limit=1,
+        )
+        if existante:
+            existantes.append(f'{souscription.name} ({meta.mois_annee})')
+            return
+        Periode._amorcer_depuis_meta(souscription, meta)
+        creees.append(f'{souscription.name} ({meta.mois_annee})')
+
+    def _ouvrir_flux(self, client, mois_str, rsc):
+        """Point de transport unique : ouvre le flux `meta_periodes` (context
+        manager). Seul endroit qui parle réseau — c'est la couture patchée en
+        tests (réponses en boîte, rien d'autre n'est mocké)."""
+        return client.meta_periodes(mois=mois_str, rsc=rsc)

--- a/models/wizard/souscription_pull_meta_periodes_wizard.py
+++ b/models/wizard/souscription_pull_meta_periodes_wizard.py
@@ -1,12 +1,12 @@
 """Wizard facturiste « Récupérer les périodes du mois » (#77, ADR 0011/0019).
 
-Brancher le seam décidé : l'addon consomme le paquet `electricore-client`
-(httpx + pydantic) et n'implémente que le mapping vers ses propres modèles
-(`souscription.periode._amorcer_depuis_meta`). Le client est acquis auprès de
-la fabrique unique `souscription.electricore.client` (ADR 0024) : ce module
-ne porte plus ni garde d'import du client, ni drapeau de disponibilité, ni
-lecture de config — seuls son propre appel d'endpoint (`meta_periodes` en
-flux) et son mapping d'exceptions, ré-exportées par la fabrique (#222).
+Coquille mince (#233, tranche 1 du PRD #231) : le propriétaire durable du
+pull — méthode de transport nommée, mapping du contrat v3, politique
+create-missing-only/skip-and-report (ADR 0011/0024) — vit désormais dans
+`souscription.pull.meta.periodes.service`. Ce wizard ne fait plus que
+construire le périmètre (toutes les souscriptions, avec/sans RSC), déléguer
+le tirage au service et formater le résumé (créées / déjà existantes / sans
+RSC / erreurs) — zéro changement de comportement observable.
 """
 
 from __future__ import annotations
@@ -14,9 +14,6 @@ from __future__ import annotations
 from datetime import timedelta
 
 from odoo import api, fields, models
-from odoo.exceptions import UserError
-
-from ..core.electricore_client_fabrique import ContractVersionError, IngestionEnCours, PreconditionNonRemplie
 
 
 class SouscriptionPullMetaPeriodesWizard(models.TransientModel):
@@ -44,17 +41,19 @@ class SouscriptionPullMetaPeriodesWizard(models.TransientModel):
         RSC, crée les périodes manquantes (create-missing-only), résume le
         résultat (créées / déjà existantes / sans RSC / erreurs).
 
-        Chemin ad-hoc (mois saisi, portée toutes-RSC) : délègue la boucle de
-        tirage à `_tirer_meta_periodes` (#176), partagée avec le chemin
-        Campagne (`souscription.campagne.facturation.action_pull_meta_periodes`,
-        portée Périmètre de campagne)."""
+        Chemin ad-hoc (mois saisi, portée toutes-RSC) : délègue le tirage au
+        service `souscription.pull.meta.periodes.service` (#233), le même que
+        le chemin Campagne
+        (`souscription.campagne.facturation.action_pull_meta_periodes`,
+        portée Périmètre de campagne) — ce wizard ne fait plus que construire
+        le périmètre et formater le résumé."""
         self.ensure_one()
         Souscription = self.env['souscription.souscription']
 
         avec_rsc = Souscription.search([('ref_situation_contractuelle', '!=', False), ('active', '=', True)])
         sans_rsc = Souscription.search([('ref_situation_contractuelle', '=', False), ('active', '=', True)])
 
-        creees, existantes, erreurs = self._tirer_meta_periodes(avec_rsc, self.mois)
+        creees, existantes, erreurs = self.env['souscription.pull.meta.periodes.service'].pull(avec_rsc, self.mois)
 
         self.resultat = self._formatter_resultat(creees, existantes, sans_rsc, erreurs)
         self.state = 'done'
@@ -65,73 +64,6 @@ class SouscriptionPullMetaPeriodesWizard(models.TransientModel):
             'view_mode': 'form',
             'target': 'new',
         }
-
-    @api.model
-    def _tirer_meta_periodes(self, souscriptions, mois):
-        """Boucle de tirage partagée (#176) : acquiert le client (fabrique
-        `souscription.electricore.client`, ADR 0024), ouvre le flux
-        `meta_periodes` pour `mois` sur les RSC de `souscriptions`, crée les
-        périodes manquantes (create-missing-only) avec savepoint par élément
-        (skip-and-report, ADR 0011) et mappe les exceptions typées electricore
-        en `UserError`. Rend `(creees, existantes, erreurs)` — trois listes de
-        libellés, consommées par le résumé du wizard ad-hoc et par le
-        résultat/toast de la Campagne (#158/#176). `souscriptions` est déjà le
-        périmètre voulu par l'appelant (toutes-RSC pour le wizard, Périmètre
-        de campagne du mois pour la Campagne) : aucun filtre supplémentaire
-        ici."""
-        client = self.env['souscription.electricore.client'].client()
-        Periode = self.env['souscription.periode']
-        par_rsc = {s.ref_situation_contractuelle: s for s in souscriptions if s.ref_situation_contractuelle}
-
-        creees, existantes, erreurs = [], [], []
-
-        if par_rsc:
-            mois_str = fields.Date.to_string(mois)
-            try:
-                with self._ouvrir_flux(client, mois_str, list(par_rsc)) as stream:
-                    for meta in stream:
-                        souscription = par_rsc.get(meta.ref_situation_contractuelle)
-                        if souscription is None:
-                            continue  # RSC hors du filtre demandé, ignorée silencieusement
-                        try:
-                            # Savepoint par élément (skip-and-report, ADR 0011) :
-                            # un échec de mapping/contrainte sur une RSC ne doit
-                            # ni écrire de résultat partiel ni casser le curseur
-                            # pour les RSC suivantes du même lot.
-                            with self.env.cr.savepoint():
-                                self._amorcer_une(Periode, souscription, meta, creees, existantes)
-                        except Exception as exc:
-                            erreurs.append(f'{souscription.name} ({meta.ref_situation_contractuelle}) : {exc}')
-            except IngestionEnCours:
-                raise UserError("L'ingestion electricore est en cours (verrou base) : réessayez plus tard.")
-            except PreconditionNonRemplie as exc:
-                raise UserError(f'Précondition non remplie côté electricore : {exc}')
-            except ContractVersionError as exc:
-                raise UserError(f'Contrat electricore obsolète : {exc}')
-
-        return creees, existantes, erreurs
-
-    def _amorcer_une(self, Periode, souscription, meta, creees, existantes):
-        """Create-missing-only (ADR 0011) : un `(souscription, mois)` déjà
-        amorcé n'est jamais réécrit. Recherche explicite d'abord (lisible,
-        rapide) ; la contrainte unique mensuelle (ADR 0020 §2) reste le
-        garde-fou de dernier recours si deux amorçages se recouvraient malgré
-        tout — remontée comme une erreur normale, absorbée par le savepoint
-        appelant."""
-        mois_cle = fields.Date.to_date(meta.debut).replace(day=1)
-        existante = Periode.search(
-            [
-                ('souscription_id', '=', souscription.id),
-                ('mois', '=', mois_cle),
-                ('type_periode', '=', 'mensuelle'),
-            ],
-            limit=1,
-        )
-        if existante:
-            existantes.append(f'{souscription.name} ({meta.mois_annee})')
-            return
-        Periode._amorcer_depuis_meta(souscription, meta)
-        creees.append(f'{souscription.name} ({meta.mois_annee})')
 
     @staticmethod
     def _formatter_resultat(creees, existantes, sans_rsc, erreurs):
@@ -151,9 +83,3 @@ class SouscriptionPullMetaPeriodesWizard(models.TransientModel):
         if erreurs:
             lignes += ['Erreurs :'] + [f'  - {ligne}' for ligne in erreurs]
         return '\n'.join(lignes)
-
-    def _ouvrir_flux(self, client, mois_str, rsc):
-        """Point de transport unique : ouvre le flux `meta_periodes` (context
-        manager). Seul endroit qui parle réseau — c'est la couture patchée en
-        tests (réponses en boîte, rien d'autre n'est mocké)."""
-        return client.meta_periodes(mois=mois_str, rsc=rsc)

--- a/tests/test_pull_meta_periodes.py
+++ b/tests/test_pull_meta_periodes.py
@@ -1,12 +1,17 @@
 """
-Tests du pull des méta-périodes (#77, ADR 0011/0019/0020).
+Tests du pull des méta-périodes (#77, ADR 0011/0019/0020 ; service extrait
+#233, tranche 1 du PRD #231).
 
-Deux tranches :
+Trois tranches :
 - `_amorcer_depuis_meta` / `_releve_vals_depuis_objet` : mapping pur
   `PeriodeMeta`/`ObjetReleve` → `create()`, testé avec des stubs duck-typés
-  (aucune dépendance à `electricore_client`, cf. la garde d'import du wizard).
-- Le wizard « Récupérer les périodes du mois » : create-missing-only,
-  skip-and-report, erreurs typées mappées — client mocké.
+  (aucune dépendance à `electricore_client`, cf. la garde d'import de la
+  fabrique).
+- Le service `souscription.pull.meta.periodes.service` — propriétaire
+  durable du pull (#233) : create-missing-only, skip-and-report, erreurs
+  typées mappées — client mocké.
+- Le wizard « Récupérer les périodes du mois », coquille mince (#233) :
+  périmètre avec/sans RSC + formatage du résumé, délègue au service.
 
 Fixtures RSC/PDL : identifiants factices (jamais des vrais échantillons).
 """
@@ -16,7 +21,7 @@ from datetime import date, timedelta
 from types import SimpleNamespace
 
 from odoo.addons.souscriptions_odoo.models.core import electricore_client_fabrique as fabrique_module
-from odoo.addons.souscriptions_odoo.models.wizard import souscription_pull_meta_periodes_wizard as wizard_module
+from odoo.addons.souscriptions_odoo.models.core import souscription_pull_meta_periodes_service as service_module
 from odoo.exceptions import UserError
 from odoo.tests.common import tagged
 
@@ -178,12 +183,146 @@ class TestAmorcerDepuisMeta(SouscriptionsTestCase):
                 self.env['souscription.periode']._amorcer_depuis_meta(self.souscription_base, _periode_meta())
 
 
-# === Wizard « Récupérer les périodes du mois » : client mocké ===
+# === Service « propriétaire durable du pull » (#233) : client mocké ===
 #
-# Les exceptions levées sont les vraies classes du module wizard (réelles si
-# electricore_client est présent, stubs de la fabrique sinon, ADR 0024/#222) :
-# aucun échange de symbole par patch, `except IngestionEnCours` du wizard
-# attrape exactement ce qui est instancié ici.
+# `souscription.pull.meta.periodes.service` porte désormais la politique
+# create-missing-only / skip-and-report (ADR 0011) et la méthode de transport
+# nommée `_ouvrir_flux` (ADR 0024 §6). Les exceptions levées sont les vraies
+# classes du module service (réelles si electricore_client est présent, stubs
+# de la fabrique sinon, ADR 0024/#222) : aucun échange de symbole par patch,
+# `except IngestionEnCours` du service attrape exactement ce qui est
+# instancié ici.
+
+
+@tagged('souscriptions', 'souscriptions_pull_meta', 'post_install', '-at_install')
+class TestPullMetaPeriodesService(SouscriptionsTestCase):
+    def _pull(self, client, souscriptions, mois=date(2024, 1, 1)):
+        """Appelle le point d'entrée unique du service (#233 AC1), transport
+        patché via la fabrique client (ADR 0024) — jamais de vrai client
+        construit."""
+        with patcher_client_fabrique(client):
+            return self.env['souscription.pull.meta.periodes.service'].pull(souscriptions, mois)
+
+    def test_cree_les_periodes_manquantes_pour_les_souscriptions_a_rsc(self):
+        """AC2 : le service crée les périodes manquantes du mois pour les
+        souscriptions à RSC."""
+        self.souscription_base.ref_situation_contractuelle = 'RSC-00000000000001'
+        meta = _periode_meta(
+            ref_situation_contractuelle='RSC-00000000000001',
+            debut='2024-01-01',
+            fin='2024-02-01',
+        )
+        client = client_flux_factice('meta_periodes', [meta])
+
+        creees, existantes, erreurs = self._pull(client, self.souscription_base)
+
+        periode = self.env['souscription.periode'].search(
+            [('souscription_id', '=', self.souscription_base.id), ('mois', '=', date(2024, 1, 1))]
+        )
+        self.assertEqual(len(periode), 1)
+        self.assertEqual(len(creees), 1)
+        self.assertFalse(existantes)
+        self.assertFalse(erreurs)
+        client.meta_periodes.assert_called_once_with(mois='2024-01-01', rsc=['RSC-00000000000001'])
+
+    def test_ne_reecrit_jamais_une_periode_existante(self):
+        """AC2/AC3 : create-missing-only — une période déjà amorcée n'est
+        jamais réécrite, même avec des valeurs différentes dans le payload."""
+        self.souscription_base.ref_situation_contractuelle = 'RSC-00000000000001'
+        existante = self.create_test_periode(
+            self.souscription_base, date_debut=date(2024, 1, 1), date_fin=date(2024, 2, 1)
+        )
+        existante.cta_eur = 1.23
+
+        meta = _periode_meta(
+            ref_situation_contractuelle='RSC-00000000000001',
+            debut='2024-01-01',
+            fin='2024-02-01',
+            cta_eur=999.0,
+        )
+        creees, existantes, erreurs = self._pull(client_flux_factice('meta_periodes', [meta]), self.souscription_base)
+
+        self.assertEqual(existante.cta_eur, 1.23)
+        self.assertEqual(len(existantes), 1)
+        self.assertFalse(creees)
+        self.assertFalse(erreurs)
+
+    def test_releves_crees_avec_identifiant_externe_et_origine(self):
+        """AC4 : relevés créés avec identifiant externe + origine."""
+        self.souscription_base.ref_situation_contractuelle = 'RSC-00000000000001'
+        meta = _periode_meta(
+            ref_situation_contractuelle='RSC-00000000000001',
+            debut='2024-01-01',
+            fin='2024-02-01',
+            releves_utilises=[_objet_releve(releve_id='ELC-999', origine_releve='flux_R151')],
+        )
+        self._pull(client_flux_factice('meta_periodes', [meta]), self.souscription_base)
+
+        releve = self.env['souscription.releve'].search([('releve_externe_id', '=', 'ELC-999')])
+        self.assertEqual(len(releve), 1)
+        self.assertEqual(releve.origine, 'flux_R151')
+
+    def test_erreur_par_periode_ne_bloque_pas_le_lot(self):
+        """Skip-and-report par élément : une erreur d'amorçage sur une RSC
+        n'empêche pas les autres d'être traitées, et apparaît dans le résumé."""
+        self.souscription_base.ref_situation_contractuelle = 'RSC-00000000000001'
+        meta_invalide = _periode_meta(
+            ref_situation_contractuelle='RSC-00000000000001',
+            debut=None,  # déclenche une erreur de mapping (Date invalide)
+            fin='2024-02-01',
+        )
+        creees, existantes, erreurs = self._pull(
+            client_flux_factice('meta_periodes', [meta_invalide]), self.souscription_base
+        )
+        self.assertEqual(len(erreurs), 1)
+
+    def test_ingestion_en_cours_mappee_en_userror_reessayable(self):
+        """AC5 : IngestionEnCours -> message « réessayer plus tard »."""
+        self.souscription_base.ref_situation_contractuelle = 'RSC-00000000000001'
+        client = client_flux_factice('meta_periodes', leve=service_module.IngestionEnCours('verrou'))
+        with self.assertRaises(UserError) as cm:
+            self._pull(client, self.souscription_base)
+        self.assertIn('plus tard', str(cm.exception))
+
+    def test_precondition_non_remplie_mappee_en_userror_actionnable(self):
+        """AC5 : PreconditionNonRemplie -> message actionnable du serveur conservé."""
+        self.souscription_base.ref_situation_contractuelle = 'RSC-00000000000001'
+        client = client_flux_factice(
+            'meta_periodes', leve=service_module.PreconditionNonRemplie('réconciliez les RSC avant de facturer')
+        )
+        with self.assertRaises(UserError) as cm:
+            self._pull(client, self.souscription_base)
+        self.assertIn('réconciliez les RSC', str(cm.exception))
+
+    def test_contract_version_error_mappee_en_erreur_dure(self):
+        """AC5 : ContractVersionError -> erreur dure (UserError, pas de retry implicite)."""
+        self.souscription_base.ref_situation_contractuelle = 'RSC-00000000000001'
+        client = client_flux_factice(
+            'meta_periodes', leve=service_module.ContractVersionError('serveur v2 < attendu v3')
+        )
+        with self.assertRaises(UserError) as cm:
+            self._pull(client, self.souscription_base)
+        self.assertIn('v2', str(cm.exception))
+
+    def test_aucune_souscription_a_rsc_naboutit_pas_a_un_appel_de_flux(self):
+        """Aucune RSC facturable -> aucun flux n'est ouvert (pas de round-trip
+        réseau inutile), même si le client est acquis en tête (fast-fail,
+        ADR 0024 §5 : la construction elle-même n'ouvre aucune socket)."""
+        self.assertFalse(self.souscription_hphc.ref_situation_contractuelle)
+        client = client_flux_factice('meta_periodes', [])
+        creees, existantes, erreurs = self._pull(client, self.souscription_hphc)
+        client.meta_periodes.assert_not_called()
+        self.assertFalse(creees)
+        self.assertFalse(existantes)
+        self.assertFalse(erreurs)
+
+
+# === Wizard « Récupérer les périodes du mois » : coquille mince (#233) ===
+#
+# La politique de pull (create-missing-only, skip-and-report, mapping des
+# exceptions) est couverte par `TestPullMetaPeriodesService` ci-dessus. Ce qui
+# reste propre au wizard : construire le périmètre (avec/sans RSC), déléguer
+# et formater le résumé — vérifié ici, client mocké.
 
 
 @tagged('souscriptions', 'souscriptions_pull_meta', 'post_install', '-at_install')
@@ -200,9 +339,9 @@ class TestWizardPullMetaPeriodes(SouscriptionsTestCase):
             wizard.action_lancer()
         return wizard
 
-    def test_cree_les_periodes_manquantes_pour_les_souscriptions_a_rsc(self):
-        """AC2 : le wizard crée les périodes manquantes du mois pour les
-        souscriptions à RSC."""
+    def test_delegue_au_service_et_formate_le_resultat(self):
+        """AC2 : le wizard délègue au service et formate le résumé (créées /
+        déjà existantes / erreurs) — comportement observable inchangé."""
         self.souscription_base.ref_situation_contractuelle = 'RSC-00000000000001'
         meta = _periode_meta(
             ref_situation_contractuelle='RSC-00000000000001',
@@ -222,8 +361,8 @@ class TestWizardPullMetaPeriodes(SouscriptionsTestCase):
         client.meta_periodes.assert_called_once_with(mois='2024-01-01', rsc=['RSC-00000000000001'])
 
     def test_ne_reecrit_jamais_une_periode_existante(self):
-        """AC2 : create-missing-only — une période déjà amorcée n'est jamais
-        réécrite, même avec des valeurs différentes dans le payload."""
+        """AC2 : create-missing-only préservé bout en bout via le wizard —
+        une période déjà amorcée n'est jamais réécrite."""
         self.souscription_base.ref_situation_contractuelle = 'RSC-00000000000001'
         existante = self.create_test_periode(
             self.souscription_base, date_debut=date(2024, 1, 1), date_fin=date(2024, 2, 1)
@@ -243,7 +382,8 @@ class TestWizardPullMetaPeriodes(SouscriptionsTestCase):
         self.assertIn('Créées : 0', wizard.resultat)
 
     def test_resume_les_souscriptions_sans_rsc(self):
-        """AC3 : résumé skip-and-report — souscriptions sans RSC comptées à part."""
+        """AC3 : résumé skip-and-report — souscriptions sans RSC comptées à
+        part (périmètre construit par le wizard, hors du service)."""
         self.assertFalse(self.souscription_hphc.ref_situation_contractuelle)
         wizard = self._lancer_avec_client(client_flux_factice('meta_periodes', []))
         self.assertIn('Sans RSC (ignorées) :', wizard.resultat)
@@ -280,24 +420,9 @@ class TestWizardPullMetaPeriodes(SouscriptionsTestCase):
         periode = self.env['souscription.periode'].search([('souscription_id', '=', souscription.id)])
         self.assertFalse(periode, 'Aucune période ne doit être amorcée pour une Souscription en instance')
 
-    def test_releves_crees_avec_identifiant_externe_et_origine(self):
-        """AC4 : relevés créés avec identifiant externe + origine."""
-        self.souscription_base.ref_situation_contractuelle = 'RSC-00000000000001'
-        meta = _periode_meta(
-            ref_situation_contractuelle='RSC-00000000000001',
-            debut='2024-01-01',
-            fin='2024-02-01',
-            releves_utilises=[_objet_releve(releve_id='ELC-999', origine_releve='flux_R151')],
-        )
-        self._lancer_avec_client(client_flux_factice('meta_periodes', [meta]))
-
-        releve = self.env['souscription.releve'].search([('releve_externe_id', '=', 'ELC-999')])
-        self.assertEqual(len(releve), 1)
-        self.assertEqual(releve.origine, 'flux_R151')
-
-    def test_erreur_par_periode_ne_bloque_pas_le_lot(self):
-        """Skip-and-report par élément : une erreur d'amorçage sur une RSC
-        n'empêche pas les autres d'être traitées, et apparaît dans le résumé."""
+    def test_erreurs_du_service_apparaissent_dans_le_resume(self):
+        """Non-régression : le wizard ne ré-implémente pas skip-and-report —
+        il affiche tel quel ce que le service rend."""
         self.souscription_base.ref_situation_contractuelle = 'RSC-00000000000001'
         meta_invalide = _periode_meta(
             ref_situation_contractuelle='RSC-00000000000001',
@@ -307,33 +432,15 @@ class TestWizardPullMetaPeriodes(SouscriptionsTestCase):
         wizard = self._lancer_avec_client(client_flux_factice('meta_periodes', [meta_invalide]))
         self.assertIn('Erreurs : 1', wizard.resultat)
 
-    def test_ingestion_en_cours_mappee_en_userror_reessayable(self):
-        """AC5 : IngestionEnCours -> message « réessayer plus tard »."""
+    def test_erreur_de_service_propage_en_userror_par_le_wizard(self):
+        """Le wizard ne capture rien : une UserError du service (ex.
+        ingestion en cours) traverse `action_lancer` telle quelle — preuve de
+        délégation réelle, pas de ré-implémentation locale."""
         self.souscription_base.ref_situation_contractuelle = 'RSC-00000000000001'
-        client = client_flux_factice('meta_periodes', leve=wizard_module.IngestionEnCours('verrou'))
+        client = client_flux_factice('meta_periodes', leve=service_module.IngestionEnCours('verrou'))
         with self.assertRaises(UserError) as cm:
             self._lancer_avec_client(client)
         self.assertIn('plus tard', str(cm.exception))
-
-    def test_precondition_non_remplie_mappee_en_userror_actionnable(self):
-        """AC5 : PreconditionNonRemplie -> message actionnable du serveur conservé."""
-        self.souscription_base.ref_situation_contractuelle = 'RSC-00000000000001'
-        client = client_flux_factice(
-            'meta_periodes', leve=wizard_module.PreconditionNonRemplie('réconciliez les RSC avant de facturer')
-        )
-        with self.assertRaises(UserError) as cm:
-            self._lancer_avec_client(client)
-        self.assertIn('réconciliez les RSC', str(cm.exception))
-
-    def test_contract_version_error_mappee_en_erreur_dure(self):
-        """AC5 : ContractVersionError -> erreur dure (UserError, pas de retry implicite)."""
-        self.souscription_base.ref_situation_contractuelle = 'RSC-00000000000001'
-        client = client_flux_factice(
-            'meta_periodes', leve=wizard_module.ContractVersionError('serveur v2 < attendu v3')
-        )
-        with self.assertRaises(UserError) as cm:
-            self._lancer_avec_client(client)
-        self.assertIn('v2', str(cm.exception))
 
     def test_aucune_souscription_a_rsc_naboutit_pas_a_un_appel_de_flux(self):
         """Aucune RSC facturable -> aucun flux n'est ouvert (pas de round-trip


### PR DESCRIPTION
Closes #233

Extrait du wizard transient le propriétaire durable du pull des méta-périodes
electricore : `souscription.pull.meta.periodes.service` (nouvel AbstractModel,
même motif que `souscription.rsc.service`) porte désormais la méthode de
transport nommée (`_ouvrir_flux`, ADR 0024 §6), le mapping du contrat v3 et la
politique create-missing-only / skip-and-report par savepoint (ADR 0011).

Le wizard « Récupérer les périodes du mois » et le bouton Campagne
(`action_pull_meta_periodes`) deviennent des coquilles minces qui délèguent au
service et formatent le résultat — zéro changement de comportement
observable (pur prefactor, carte « propriétaire durable du pull » de la revue
d'architecture du 2026-07-12).

La suite `tests/test_pull_meta_periodes.py` migre sur la nouvelle couture
(`TestPullMetaPeriodesService` couvre la politique de pull directement ;
`TestWizardPullMetaPeriodes` se réduit à la construction du périmètre et au
formatage). Aucun nouveau fichier de test, aucun changement de schéma.

Suite docker complète verte sur la branche : `0 failed, 0 error(s) of 504 tests`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
