### PR TITLE
refonte(periode): énergie facturée universelle — tampon non-lissé à la facturation + backfill (tranche 3 du PRD #231)

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -48,6 +48,7 @@ Journeys de capacités (`REQ-XXX-nn`), chacune avec un statut (✅ Proven · ⚠
 - REQ-FAC-10 ✅ facture d'énergie PDF sur template dédié — preuve: tests/test_invoice_template.py, tests/test_facture_document.py::test_facture_energie_pdf
 - REQ-FAC-11 ✅ prestations F15 synchronisées puis refacturées (TVA par nature) — preuve: tests/test_sync_prestations.py, tests/test_refacturation.py · #147
 - REQ-FAC-12 ✅ chèques énergie : imputation FIFO à la facturation — preuve: tests/test_periode_facture.py::test_fifo_par_expiration_le_plus_proche_consomme_en_premier, tests/test_cheque_energie.py · #172
+- REQ-FAC-13 ✅ Énergie facturée universelle : la provision, tamponnée `provision := energie` à la facturation pour un contrat non lissé (dé-figeage/refacturation re-tamponne), porte uniformément la quantité facturée ; backfill des non-lissées déjà facturées — preuve: tests/test_periode_composition.py::test_creer_facture_tamponne_la_provision_non_lissee, tests/test_migration_energie_facturee.py · #234
 
 ## Parcours : espace usager (portail)
 

--- a/__manifest__.py
+++ b/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Souscriptions Électricité',
-    'version': '19.0.1.13.0',
+    'version': '19.0.1.14.0',
     'depends': ['base', 'mail', 'contacts', 'account', 'base_iban', 'portal'],
     'author': 'Virgile Daugé',
     'category': 'Energy',

--- a/migrations/19.0.1.14.0/post-migrate.py
+++ b/migrations/19.0.1.14.0/post-migrate.py
@@ -1,0 +1,40 @@
+"""Backfill `provision := energie` sur les non-lissées déjà facturées (#234,
+ADR 0030 décision 2 — Énergie facturée universelle).
+
+Avant cette version, `_quantite_facturee` facturait le mesuré (`energie_*`)
+directement pour un contrat non lissé, sans jamais écrire `provision_*` : ce
+champ restait à 0 (défaut), jamais réécrit par le pull create-missing-only
+(ADR-0011) ni par `create()` (qui ne peuple la provision que pour un contrat
+lissé, `souscription_periode.py::create`). Sûr, donc, d'écraser `provision_*`
+par `energie_*` sur les Périodes non lissées déjà facturées : aucune donnée
+utile n'y est perdue, et leur écart mesuré − facturé (`ecart_*_kwh`, calculé)
+retombe à zéro juste après — comme si elles avaient toujours été tamponnées
+à la facturation.
+
+SQL direct : `provision_*` est un champ verrouillé (#14) dès qu'une facture
+référence la Période — la voie ORM (`write()`) lèverait une UserError sur
+exactement les lignes visées ici. Idempotent : la clause `IS DISTINCT FROM`
+ne touche que les lignes où `provision_*` diverge encore de `energie_*` ;
+rejouer ce script est un no-op.
+"""
+
+
+def migrate(cr, version):
+    cr.execute(
+        """
+        UPDATE souscription_periode p
+        SET provision_hp_kwh = p.energie_hp_kwh,
+            provision_hc_kwh = p.energie_hc_kwh,
+            provision_base_kwh = p.energie_base_kwh
+        WHERE p.lisse_periode = false
+          AND EXISTS (
+              SELECT 1 FROM account_move m
+              WHERE m.periode_id = p.id AND m.move_type = 'out_invoice'
+          )
+          AND (
+              p.provision_hp_kwh IS DISTINCT FROM p.energie_hp_kwh
+              OR p.provision_hc_kwh IS DISTINCT FROM p.energie_hc_kwh
+              OR p.provision_base_kwh IS DISTINCT FROM p.energie_base_kwh
+          )
+        """
+    )

--- a/models/core/souscription_periode.py
+++ b/models/core/souscription_periode.py
@@ -59,14 +59,17 @@ class SouscriptionPeriode(models.Model):
     energie_hc_kwh = fields.Float(string='Énergie HC (kWh)', compute='_compute_hp_hc', store=True, readonly=False)
     energie_base_kwh = fields.Float(string='Énergie BASE (kWh)', compute='_compute_base', store=True, readonly=False)
 
-    # Provision d'énergie par cadran facturé (#14) — distincte du mesuré/estimé
-    # (energie_*_kwh). C'est CETTE quantité qui est portée sur la facture (voir
-    # _composer_lignes) :
+    # Provision d'énergie par cadran facturé (#14) — l'Énergie facturée
+    # universelle (ADR 0030 décision 2, #234), distincte du mesuré/estimé
+    # (energie_*_kwh). C'est CETTE quantité, et elle seule, qui est portée sur
+    # la facture (voir _quantite_facturee/_composer_lignes) :
     #  - Contrat lissé : provision contractuelle (peuplée à la création depuis la
     #    souscription) ; l'écart avec le mesuré (energie_*_kwh) est suivi par
     #    ecart_*_kwh et soldé en régularisation (ADR 0005).
-    #  - Contrat non lissé : la provision vaut la consommation mesurée/estimée
-    #    (alignée par electricore / le·la facturiste).
+    #  - Contrat non lissé : tamponnée `provision := energie` à la création de
+    #    la facture (_tamponner_provision, appelée par _creer_facture) — la
+    #    meilleure mesure/estimation du moment, gelée dès lors comme le reste
+    #    du snapshot facturé.
     provision_hp_kwh = fields.Float(string='Provision HP (kWh)')
     provision_hc_kwh = fields.Float(string='Provision HC (kWh)')
     provision_base_kwh = fields.Float(string='Provision BASE (kWh)')
@@ -117,7 +120,7 @@ class SouscriptionPeriode(models.Model):
         string='Taux accise (€/MWh)',
         readonly=True,
         help="Taux d'accise servi par electricore ; l'assiette est l'énergie facturée par Odoo "
-        '(la provision si le contrat est lissé) — le montant se calcule côté Odoo.',
+        '(la provision, quel que soit le lissage — ADR 0030) — le montant se calcule côté Odoo.',
     )
     puissance_moyenne_kva = fields.Float(
         string='Puissance moyenne (kVA)',
@@ -502,10 +505,15 @@ class SouscriptionPeriode(models.Model):
     def _quantite_facturee(self, cadran):
         """Quantité d'énergie à facturer pour un cadran facturé ('base'/'hp'/'hc').
 
-        Contrat **lissé** : la *provision* contractuelle (``provision_*_kwh``) ;
-        l'écart avec le mesuré est soldé plus tard en régularisation.
-        Contrat **non lissé** : le *mesuré / estimé* (``energie_*_kwh``) directement.
-        Le choix s'appuie sur le snapshot figé ``lisse_periode`` (ADR 0006).
+        Énergie facturée universelle (ADR 0030 décision 2, #234) : toujours la
+        *provision* (``provision_*_kwh``), lissé ou non — la branche qui lisait
+        le mesuré (``energie_*_kwh``) directement pour un contrat non lissé a
+        disparu. Contrat **lissé** : la provision contractuelle, fixée à la
+        création de la Période. Contrat **non lissé** : la provision est
+        tamponnée ``provision := energie`` à la création de la facture (voir
+        ``_tamponner_provision``, appelée par ``_creer_facture`` avant
+        composition) — elle porte donc déjà la meilleure mesure/estimation du
+        moment quand cette méthode la lit.
         """
         self.ensure_one()
         provision = {
@@ -513,12 +521,7 @@ class SouscriptionPeriode(models.Model):
             'hp': self.provision_hp_kwh,
             'hc': self.provision_hc_kwh,
         }
-        mesure = {
-            'base': self.energie_base_kwh,
-            'hp': self.energie_hp_kwh,
-            'hc': self.energie_hc_kwh,
-        }
-        return provision[cadran] if self.lisse_periode else mesure[cadran]
+        return provision[cadran]
 
     def _composer_lignes(self, grille):
         """Compose les lignes de facture (``[(0, 0, vals)]``) de cette période.
@@ -656,16 +659,49 @@ class SouscriptionPeriode(models.Model):
             'origine': releve.evenement or releve.origine_releve,
         }
 
+    def _tamponner_provision(self):
+        """Tamponne ``provision_* := energie_*`` (par cadran facturé) sur une
+        Période **non lissée**, juste avant sa facturation — Énergie facturée
+        universelle (ADR 0030 décision 2, #234) : la provision devient le
+        facturé pour tout contrat, la branche lissé/non-lissé de
+        ``_quantite_facturee`` meurt. Contrat **lissé** : no-op, la provision
+        contractuelle est déjà fixée à la création (inchangé).
+
+        Doit s'exécuter **avant** ``account.move.create()`` dans
+        ``_creer_facture`` : le verrou de facturation (#14) refuse l'écriture
+        de ``provision_*`` dès qu'une facture référence la Période, donc ce
+        tampon doit précéder le gel. Passe par ``write()`` (pas d'écriture
+        directe), encore autorisé tant que la Période n'est pas facturée.
+
+        Dé-figeage : supprimer la facture dé-fige la Période (#14 write()) ;
+        rappeler ``_creer_facture`` rejoue ce tampon aux valeurs courantes de
+        ``energie_*`` — la future « régularisation des réels » d'un non-lissé
+        rééditée par Enedis emprunte le même mécanisme.
+        """
+        self.ensure_one()
+        if self.lisse_periode:
+            return
+        self.write(
+            {
+                'provision_hp_kwh': self.energie_hp_kwh,
+                'provision_hc_kwh': self.energie_hc_kwh,
+                'provision_base_kwh': self.energie_base_kwh,
+            }
+        )
+
     # Underscore délibéré : ferme la porte RPC externe, même idiome que
     # `sale.order._create_invoices` (décision du grill, amende la revue d'architecture).
     def _creer_facture(self):
         """Émet la facture (``account.move``) de cette période.
 
-        Coquille fine : sélectionne la grille active à la date de fin, compose les
-        lignes (``_composer_lignes``) et crée le move en posant ``periode_id``
-        (source unique du lien Période ↔ Facture, ADR 0004).
+        Tamponne d'abord la provision (``_tamponner_provision``, non-lissé
+        uniquement, no-op sinon), puis sélectionne la grille active à la date
+        de fin, compose les lignes (``_composer_lignes``) et crée le move en
+        posant ``periode_id`` (source unique du lien Période ↔ Facture, ADR
+        0004).
         """
         self.ensure_one()
+        self._tamponner_provision()
         grille = self.env['grille.prix'].get_grille_active(self.date_fin, regime=self.regime_prix_periode)
         facture = self.env['account.move'].create(
             {

--- a/models/core/souscription_periode.py
+++ b/models/core/souscription_periode.py
@@ -681,6 +681,11 @@ class SouscriptionPeriode(models.Model):
         self.ensure_one()
         if self.lisse_periode:
             return
+        if self.facture_id or self.facture_legacy_ref:
+            # Le facturé gelé (ADR 0030) : une Période encore facturée garde sa
+            # provision scellée — refacturer sans dé-figer compose sur le gelé,
+            # même condition que le verrou de write().
+            return
         self.write(
             {
                 'provision_hp_kwh': self.energie_hp_kwh,

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -17,6 +17,7 @@ from . import (
     test_invoice_template,
     test_mails_raccordement,
     test_meta_exhaustivite,
+    test_migration_energie_facturee,
     test_paiements_reglements_attente,
     test_periode_atterrissage,
     test_periode_composition,

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -59,7 +59,9 @@ class TestIntegration(TransactionCase):
                 'date_debut': date(2024, 1, 1),
                 'date_fin': date(2024, 1, 31),
                 'type_periode': 'mensuelle',
-                # Contrat non lissé : on facture le mesuré (energie_*), pas une provision.
+                # Contrat non lissé : la provision est tamponnée sur le mesuré
+                # (energie_*) à la facturation (#234) — on la facture ensuite,
+                # comme tout contrat (ADR 0030 décision 2).
                 'energie_base_kwh': 280.0,
                 'turpe_fixe': 8.50,
                 'turpe_variable': 12.30,
@@ -116,7 +118,8 @@ class TestIntegration(TransactionCase):
                 'date_debut': date(2024, 2, 1),
                 'date_fin': date(2024, 2, 29),
                 'type_periode': 'mensuelle',
-                # Contrat non lissé : on facture le mesuré. Calendrier 4 cadrans →
+                # Contrat non lissé : provision tamponnée sur le mesuré à la
+                # facturation (#234). Calendrier 4 cadrans →
                 # energie_hp = HPH+HPB (180), energie_hc = HCH+HCB (120).
                 'energie_hph_kwh': 180.0,
                 'energie_hch_kwh': 120.0,

--- a/tests/test_migration_energie_facturee.py
+++ b/tests/test_migration_energie_facturee.py
@@ -1,0 +1,137 @@
+"""Tests de la migration `19.0.1.14.0` — backfill `provision := energie` sur
+les Périodes non lissées déjà facturées (#234, ADR 0030 décision 2 —
+Énergie facturée universelle).
+
+Charge le script par chemin (`runpy.run_path`, même idiome que
+`test_releve.py::TestMigrationIndexInteger` — le dossier de version n'est pas
+un identifiant Python importable) et l'exécute contre le curseur réel de la
+transaction de test : le script parle SQL brut, `provision_*` étant verrouillé
+dès qu'une Période est facturée (#14) — la voie ORM (`write()`) lèverait une
+UserError sur exactement les lignes visées ici.
+"""
+
+import os
+import runpy
+from datetime import date
+
+from odoo.tests.common import tagged
+
+from .common import SouscriptionsTestCase
+
+
+@tagged('souscriptions', 'souscriptions_migration', 'post_install', '-at_install')
+class TestMigrationEnergieFacturee(SouscriptionsTestCase):
+    @staticmethod
+    def _migrer(cr):
+        chemin = os.path.join(
+            os.path.dirname(os.path.dirname(__file__)), 'migrations', '19.0.1.14.0', 'post-migrate.py'
+        )
+        module = runpy.run_path(chemin)
+        module['migrate'](cr, None)
+
+    def _periode_facturee(self, souscription, **vals):
+        """Crée une Période et son `account.move` (out_invoice) — facturée,
+        sans passer par `_creer_facture` (on veut la provision non tamponnée,
+        comme l'état pré-#234 que la migration doit réparer)."""
+        base = {
+            'souscription_id': souscription.id,
+            'date_debut': date(2024, 1, 1),
+            'date_fin': date(2024, 1, 31),
+            'type_periode': 'mensuelle',
+        }
+        base.update(vals)
+        periode = self.env['souscription.periode'].create(base)
+        self.env['account.move'].create(
+            {
+                'move_type': 'out_invoice',
+                'partner_id': souscription.partner_id.id,
+                'invoice_date': periode.date_fin,
+                'periode_id': periode.id,
+            }
+        )
+        return periode
+
+    def test_backfill_provision_non_lissee_facturee(self):
+        """AC4 : une non-lissée déjà facturée reçoit `provision := energie`
+        par cadran ; son écart mesuré − facturé est nul après backfill."""
+        periode = self._periode_facturee(self.souscription_base, energie_base_kwh=280.0)
+        self.assertFalse(periode.lisse_periode)
+        self.assertEqual(periode.provision_base_kwh, 0.0)
+
+        self._migrer(self.env.cr)
+        periode.invalidate_recordset()
+
+        self.assertEqual(periode.provision_base_kwh, 280.0)
+        self.assertEqual(periode.ecart_base_kwh, 0.0)
+
+    def test_backfill_par_cadran_hp_hc(self):
+        """Backfill HP/HC : chaque cadran est tamponné indépendamment."""
+        souscription = self.env['souscription.souscription'].create(
+            {
+                'partner_id': self.partner_test.id,
+                'pdl': 'PDL_MIGRATION_HPHC',
+                'puissance_souscrite': '9',
+                'type_tarif': 'hphc',
+                'date_debut': date(2024, 1, 1),
+            }
+        )
+        periode = self._periode_facturee(souscription, energie_hp_kwh=210.0, energie_hc_kwh=95.0)
+        self.assertFalse(periode.lisse_periode)
+
+        self._migrer(self.env.cr)
+        periode.invalidate_recordset()
+
+        self.assertEqual(periode.provision_hp_kwh, 210.0)
+        self.assertEqual(periode.provision_hc_kwh, 95.0)
+        self.assertEqual(periode.ecart_hp_kwh, 0.0)
+        self.assertEqual(periode.ecart_hc_kwh, 0.0)
+
+    def test_lissee_facturee_non_touchee(self):
+        """Une Période lissée facturée n'est pas concernée par le backfill —
+        elle garde sa provision contractuelle, même si elle diverge du
+        mesuré (l'écart lissé se solde en régularisation, pas par backfill)."""
+        periode = self._periode_facturee(
+            self.souscription_hphc,
+            provision_hp_kwh=150.0,
+            provision_hc_kwh=100.0,
+            energie_hp_kwh=999.0,
+            energie_hc_kwh=999.0,
+        )
+        self.assertTrue(periode.lisse_periode)
+
+        self._migrer(self.env.cr)
+        periode.invalidate_recordset()
+
+        self.assertEqual(periode.provision_hp_kwh, 150.0)
+        self.assertEqual(periode.provision_hc_kwh, 100.0)
+
+    def test_non_lissee_non_facturee_non_touchee(self):
+        """Une Période non lissée mais pas encore facturée (aucun move) n'est
+        pas concernée : elle reste le brouillon de travail éditable normal."""
+        periode = self.env['souscription.periode'].create(
+            {
+                'souscription_id': self.souscription_base.id,
+                'date_debut': date(2024, 2, 1),
+                'date_fin': date(2024, 2, 29),
+                'type_periode': 'mensuelle',
+                'energie_base_kwh': 280.0,
+            }
+        )
+        self.assertFalse(periode.facture_id)
+
+        self._migrer(self.env.cr)
+        periode.invalidate_recordset()
+
+        self.assertEqual(periode.provision_base_kwh, 0.0)
+
+    def test_idempotent_rejouer_sans_effet(self):
+        """Rejouer le script après un premier passage est un no-op."""
+        periode = self._periode_facturee(self.souscription_base, energie_base_kwh=280.0)
+
+        self._migrer(self.env.cr)
+        periode.invalidate_recordset()
+        self.assertEqual(periode.provision_base_kwh, 280.0)
+
+        self._migrer(self.env.cr)  # rejoué : rien à corriger
+        periode.invalidate_recordset()
+        self.assertEqual(periode.provision_base_kwh, 280.0)

--- a/tests/test_periode_composition.py
+++ b/tests/test_periode_composition.py
@@ -63,21 +63,27 @@ class TestPeriodeComposition(SouscriptionsTestCase):
         self.assertEqual(hp['quantity'], 150.0)
         self.assertEqual(hc['quantity'], 100.0)
 
-    def test_composer_lignes_non_lisse_facture_le_mesure(self):
-        """Contrat non lissé : on facture le mesuré/estimé (energie_*), pas la
-        provision (issue #14 — clarification provision vs réel)."""
+    def test_composer_lignes_facture_toujours_la_provision(self):
+        """Énergie facturée universelle (ADR 0030 décision 2, #234) : la
+        quantité facturée se lit uniformément depuis la provision, lissé ou
+        non — la branche qui lisait le mesuré (energie_*) directement pour un
+        contrat non lissé a disparu de `_quantite_facturee`. Le tampon
+        `provision := energie` est la responsabilité de `_creer_facture` (via
+        `_tamponner_provision`), pas de `_composer_lignes` : appelée seule,
+        comme ici, elle facture la provision telle qu'elle est stockée, même
+        si elle diverge du mesuré."""
         # souscription_base est non lissée ; calendrier de comptage 'base' →
         # energie_base_kwh est saisi directement.
         periode = self._periode(
             self.souscription_base,
             energie_base_kwh=280.0,
-            provision_base_kwh=999.0,  # ne doit PAS être facturée (non lissé)
+            provision_base_kwh=999.0,  # la provision gagne désormais, même non lissé
         )
         self.assertFalse(periode.lisse_periode)
 
         produits = [d for d in self._dicts(periode._composer_lignes(self.grille_prix)) if d.get('product_id')]
         base = next(d for d in produits if d['name'] == 'Énergie Base')
-        self.assertEqual(base['quantity'], 280.0)
+        self.assertEqual(base['quantity'], 999.0)
 
     def test_composer_lignes_note_turpe_uniquement_si_positif(self):
         """Les notes TURPE n'apparaissent que si le montant est > 0."""
@@ -167,6 +173,51 @@ class TestPeriodeComposition(SouscriptionsTestCase):
         self.assertEqual(facture.invoice_date, periode.date_fin)
         # facture_id dérivé de account.move.periode_id (ADR 0004)
         self.assertEqual(periode.facture_id, facture)
+
+    def test_creer_facture_tamponne_la_provision_non_lissee(self):
+        """AC1 (#234, ADR 0030 décision 2) : facturer une Période non lissée
+        tamponne provision_* aux valeurs mesurées du moment (energie_*) —
+        la facture porte ces quantités tamponnées."""
+        periode = self._periode(self.souscription_base, energie_base_kwh=280.0)
+        self.assertFalse(periode.lisse_periode)
+        self.assertEqual(periode.provision_base_kwh, 0.0)  # pas encore tamponnée
+
+        facture = periode._creer_facture()
+
+        self.assertEqual(periode.provision_base_kwh, 280.0)  # tamponnée par _creer_facture
+        ligne = facture.invoice_line_ids.filtered(lambda l: l.name == 'Énergie Base')
+        self.assertEqual(ligne.quantity, 280.0)
+
+    def test_creer_facture_lissee_ne_touche_pas_la_provision(self):
+        """AC3 (#234) : comportement lissé inchangé — la provision contractuelle
+        fixée à la création n'est pas écrasée par le mesuré à la facturation."""
+        periode = self._periode(self.souscription_hphc, provision_hp_kwh=150.0, provision_hc_kwh=100.0)
+        self.assertTrue(periode.lisse_periode)
+
+        facture = periode._creer_facture()
+
+        self.assertEqual(periode.provision_hp_kwh, 150.0)
+        self.assertEqual(periode.provision_hc_kwh, 100.0)
+        hp = facture.invoice_line_ids.filtered(lambda l: l.name == 'Énergie HP')
+        self.assertEqual(hp.quantity, 150.0)
+
+    def test_defigeage_puis_refacturation_retamponne(self):
+        """AC2 (#234) : supprimer la facture dé-fige la Période (#14) ;
+        refacturer re-tamponne aux valeurs courantes de energie_* (une mesure
+        raffinée après coup est reprise)."""
+        periode = self._periode(self.souscription_base, energie_base_kwh=280.0)
+        facture_1 = periode._creer_facture()
+        self.assertEqual(periode.provision_base_kwh, 280.0)
+
+        facture_1.unlink()  # dé-figeage
+        self.assertFalse(periode.facture_id)
+        periode.write({'energie_base_kwh': 310.0})  # mesure raffinée par electricore
+
+        facture_2 = periode._creer_facture()
+
+        self.assertEqual(periode.provision_base_kwh, 310.0)
+        ligne = facture_2.invoice_line_ids.filtered(lambda l: l.name == 'Énergie Base')
+        self.assertEqual(ligne.quantity, 310.0)
 
     def test_periode_surface_facture_brouillon(self):
         """Une facture en BROUILLON liée à une période reste visible côté gestion :

--- a/tests/test_periode_snapshot.py
+++ b/tests/test_periode_snapshot.py
@@ -74,8 +74,13 @@ class TestPeriodeSnapshotType(SouscriptionsTestCase):
     def test_periode_figee_des_la_facturation(self):
         """Dès qu'une facture référence la période (brouillon de facture compris),
         ses champs facturables sont figés : toute réécriture est rejetée
-        (UserError), y compris via RPC (#14)."""
-        periode = self._periode(self.souscription_base, provision_base_kwh=100.0)
+        (UserError), y compris via RPC (#14).
+
+        `energie_base_kwh` est aligné sur `provision_base_kwh` : souscription_base
+        est non lissée, donc `_creer_facture` tamponne `provision := energie`
+        (#234) — sans cet alignement le tampon écraserait la provision saisie
+        avant de tester le verrou, ce qui n'est pas le sujet de ce test."""
+        periode = self._periode(self.souscription_base, provision_base_kwh=100.0, energie_base_kwh=100.0)
         periode._creer_facture()  # facture créée (brouillon) → période figée
 
         with self.assertRaises(UserError):


### PR DESCRIPTION
Closes #234

Énergie facturée universelle (ADR 0030 décision 2, PRD #231 tranche 3) : `provision_*` devient le
facturé pour tout contrat, pas seulement le lissé. À la facturation d'une Période non lissée,
`_creer_facture` tamponne `provision := energie` (par cadran) avant de composer les lignes — la
branche lissé/non-lissé de `_quantite_facturee` disparaît, la facture lit toujours la provision.
Dé-figer (supprimer la facture) puis refacturer rejoue le tampon aux valeurs courantes. Migration
19.0.1.14.0 : backfill SQL direct `provision := energie` sur les non-lissées déjà facturées (le
verrou #14 bloquerait la voie ORM), idempotent. Le verrou de facturation lui-même est inchangé.

Résultat : l'écart mesuré − facturé redevient significatif pour toutes les Périodes facturées —
la matière première de la future régularisation.

Correctif d'orchestration après première passe de suite : le tampon reprend la condition du
verrou (`facture_id or facture_legacy_ref`) et ne re-tamponne jamais une Période encore
facturée — refacturer sans dé-figer compose sur le gelé (cas documenté par
`test_erreur_periode_deja_facturee`), le dé-figeage re-tamponne comme spécifié.

Suite docker complète verte sur la branche : `0 failed, 0 error(s) of 507 tests`
(dont les 5 tests du nouveau `tests/test_migration_energie_facturee.py`, découverte vérifiée).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
