### PR TITLE
refonte(pull): pull unifié gardé par l'empreinte — mesuré vivant, exemption du verrou (tranche 2 du PRD #231)

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -49,6 +49,7 @@ Journeys de capacités (`REQ-XXX-nn`), chacune avec un statut (✅ Proven · ⚠
 - REQ-FAC-11 ✅ prestations F15 synchronisées puis refacturées (TVA par nature) — preuve: tests/test_sync_prestations.py, tests/test_refacturation.py · #147
 - REQ-FAC-12 ✅ chèques énergie : imputation FIFO à la facturation — preuve: tests/test_periode_facture.py::test_fifo_par_expiration_le_plus_proche_consomme_en_premier, tests/test_cheque_energie.py · #172
 - REQ-FAC-13 ✅ Énergie facturée universelle : la provision, tamponnée `provision := energie` à la facturation pour un contrat non lissé (dé-figeage/refacturation re-tamponne), porte uniformément la quantité facturée ; backfill des non-lissées déjà facturées — preuve: tests/test_periode_composition.py::test_creer_facture_tamponne_la_provision_non_lissee, tests/test_migration_energie_facturee.py · #234
+- REQ-FAC-14 ✅ Pull unifié gardé par l'empreinte : `source_hash` inchangé n'écrit rien, empreinte nouvelle + verdict fiable rafraîchit le mesuré v3 en bloc (relevés remplacés en bloc seulement si non facturée), incalculable/mois absent conservé et signalé ; exemption chirurgicale du verrou de facturation sur le mesuré (jamais la provision) ; scope refresh (plage de mois, ne crée rien) pour la Régularisation — preuve: tests/test_pull_meta_periodes.py::TestPullMetaPeriodesService, tests/test_pull_meta_periodes.py::TestPullMetaPeriodesServiceRefresh, tests/test_periode_atterrissage.py::test_champs_atterrissage_reecrivables_apres_facturation · #235
 
 ## Parcours : espace usager (portail)
 

--- a/docs/adr/0011-contrat-pull-facturation-electricore-cle-rsc-mois.md
+++ b/docs/adr/0011-contrat-pull-facturation-electricore-cle-rsc-mois.md
@@ -9,7 +9,21 @@ d'electricore — `PeriodeMeta` **v3**, qui fait foi
 le fil pour prixer l'abonnement (#78) ; les énergies arrivent **déjà regroupées** base/HP/HC
 (plus de grain `config_cadrans` sur le fil), le détail par registre survivant dans la trace
 d'index `releves_utilises`. La direction, la clé `(RSC, mois)`, le déclencheur facturiste et
-create-missing-only sont inchangés.*
+la clé de **création** create-missing sont inchangés — la politique de **réécriture**, elle,
+change (cf. note ci-dessous).*
+
+*Note (juillet 2026, #235) : le §3 amendé —
+[ADR-0030](0030-facture-gele-mesure-vivant-regularisation-modele-propre-solde-tampon.md)
+décision 1 **unifie** le pull. Le create-missing-only **strict** meurt : un `(RSC, mois)` déjà
+amorcé n'est plus systématiquement ignoré, il est désormais évalué par l'**empreinte**
+(`source_hash`) — inchangée → rien ne bouge (la protection des corrections manuelles du·de la
+facturiste survit, dans le même esprit) ; nouvelle + verdict `réelle`/`estimée` → le mesuré
+(l'atterrissage v3) est rafraîchi **en bloc**, y compris sur une Période **facturée** (exemption
+chirurgicale du verrou #14, jamais la provision) ; `incalculable`/mois absent du flux → conservé,
+signalé. « L'énergie arrivée en retard se reprend par une re-récupération explicite » (fin du §3)
+est donc caduc : la reprise est désormais automatique, gardée par l'empreinte. Portée par
+`souscription.pull.meta.periodes.service`, deux scopes : `pull` (un mois, crée les manquantes) et
+`refresh` (plage de mois, ne crée rien — pour la Régularisation, tranche 4 du PRD #231).*
 
 [ADR-0001](0001-odoo-systeme-ecriture-electricore-api-read-only.md) a tranché la **direction**
 (Odoo *tire*, electricore *calcule-et-renvoie*, n'écrit jamais le nouveau module). Cet ADR fixe

--- a/docs/adr/0015-releves-index-enfant-fige-periode-projete-facture.md
+++ b/docs/adr/0015-releves-index-enfant-fige-periode-projete-facture.md
@@ -1,5 +1,16 @@
 # Relevés d'index : enfant figé de la Période, projeté sur la facture (pas de bundle)
 
+*Note (juillet 2026, #235) : le re-pull « non facturée → remplacement en bloc » annoncé plus bas
+(Conséquences) est **réalisé** —
+[ADR-0030](0030-facture-gele-mesure-vivant-regularisation-modele-propre-solde-tampon.md)
+décision 1 le porte dans `souscription.periode._rafraichir_depuis_meta`, appelée par
+`souscription.pull.meta.periodes.service` : empreinte (`source_hash`) nouvelle + verdict fiable
+sur une Période **non facturée** → `releve_ids` remplacé en bloc (exactement la commande
+`[(5, 0, 0), (0, 0, …)]` prévue ici) et `source_hash` mis à jour. Sur une Période **facturée**,
+ce remplacement est refusé — le relevé-justificatif reste figé (cf. « Figé avec le snapshot »
+ci-dessous, verrou inchangé) ; seul le **mesuré** de la Période (énergies, verdicts, TURPE…) est
+rafraîchi, jamais le relevé. La dette de ce paragraphe s'éteint.*
+
 La facture d'énergie doit **afficher tous les index qu'electricore a utilisés** pour son calcul :
 c'est une **obligation légale** et le support de **vérification** par le·la *souscripteur·rice*
 (re-jouer le calcul de conso). Aujourd'hui le module ne porte **aucun** index : la *Période*

--- a/models/core/souscription_campagne.py
+++ b/models/core/souscription_campagne.py
@@ -340,22 +340,28 @@ class SouscriptionCampagneFacturation(models.Model):
         cible le Périmètre de campagne (#175) pour `self.mois` — aucun mois
         re-proposé, la scope est déjà celle de la campagne — et délègue au
         propriétaire durable du pull, `souscription.pull.meta.periodes.service`
-        (#233, même couture réseau `_ouvrir_flux`/fabrique client, ADR 0024
-        — partagée avec le wizard ad-hoc). Retourne une notification résumant
-        créées/déjà présentes/erreurs — sticky si des erreurs, auto-dismiss
-        sinon — aucun résumé persisté."""
+        (#233, scope facturation `pull()`, même couture réseau
+        `_ouvrir_flux`/fabrique client, ADR 0024 — partagée avec le wizard
+        ad-hoc). Retourne une notification résumant créées/rafraîchies/
+        conservées/erreurs (politique gardée par l'empreinte, ADR 0030
+        décision 1, #235) — sticky si des erreurs, auto-dismiss sinon — aucun
+        résumé persisté."""
         self.ensure_one()
         cibles = self._souscriptions_facturables()
-        creees, existantes, erreurs = self.env['souscription.pull.meta.periodes.service'].pull(cibles, self.mois)
+        creees, rafraichies, inchangees, conservees, erreurs = self.env['souscription.pull.meta.periodes.service'].pull(
+            cibles, self.mois
+        )
         return {
             'type': 'ir.actions.client',
             'tag': 'display_notification',
             'params': {
                 'title': _('Pull méta-périodes'),
                 'message': _(
-                    'Créées : %(creees)s · Déjà présentes : %(existantes)s · Erreurs : %(erreurs)s',
+                    'Créées : %(creees)s · Rafraîchies : %(rafraichies)s · Conservées : %(conservees)s · '
+                    'Erreurs : %(erreurs)s',
                     creees=len(creees),
-                    existantes=len(existantes),
+                    rafraichies=len(rafraichies),
+                    conservees=len(conservees),
                     erreurs=len(erreurs),
                 ),
                 'type': 'warning' if erreurs else 'success',

--- a/models/core/souscription_periode.py
+++ b/models/core/souscription_periode.py
@@ -294,11 +294,22 @@ class SouscriptionPeriode(models.Model):
 
         return super().create(vals_list)
 
-    # Champs facturables figés : dès qu'une facture référence la période, les
+    # Champs **facturés**, gelés : dès qu'une facture référence la période, les
     # réécrire désaccorderait la facture de la période. Le verrou (#14) les
     # protège ; les champs techniques/calculés (facture_id, facture_state,
     # mois_annee, jours…) restent recalculables par l'ORM (passe par _write, pas
     # par ce write public).
+    #
+    # Le **mesuré** — l'atterrissage réseau v3 (énergies par cadran, verdicts,
+    # TURPE fixe/variable, CTA, taux d'accise, puissance moyenne, empreinte) —
+    # est volontairement ABSENT de cette liste (ADR 0030 décision 1, #235) :
+    # exemption chirurgicale du verrou, il redevient réécrivable après
+    # facturation, gardé par l'empreinte côté pull
+    # (`souscription.pull.meta.periodes.service`) et à la main par le·la
+    # facturiste (correction directe). Seul le **facturé** — provisions, jours
+    # (dérivé de date_debut/date_fin, tous deux ici), snapshot contractuel,
+    # relevés-justificatifs (verrou propre, souscription_releve.py) — reste
+    # verrouillé ; aucun canal de pull n'écrit jamais `provision_*`.
     _LOCKED_FIELDS = frozenset(
         {
             'date_debut',
@@ -307,18 +318,9 @@ class SouscriptionPeriode(models.Model):
             'lisse',
             'config_cadrans',
             'type_periode',
-            'energie_hph_kwh',
-            'energie_hpb_kwh',
-            'energie_hch_kwh',
-            'energie_hcb_kwh',
-            'energie_hp_kwh',
-            'energie_hc_kwh',
-            'energie_base_kwh',
             'provision_hp_kwh',
             'provision_hc_kwh',
             'provision_base_kwh',
-            'turpe_fixe',
-            'turpe_variable',
             'type_tarif_periode',
             'tarif_solidaire_periode',
             'regime_prix_periode',
@@ -326,16 +328,10 @@ class SouscriptionPeriode(models.Model):
             'puissance_souscrite_periode',
             'provision_mensuelle_kwh_periode',
             'coeff_pro_periode',
-            # Identité et atterrissage v3 (#76, ADR 0020 §7) : figés au même titre
-            # que le reste du snapshot dès qu'une facture référence la période.
+            # Identité (#76, ADR 0020 §7, ADR 0010) : snapshot au même titre
+            # que le reste du contrat — jamais réécrite par le pull (la clé
+            # (RSC, mois) se lit sur la Souscription courante, pas la Période).
             'ref_situation_contractuelle',
-            'qualite',
-            'statut_communication',
-            'has_changement',
-            'source_hash',
-            'cta_eur',
-            'taux_accise_eur_mwh',
-            'puissance_moyenne_kva',
             # Référence de la facture legacy (#107) : au même titre que
             # facture_id, sa présence fige la période — l'écraser romprait le
             # lien vers la facture prod sans passer par le verrou.
@@ -624,18 +620,7 @@ class SouscriptionPeriode(models.Model):
             'date_debut': fields.Date.to_date(meta.debut),
             'date_fin': fields.Date.to_date(meta.fin),
             'type_periode': 'mensuelle',
-            'puissance_moyenne_kva': meta.puissance_moyenne_kva or 0.0,
-            'energie_base_kwh': meta.energie_base_kwh or 0.0,
-            'energie_hp_kwh': meta.energie_hp_kwh or 0.0,
-            'energie_hc_kwh': meta.energie_hc_kwh or 0.0,
-            'turpe_fixe': meta.turpe_fixe_eur or 0.0,
-            'turpe_variable': meta.turpe_variable_eur or 0.0,
-            'cta_eur': meta.cta_eur or 0.0,
-            'taux_accise_eur_mwh': meta.taux_accise_eur_mwh or 0.0,
-            'has_changement': bool(meta.has_changement),
-            'qualite': meta.qualite or 'incalculable',
-            'statut_communication': meta.statut_communication or False,
-            'source_hash': meta.source_hash,
+            **self._vals_atterrissage_v3(meta),
             'releve_ids': [(0, 0, self._releve_vals_depuis_objet(releve)) for releve in (meta.releves_utilises or [])],
         }
         return self.create(vals)
@@ -658,6 +643,56 @@ class SouscriptionPeriode(models.Model):
             'releve_externe_id': releve.releve_id,
             'origine': releve.evenement or releve.origine_releve,
         }
+
+    # Champs de l'atterrissage v3 rafraîchis EN BLOC par le pull (ADR 0030
+    # décision 1, #235) — jamais d'énergie fraîche sur TURPE périmé : un seul
+    # `write()`. Volontairement absents : `date_debut`/`date_fin`/
+    # `type_periode`/`ref_situation_contractuelle` (identité, jamais réécrite
+    # par le pull) et `provision_*` (le facturé, jamais écrit par aucun canal
+    # de pull).
+    def _vals_atterrissage_v3(self, meta):
+        return {
+            'puissance_moyenne_kva': meta.puissance_moyenne_kva or 0.0,
+            'energie_base_kwh': meta.energie_base_kwh or 0.0,
+            'energie_hp_kwh': meta.energie_hp_kwh or 0.0,
+            'energie_hc_kwh': meta.energie_hc_kwh or 0.0,
+            'turpe_fixe': meta.turpe_fixe_eur or 0.0,
+            'turpe_variable': meta.turpe_variable_eur or 0.0,
+            'cta_eur': meta.cta_eur or 0.0,
+            'taux_accise_eur_mwh': meta.taux_accise_eur_mwh or 0.0,
+            'has_changement': bool(meta.has_changement),
+            'qualite': meta.qualite or 'incalculable',
+            'statut_communication': meta.statut_communication or False,
+            'source_hash': meta.source_hash,
+        }
+
+    def _rafraichir_depuis_meta(self, meta):
+        """Rafraîchit une Période **déjà amorcée** depuis une nouvelle `meta`
+        (#235, ADR 0030 décision 1) : appelée par
+        `souscription.pull.meta.periodes.service` une fois l'empreinte jugée
+        nouvelle et le verdict fiable (`réelle`/`estimée`) — cette méthode
+        écrit **inconditionnellement**, la garde vit chez l'appelant.
+
+        Écrase l'atterrissage réseau v3 **en bloc** (`_vals_atterrissage_v3`) —
+        un seul `write()`, jamais d'énergie fraîche sur TURPE périmé. Passe
+        par `write()` (pas d'écriture directe) : l'exemption ciblée du verrou
+        de facturation (#14, cf. `_LOCKED_FIELDS`) rend cette écriture valide
+        même sur une Période facturée — c'est précisément ce qui réalise « le
+        mesuré vivant » d'ADR 0030.
+
+        Relevés : remplacés **en bloc** (`releve_ids`, le re-pull promis par
+        ADR 0015) **seulement si la Période n'est pas encore facturée** — sur
+        une Période facturée, le relevé-justificatif reste figé (verrou propre
+        de `souscription.releve`, jamais contourné ici) et `releve_ids` est
+        absent des vals, donc intact.
+        """
+        self.ensure_one()
+        vals = self._vals_atterrissage_v3(meta)
+        if not (self.facture_id or self.facture_legacy_ref):
+            vals['releve_ids'] = [(5, 0, 0)] + [
+                (0, 0, self._releve_vals_depuis_objet(releve)) for releve in (meta.releves_utilises or [])
+            ]
+        self.write(vals)
 
     def _tamponner_provision(self):
         """Tamponne ``provision_* := energie_*`` (par cadran facturé) sur une

--- a/models/core/souscription_pull_meta_periodes_service.py
+++ b/models/core/souscription_pull_meta_periodes_service.py
@@ -1,43 +1,63 @@
-"""Propriétaire durable du pull des méta-périodes electricore (#233, tranche 1
-du PRD #231 — « le facturé gelé, le mesuré vivant », ADR 0030).
+"""Propriétaire durable du pull des méta-périodes electricore — pull **unifié**
+gardé par l'empreinte (#235, tranche 2 du PRD #231 — ADR 0030 décision 1,
+amende ADR-0011/0015).
 
-Extrait du wizard transient `souscription.pull.meta.periodes.wizard` (#77),
-qui en était jusqu'ici le seul propriétaire : ce module porte désormais la
-méthode de transport nommée (couture de test, ADR 0024 §6), le mapping du
-contrat v3 (`souscription.periode._amorcer_depuis_meta`) et la politique
-d'écriture **actuelle** — create-missing-only, skip-and-report par savepoint
-(ADR 0011) — sur un `AbstractModel` durable, même motif que
-`souscription.rsc.service`. Le wizard mensuel et le bouton Campagne
-(`souscription.campagne.facturation.action_pull_meta_periodes`) en deviennent
-des coquilles minces qui délèguent à `pull()` et formatent le résultat :
-**zéro changement de comportement observable** (pur prefactor, carte
-« propriétaire durable du pull » de la revue d'architecture du 2026-07-12).
+Politique d'écriture unique, appliquée à chaque `(souscription, mois)` déjà
+amorcé :
 
-La politique unifiée gardée par l'empreinte (ADR 0030 §1 : `source_hash`
-inchangé -> ne rien toucher, empreinte nouvelle + verdict réel/estimé ->
-écraser) arrive à la tranche suivante — ce service reste create-missing-only
-pour l'instant.
+- `source_hash` **inchangé** -> rien n'est touché (une correction manuelle du·
+  de la facturiste survit à la relecture de données inchangées) ;
+- empreinte **nouvelle** + verdict `réelle`/`estimée` -> écrase l'atterrissage
+  réseau v3 **en bloc** (`souscription.periode._rafraichir_depuis_meta`) —
+  jamais d'énergie fraîche sur TURPE périmé — et, **seulement si la Période
+  n'est pas facturée**, remplace aussi les relevés en bloc (le re-pull promis
+  par ADR 0015) ;
+- `incalculable` ou mois absent du flux -> la valeur stockée est conservée,
+  signalée au rapport (« je ne sais pas » n'écrase pas « je savais »).
+
+Le create-missing-only **strict** d'ADR 0011 meurt : create-missing reste la
+politique de **création** (une Période déjà amorcée n'est jamais recréée),
+mais elle n'est plus systématiquement **ignorée** — elle est désormais
+évaluée par l'empreinte ci-dessus.
+
+Exemption chirurgicale du verrou de facturation (#14) : le **mesuré** d'une
+Période facturée redevient réécrivable par ce service (et par le·la
+facturiste à la main, cf. `souscription.periode._LOCKED_FIELDS`). Le
+**facturé** (provisions, jours, snapshot contractuel, relevés-justificatifs)
+reste refusé — ce service n'écrit **jamais** `provision_*`.
+
+Deux scopes partagent cette politique (ADR 0030 conséquences) :
+- `pull(souscriptions, mois)` — scope **facturation** : un mois, crée les
+  Périodes manquantes (wizard ad-hoc, bouton Campagne) ;
+- `refresh(souscriptions, mois_debut, mois_fin)` — scope **refresh** : plage
+  de mois, ne crée jamais de Période (consommé par la Régularisation,
+  tranche 4 du PRD #231, pour rafraîchir le mesuré des mois candidats avant
+  de calculer les écarts).
 """
 
 from __future__ import annotations
+
+from datetime import date
 
 from odoo import fields, models
 from odoo.exceptions import UserError
 
 from .electricore_client_fabrique import ContractVersionError, IngestionEnCours, PreconditionNonRemplie
 
+# Verdicts electricore jugés fiables pour écraser le mesuré stocké (ADR 0030
+# décision 1) — les termes du glossaire electricore, accents compris
+# (CONTEXT.md « Qualité »).
+_QUALITES_FIABLES = ('réelle', 'estimée')
+
 
 class SouscriptionPullMetaPeriodesService(models.AbstractModel):
     _name = 'souscription.pull.meta.periodes.service'
-    _description = 'Pull des méta-périodes electricore — propriétaire durable (ADR 0011/0024, #233)'
+    _description = "Pull unifié des méta-périodes electricore, gardé par l'empreinte (ADR 0030, #235)"
 
     def pull(self, souscriptions, mois):
-        """Point d'entrée unique du pull (#233 AC1) : acquiert le client
-        (fabrique `souscription.electricore.client`, ADR 0024), ouvre le flux
-        `meta_periodes` pour `mois` sur les RSC de `souscriptions`, crée les
-        périodes manquantes (create-missing-only) avec savepoint par élément
-        (skip-and-report, ADR 0011) et mappe les exceptions typées electricore
-        en `UserError`.
+        """Scope **facturation** (#233/#235) : un mois, crée les Périodes
+        manquantes (create-missing) et rafraîchit les existantes selon la
+        politique gardée par l'empreinte (docstring du module).
 
         Args:
             souscriptions: le périmètre déjà voulu par l'appelant (toutes-RSC
@@ -48,49 +68,129 @@ class SouscriptionPullMetaPeriodesService(models.AbstractModel):
                 comptent).
 
         Returns:
-            tuple[list[str], list[str], list[str]] : `(creees, existantes,
-            erreurs)`, trois listes de libellés consommées par le résumé du
-            wizard ad-hoc et par le résultat/toast de la Campagne (#158/#176).
+            tuple[list[str], list[str], list[str], list[str], list[str]] :
+            `(creees, rafraichies, inchangees, conservees, erreurs)`, cinq
+            listes de libellés consommées par le résumé du wizard ad-hoc et
+            par le résultat/toast de la Campagne (#158/#176).
         """
+        return self._pull_un_mois(souscriptions, mois, creer_manquantes=True)
+
+    def refresh(self, souscriptions, mois_debut, mois_fin):
+        """Scope **refresh** (#235 AC6) : rafraîchit, gardé par l'empreinte,
+        les Périodes déjà amorcées sur la plage `[mois_debut, mois_fin]`
+        (bornes incluses, tronquées au 1er du mois) — ne crée **jamais** de
+        Période manquante. Consommé par la Régularisation (tranche 4 du PRD
+        #231) pour rafraîchir le mesuré des mois candidats avant de calculer
+        les écarts.
+
+        Un appel de flux electricore **par mois** : l'endpoint
+        `meta_periodes` (contrat v3) ne sait interroger qu'un seul mois à la
+        fois — le coût est proportionnel au nombre de mois de la plage, pas
+        au nombre de souscriptions.
+
+        Returns:
+            Même forme à cinq listes que `pull()` (`creees` toujours vide).
+        """
+        debut = fields.Date.to_date(mois_debut).replace(day=1)
+        fin = fields.Date.to_date(mois_fin).replace(day=1)
+        creees, rafraichies, inchangees, conservees, erreurs = [], [], [], [], []
+        mois_courant = debut
+        while mois_courant <= fin:
+            c, r, i, cons, e = self._pull_un_mois(souscriptions, mois_courant, creer_manquantes=False)
+            creees += c
+            rafraichies += r
+            inchangees += i
+            conservees += cons
+            erreurs += e
+            mois_courant = self._mois_suivant(mois_courant)
+        return creees, rafraichies, inchangees, conservees, erreurs
+
+    @staticmethod
+    def _mois_suivant(mois):
+        """1er du mois suivant `mois` — sans dépendance à dateutil (même
+        idiome que `souscription.campagne.facturation._default_mois`)."""
+        return date(mois.year + (mois.month // 12), mois.month % 12 + 1, 1)
+
+    def _pull_un_mois(self, souscriptions, mois, *, creer_manquantes):
+        """Un seul appel de flux `meta_periodes` pour `mois`, appliqué selon
+        la politique gardée par l'empreinte à toutes les souscriptions à RSC
+        de `souscriptions` — brique partagée par `pull()` et `refresh()`."""
         client = self.env['souscription.electricore.client'].client()
         Periode = self.env['souscription.periode']
         par_rsc = {s.ref_situation_contractuelle: s for s in souscriptions if s.ref_situation_contractuelle}
 
-        creees, existantes, erreurs = [], [], []
+        creees, rafraichies, inchangees, conservees, erreurs = [], [], [], [], []
+        if not par_rsc:
+            return creees, rafraichies, inchangees, conservees, erreurs
 
-        if par_rsc:
-            mois_str = fields.Date.to_string(mois)
-            try:
-                with self._ouvrir_flux(client, mois_str, list(par_rsc)) as stream:
-                    for meta in stream:
-                        souscription = par_rsc.get(meta.ref_situation_contractuelle)
-                        if souscription is None:
-                            continue  # RSC hors du filtre demandé, ignorée silencieusement
-                        try:
-                            # Savepoint par élément (skip-and-report, ADR 0011) :
-                            # un échec de mapping/contrainte sur une RSC ne doit
-                            # ni écrire de résultat partiel ni casser le curseur
-                            # pour les RSC suivantes du même lot.
-                            with self.env.cr.savepoint():
-                                self._amorcer_une(Periode, souscription, meta, creees, existantes)
-                        except Exception as exc:
-                            erreurs.append(f'{souscription.name} ({meta.ref_situation_contractuelle}) : {exc}')
-            except IngestionEnCours:
-                raise UserError("L'ingestion electricore est en cours (verrou base) : réessayez plus tard.")
-            except PreconditionNonRemplie as exc:
-                raise UserError(f'Précondition non remplie côté electricore : {exc}')
-            except ContractVersionError as exc:
-                raise UserError(f'Contrat electricore obsolète : {exc}')
+        # `mois_cle_requete` : le mois demandé au serveur — sert à construire
+        # `mois_str` et, en repli, à chercher les Périodes déjà amorcées dont
+        # la RSC n'est pas revenue dans le lot (aucune `meta` disponible pour
+        # ces cas, cf. plus bas). La recherche par (souscription, mois) d'une
+        # RSC **présente** dans le flux dérive plutôt son `mois_cle` de
+        # `meta.debut` (dans `_appliquer_une`, même idiome que
+        # `_amorcer_depuis_meta`) — défensif si jamais le serveur tronque le
+        # mois différemment de ce qui a été demandé.
+        mois_cle_requete = fields.Date.to_date(mois).replace(day=1)
+        mois_str = fields.Date.to_string(mois_cle_requete)
+        rsc_traitees = set()
 
-        return creees, existantes, erreurs
+        try:
+            with self._ouvrir_flux(client, mois_str, list(par_rsc)) as stream:
+                for meta in stream:
+                    souscription = par_rsc.get(meta.ref_situation_contractuelle)
+                    if souscription is None:
+                        continue  # RSC hors du filtre demandé, ignorée silencieusement
+                    rsc_traitees.add(meta.ref_situation_contractuelle)
+                    try:
+                        # Savepoint par élément (skip-and-report, ADR 0011) :
+                        # un échec de mapping/contrainte sur une RSC ne doit
+                        # ni écrire de résultat partiel ni casser le curseur
+                        # pour les RSC suivantes du même lot.
+                        with self.env.cr.savepoint():
+                            self._appliquer_une(
+                                Periode,
+                                souscription,
+                                meta,
+                                creer_manquantes=creer_manquantes,
+                                creees=creees,
+                                rafraichies=rafraichies,
+                                inchangees=inchangees,
+                                conservees=conservees,
+                            )
+                    except Exception as exc:
+                        erreurs.append(f'{souscription.name} ({mois_str}) : {exc}')
+        except IngestionEnCours:
+            raise UserError("L'ingestion electricore est en cours (verrou base) : réessayez plus tard.")
+        except PreconditionNonRemplie as exc:
+            raise UserError(f'Précondition non remplie côté electricore : {exc}')
+        except ContractVersionError as exc:
+            raise UserError(f'Contrat electricore obsolète : {exc}')
 
-    def _amorcer_une(self, Periode, souscription, meta, creees, existantes):
-        """Create-missing-only (ADR 0011) : un `(souscription, mois)` déjà
-        amorcé n'est jamais réécrit. Recherche explicite d'abord (lisible,
-        rapide) ; la contrainte unique mensuelle (ADR 0020 §2) reste le
-        garde-fou de dernier recours si deux amorçages se recouvraient malgré
-        tout — remontée comme une erreur normale, absorbée par le savepoint
-        appelant."""
+        # Mois absent du flux (ADR 0030 décision 1) : une Période déjà
+        # amorcée dont la RSC n'est pas revenue dans ce lot est conservée et
+        # signalée — « je ne sais pas » n'écrase pas « je savais ».
+        rsc_absentes = [rsc for rsc in par_rsc if rsc not in rsc_traitees]
+        if rsc_absentes:
+            souscription_ids = [par_rsc[rsc].id for rsc in rsc_absentes]
+            existantes = Periode.search(
+                [
+                    ('souscription_id', 'in', souscription_ids),
+                    ('mois', '=', mois_cle_requete),
+                    ('type_periode', '=', 'mensuelle'),
+                ]
+            )
+            for periode in existantes:
+                conservees.append(f'{periode.souscription_id.name} ({periode.mois_annee}) : mois absent du flux')
+
+        return creees, rafraichies, inchangees, conservees, erreurs
+
+    def _appliquer_une(
+        self, Periode, souscription, meta, *, creer_manquantes, creees, rafraichies, inchangees, conservees
+    ):
+        """Applique la politique gardée par l'empreinte (ADR 0030 décision 1)
+        à un couple `(souscription, mois)` face à une `meta` du flux — le mois
+        se dérive de `meta.debut` (même idiome que `_amorcer_depuis_meta`)."""
         mois_cle = fields.Date.to_date(meta.debut).replace(day=1)
         existante = Periode.search(
             [
@@ -100,11 +200,24 @@ class SouscriptionPullMetaPeriodesService(models.AbstractModel):
             ],
             limit=1,
         )
-        if existante:
-            existantes.append(f'{souscription.name} ({meta.mois_annee})')
+
+        if not existante:
+            if creer_manquantes:
+                Periode._amorcer_depuis_meta(souscription, meta)
+                creees.append(f'{souscription.name} ({meta.mois_annee})')
+            return  # scope refresh : ne crée jamais (#235 AC6)
+
+        if existante.source_hash and existante.source_hash == meta.source_hash:
+            inchangees.append(f'{souscription.name} ({meta.mois_annee})')
             return
-        Periode._amorcer_depuis_meta(souscription, meta)
-        creees.append(f'{souscription.name} ({meta.mois_annee})')
+
+        qualite = meta.qualite or 'incalculable'
+        if qualite not in _QUALITES_FIABLES:
+            conservees.append(f'{souscription.name} ({meta.mois_annee}) : qualité {qualite}')
+            return
+
+        existante._rafraichir_depuis_meta(meta)
+        rafraichies.append(f'{souscription.name} ({meta.mois_annee})')
 
     def _ouvrir_flux(self, client, mois_str, rsc):
         """Point de transport unique : ouvre le flux `meta_periodes` (context

--- a/models/wizard/souscription_pull_meta_periodes_wizard.py
+++ b/models/wizard/souscription_pull_meta_periodes_wizard.py
@@ -2,11 +2,11 @@
 
 Coquille mince (#233, tranche 1 du PRD #231) : le propriétaire durable du
 pull — méthode de transport nommée, mapping du contrat v3, politique
-create-missing-only/skip-and-report (ADR 0011/0024) — vit désormais dans
-`souscription.pull.meta.periodes.service`. Ce wizard ne fait plus que
+d'écriture gardée par l'empreinte (ADR 0030 décision 1, #235) — vit désormais
+dans `souscription.pull.meta.periodes.service`. Ce wizard ne fait plus que
 construire le périmètre (toutes les souscriptions, avec/sans RSC), déléguer
-le tirage au service et formater le résumé (créées / déjà existantes / sans
-RSC / erreurs) — zéro changement de comportement observable.
+le tirage au service (scope facturation, `pull()`) et formater le résumé
+(créées / rafraîchies / inchangées / conservées / sans RSC / erreurs).
 """
 
 from __future__ import annotations
@@ -38,8 +38,10 @@ class SouscriptionPullMetaPeriodesWizard(models.TransientModel):
 
     def action_lancer(self):
         """Récupère les méta-périodes du mois pour toutes les souscriptions à
-        RSC, crée les périodes manquantes (create-missing-only), résume le
-        résultat (créées / déjà existantes / sans RSC / erreurs).
+        RSC (scope facturation, `pull()`) : crée les périodes manquantes,
+        rafraîchit les existantes selon la politique gardée par l'empreinte
+        (ADR 0030 décision 1, #235), résume le résultat (créées / rafraîchies
+        / inchangées / conservées / sans RSC / erreurs).
 
         Chemin ad-hoc (mois saisi, portée toutes-RSC) : délègue le tirage au
         service `souscription.pull.meta.periodes.service` (#233), le même que
@@ -53,9 +55,11 @@ class SouscriptionPullMetaPeriodesWizard(models.TransientModel):
         avec_rsc = Souscription.search([('ref_situation_contractuelle', '!=', False), ('active', '=', True)])
         sans_rsc = Souscription.search([('ref_situation_contractuelle', '=', False), ('active', '=', True)])
 
-        creees, existantes, erreurs = self.env['souscription.pull.meta.periodes.service'].pull(avec_rsc, self.mois)
+        creees, rafraichies, inchangees, conservees, erreurs = self.env['souscription.pull.meta.periodes.service'].pull(
+            avec_rsc, self.mois
+        )
 
-        self.resultat = self._formatter_resultat(creees, existantes, sans_rsc, erreurs)
+        self.resultat = self._formatter_resultat(creees, rafraichies, inchangees, conservees, sans_rsc, erreurs)
         self.state = 'done'
         return {
             'type': 'ir.actions.act_window',
@@ -66,18 +70,26 @@ class SouscriptionPullMetaPeriodesWizard(models.TransientModel):
         }
 
     @staticmethod
-    def _formatter_resultat(creees, existantes, sans_rsc, erreurs):
+    def _formatter_resultat(creees, rafraichies, inchangees, conservees, sans_rsc, erreurs):
         lignes = [
             f'Créées : {len(creees)}',
-            f'Déjà existantes : {len(existantes)}',
+            f'Rafraîchies : {len(rafraichies)}',
+            f'Inchangées : {len(inchangees)}',
+            f'Conservées (signalées) : {len(conservees)}',
             f'Sans RSC (ignorées) : {len(sans_rsc)}',
             f'Erreurs : {len(erreurs)}',
             '',
         ]
         if creees:
             lignes += ['Périodes créées :'] + [f'  - {ligne}' for ligne in creees] + ['']
-        if existantes:
-            lignes += ['Déjà existantes (non réécrites) :'] + [f'  - {ligne}' for ligne in existantes] + ['']
+        if rafraichies:
+            lignes += ['Rafraîchies (mesuré v3 en bloc) :'] + [f'  - {ligne}' for ligne in rafraichies] + ['']
+        if conservees:
+            lignes += (
+                ['Conservées (empreinte incertaine ou mois absent, signalées) :']
+                + [f'  - {ligne}' for ligne in conservees]
+                + ['']
+            )
         if sans_rsc:
             lignes += ['Souscriptions sans RSC (ignorées) :'] + [f'  - {s.name}' for s in sans_rsc] + ['']
         if erreurs:

--- a/tests/test_campagne_etapes_actions.py
+++ b/tests/test_campagne_etapes_actions.py
@@ -71,7 +71,7 @@ class TestCampagneEtapePullMetaPeriodes(SouscriptionsTestCase):
         self.assertEqual(action['tag'], 'display_notification')
         params = action['params']
         self.assertIn('Créées : 1', params['message'])
-        self.assertIn('Déjà présentes : 0', params['message'])
+        self.assertIn('Rafraîchies : 0', params['message'])
         self.assertIn('Erreurs : 0', params['message'])
         self.assertEqual(params['type'], 'success')
         self.assertFalse(params['sticky'], "pas d'erreur -> toast auto-dismiss")

--- a/tests/test_periode_atterrissage.py
+++ b/tests/test_periode_atterrissage.py
@@ -1,12 +1,19 @@
 """
 Tests des champs d'atterrissage du contrat PeriodeMeta v3 electricore
-(#76, ADR 0020 §4/§6/§7).
+(#76, ADR 0020 §4/§6/§7 ; exemption chirurgicale du verrou #235, ADR 0030
+décision 1).
 
 `qualite`/`statut_communication` (verdicts jumeaux), `has_changement`,
 `source_hash`, `cta_eur`, `taux_accise_eur_mwh`, `puissance_moyenne_kva`
 atterrissent sur la Période sous le nom du contrat. `releve_externe_id` et
-`origine` portent la provenance du justificatif sur le Relevé. Tous figés dès
-la facturation (ADR 0007), symétrique du verrou existant (#14).
+`origine` portent la provenance du justificatif sur le Relevé.
+
+Depuis #235 (ADR 0030 décision 1), l'atterrissage v3 — le **mesuré** — est
+volontairement EXEMPTÉ du verrou de facturation : il redevient réécrivable
+après facturation (par le pull, gardé par l'empreinte, et par le·la
+facturiste à la main). Seul le **facturé** (provisions, jours, snapshot
+contractuel) reste verrouillé ; les relevés-justificatifs suivent leur propre
+verrou (souscription_releve.py), jamais contourné.
 """
 
 from datetime import date
@@ -56,20 +63,39 @@ class TestPeriodeAtterrissage(SouscriptionsTestCase):
         periode = self._periode(self.souscription_base, qualite='incalculable')
         self.assertEqual(periode.qualite, 'incalculable')
 
-    def test_champs_atterrissage_verrouilles_apres_facturation(self):
-        """Dès qu'une facture référence la période, les champs d'atterrissage
-        sont figés (extension du verrou #14, ADR 0020 §7)."""
-        periode = self._periode(self.souscription_base, provision_base_kwh=100.0, cta_eur=4.2)
+    def test_champs_atterrissage_reecrivables_apres_facturation(self):
+        """AC5 (#235, ADR 0030 décision 1) : exemption chirurgicale du verrou
+        — le mesuré (atterrissage v3) devient réécrivable dès qu'une facture
+        référence la période (le pull le rafraîchit, le·la facturiste peut
+        aussi corriger l'énergie à la main)."""
+        periode = self._periode(self.souscription_base, provision_base_kwh=100.0, energie_base_kwh=100.0, cta_eur=4.2)
+        periode._creer_facture()
+
+        periode.write({'cta_eur': 999.0})
+        periode.write({'qualite': 'réelle'})
+        periode.write({'puissance_moyenne_kva': 12.0})
+        periode.write({'energie_base_kwh': 310.0})  # correction manuelle du·de la facturiste
+
+        self.assertEqual(periode.cta_eur, 999.0)
+        self.assertEqual(periode.qualite, 'réelle')
+        self.assertEqual(periode.puissance_moyenne_kva, 12.0)
+        self.assertEqual(periode.energie_base_kwh, 310.0)
+
+    def test_facture_gele_provisions_jours_et_snapshot_malgre_lexemption(self):
+        """AC5 : le verrou refuse toujours provisions/jours (dérivé des
+        dates)/snapshot contractuel — l'exemption du mesuré ne les concerne
+        pas, aucun canal de pull n'écrit jamais la provision."""
+        periode = self._periode(self.souscription_base, provision_base_kwh=100.0, energie_base_kwh=100.0, cta_eur=4.2)
         periode._creer_facture()
 
         with self.assertRaises(UserError):
-            periode.write({'cta_eur': 999.0})
+            periode.write({'provision_base_kwh': 999.0})
         with self.assertRaises(UserError):
-            periode.write({'qualite': 'réelle'})
+            periode.write({'date_debut': date(2024, 1, 2)})
         with self.assertRaises(UserError):
-            periode.write({'puissance_moyenne_kva': 12.0})
+            periode.write({'type_tarif_periode': 'hphc'})
 
-        self.assertEqual(periode.cta_eur, 4.2)
+        self.assertEqual(periode.provision_base_kwh, 100.0)
 
 
 @tagged('souscriptions', 'souscriptions_atterrissage', 'post_install', '-at_install')

--- a/tests/test_pull_meta_periodes.py
+++ b/tests/test_pull_meta_periodes.py
@@ -1,15 +1,20 @@
 """
 Tests du pull des méta-périodes (#77, ADR 0011/0019/0020 ; service extrait
-#233, tranche 1 du PRD #231).
+#233, tranche 1 du PRD #231 ; pull unifié gardé par l'empreinte #235, tranche
+2 du PRD #231 — ADR 0030 décision 1).
 
-Trois tranches :
+Quatre tranches :
 - `_amorcer_depuis_meta` / `_releve_vals_depuis_objet` : mapping pur
   `PeriodeMeta`/`ObjetReleve` → `create()`, testé avec des stubs duck-typés
   (aucune dépendance à `electricore_client`, cf. la garde d'import de la
   fabrique).
+- `_rafraichir_depuis_meta` : mapping pur `PeriodeMeta` → `write()` en bloc
+  sur une Période déjà amorcée (#235), relevés remplacés en bloc seulement
+  si non facturée.
 - Le service `souscription.pull.meta.periodes.service` — propriétaire
-  durable du pull (#233) : create-missing-only, skip-and-report, erreurs
-  typées mappées — client mocké.
+  durable du pull (#233), gardé par l'empreinte (#235) : create-missing,
+  écriture gardée par `source_hash`, skip-and-report, erreurs typées
+  mappées, scope refresh — client mocké.
 - Le wizard « Récupérer les périodes du mois », coquille mince (#233) :
   périmètre avec/sans RSC + formatage du résumé, délègue au service.
 
@@ -19,13 +24,14 @@ Fixtures RSC/PDL : identifiants factices (jamais des vrais échantillons).
 import unittest
 from datetime import date, timedelta
 from types import SimpleNamespace
+from unittest.mock import MagicMock
 
 from odoo.addons.souscriptions_odoo.models.core import electricore_client_fabrique as fabrique_module
 from odoo.addons.souscriptions_odoo.models.core import souscription_pull_meta_periodes_service as service_module
 from odoo.exceptions import UserError
 from odoo.tests.common import tagged
 
-from .common import SouscriptionsTestCase, client_flux_factice, patcher_client_fabrique
+from .common import SouscriptionsTestCase, client_flux_factice, flux_electricore, patcher_client_fabrique
 
 
 def _objet_releve(**kwargs):
@@ -183,25 +189,114 @@ class TestAmorcerDepuisMeta(SouscriptionsTestCase):
                 self.env['souscription.periode']._amorcer_depuis_meta(self.souscription_base, _periode_meta())
 
 
-# === Service « propriétaire durable du pull » (#233) : client mocké ===
+# === `_rafraichir_depuis_meta` : mapping pur PeriodeMeta -> write() en bloc
+# sur une Période déjà amorcée (#235, ADR 0030 décision 1). Appelée par le
+# service une fois l'empreinte/le verdict jugés fiables — la garde vit chez
+# l'appelant (cf. TestPullMetaPeriodesService plus bas) ; ici on vérifie que
+# la méthode écrit inconditionnellement, en bloc, et respecte le facturé gelé.
+
+
+@tagged('souscriptions', 'souscriptions_pull_meta', 'post_install', '-at_install')
+class TestRafraichirDepuisMeta(SouscriptionsTestCase):
+    def test_ecrase_latterrissage_v3_en_bloc(self):
+        """L'énergie, le TURPE, la CTA, l'accise, la puissance moyenne, les
+        verdicts et l'empreinte sont tous écrasés par un seul write()."""
+        periode = self.env['souscription.periode']._amorcer_depuis_meta(
+            self.souscription_base,
+            _periode_meta(source_hash='H1', energie_base_kwh=280.0, turpe_fixe_eur=8.5, cta_eur=1.1),
+        )
+        meta = _periode_meta(
+            source_hash='H2',
+            energie_base_kwh=310.0,
+            turpe_fixe_eur=9.0,
+            turpe_variable_eur=4.8,
+            cta_eur=1.3,
+            taux_accise_eur_mwh=22.0,
+            puissance_moyenne_kva=7.0,
+            qualite='estimée',
+            statut_communication='non_communicante',
+            has_changement=True,
+        )
+
+        periode._rafraichir_depuis_meta(meta)
+
+        self.assertEqual(periode.energie_base_kwh, 310.0)
+        self.assertEqual(periode.turpe_fixe, 9.0)
+        self.assertEqual(periode.turpe_variable, 4.8)
+        self.assertEqual(periode.cta_eur, 1.3)
+        self.assertEqual(periode.taux_accise_eur_mwh, 22.0)
+        self.assertEqual(periode.puissance_moyenne_kva, 7.0)
+        self.assertEqual(periode.qualite, 'estimée')
+        self.assertEqual(periode.statut_communication, 'non_communicante')
+        self.assertTrue(periode.has_changement)
+        self.assertEqual(periode.source_hash, 'H2')
+
+    def test_remplace_les_releves_en_bloc_si_non_facturee(self):
+        """AC3 : Période non facturée -> relevés remplacés en bloc (le
+        re-pull promis par ADR 0015)."""
+        periode = self.env['souscription.periode']._amorcer_depuis_meta(
+            self.souscription_base,
+            _periode_meta(releves_utilises=[_objet_releve(releve_id='R1', index_base_kwh=1000)]),
+        )
+        self.assertEqual(periode.releve_ids.releve_externe_id, 'R1')
+
+        periode._rafraichir_depuis_meta(
+            _periode_meta(source_hash='H2', releves_utilises=[_objet_releve(releve_id='R2', index_base_kwh=1310)])
+        )
+
+        self.assertEqual(len(periode.releve_ids), 1)
+        self.assertEqual(periode.releve_ids.releve_externe_id, 'R2')
+
+    def test_provisions_et_releves_intacts_si_facturee(self):
+        """AC2/AC5 : Période facturée -> le mesuré est rafraîchi mais la
+        provision (facturé gelé) et le relevé-justificatif restent intacts —
+        exemption chirurgicale du verrou (#14), jamais la provision."""
+        periode = self.env['souscription.periode']._amorcer_depuis_meta(
+            self.souscription_base,
+            _periode_meta(
+                releves_utilises=[_objet_releve(releve_id='R1', index_base_kwh=1000)], energie_base_kwh=280.0
+            ),
+        )
+        periode._creer_facture()  # facturée -> tampon provision := energie (#234)
+        self.assertEqual(periode.provision_base_kwh, 280.0)
+
+        periode._rafraichir_depuis_meta(
+            _periode_meta(
+                releves_utilises=[_objet_releve(releve_id='R2', index_base_kwh=1310)],
+                energie_base_kwh=310.0,
+                source_hash='H2',
+                qualite='réelle',
+            )
+        )
+
+        self.assertEqual(periode.energie_base_kwh, 310.0)  # mesuré rafraîchi
+        self.assertEqual(periode.provision_base_kwh, 280.0)  # facturé gelé, intact
+        self.assertEqual(periode.releve_ids.releve_externe_id, 'R1')  # relevé-justificatif intact
+
+
+# === Service « propriétaire durable du pull », gardé par l'empreinte (#233,
+# #235) : client mocké ===
 #
 # `souscription.pull.meta.periodes.service` porte désormais la politique
-# create-missing-only / skip-and-report (ADR 0011) et la méthode de transport
-# nommée `_ouvrir_flux` (ADR 0024 §6). Les exceptions levées sont les vraies
-# classes du module service (réelles si electricore_client est présent, stubs
-# de la fabrique sinon, ADR 0024/#222) : aucun échange de symbole par patch,
-# `except IngestionEnCours` du service attrape exactement ce qui est
-# instancié ici.
+# gardée par l'empreinte (ADR 0030 décision 1, #235 — create-missing pour la
+# création, source_hash/qualite pour l'écriture d'une Période existante) et
+# skip-and-report (ADR 0011), et la méthode de transport nommée `_ouvrir_flux`
+# (ADR 0024 §6). Les exceptions levées sont les vraies classes du module
+# service (réelles si electricore_client est présent, stubs de la fabrique
+# sinon, ADR 0024/#222) : aucun échange de symbole par patch, `except
+# IngestionEnCours` du service attrape exactement ce qui est instancié ici.
 
 
 @tagged('souscriptions', 'souscriptions_pull_meta', 'post_install', '-at_install')
 class TestPullMetaPeriodesService(SouscriptionsTestCase):
     def _pull(self, client, souscriptions, mois=date(2024, 1, 1)):
-        """Appelle le point d'entrée unique du service (#233 AC1), transport
-        patché via la fabrique client (ADR 0024) — jamais de vrai client
-        construit."""
+        """Appelle le point d'entrée unique du scope facturation (#233 AC1),
+        transport patché via la fabrique client (ADR 0024) — jamais de vrai
+        client construit."""
         with patcher_client_fabrique(client):
             return self.env['souscription.pull.meta.periodes.service'].pull(souscriptions, mois)
+
+    # --- Création (create-missing) ---
 
     def test_cree_les_periodes_manquantes_pour_les_souscriptions_a_rsc(self):
         """AC2 : le service crée les périodes manquantes du mois pour les
@@ -214,41 +309,21 @@ class TestPullMetaPeriodesService(SouscriptionsTestCase):
         )
         client = client_flux_factice('meta_periodes', [meta])
 
-        creees, existantes, erreurs = self._pull(client, self.souscription_base)
+        creees, rafraichies, inchangees, conservees, erreurs = self._pull(client, self.souscription_base)
 
         periode = self.env['souscription.periode'].search(
             [('souscription_id', '=', self.souscription_base.id), ('mois', '=', date(2024, 1, 1))]
         )
         self.assertEqual(len(periode), 1)
         self.assertEqual(len(creees), 1)
-        self.assertFalse(existantes)
+        self.assertFalse(rafraichies)
+        self.assertFalse(inchangees)
+        self.assertFalse(conservees)
         self.assertFalse(erreurs)
         client.meta_periodes.assert_called_once_with(mois='2024-01-01', rsc=['RSC-00000000000001'])
 
-    def test_ne_reecrit_jamais_une_periode_existante(self):
-        """AC2/AC3 : create-missing-only — une période déjà amorcée n'est
-        jamais réécrite, même avec des valeurs différentes dans le payload."""
-        self.souscription_base.ref_situation_contractuelle = 'RSC-00000000000001'
-        existante = self.create_test_periode(
-            self.souscription_base, date_debut=date(2024, 1, 1), date_fin=date(2024, 2, 1)
-        )
-        existante.cta_eur = 1.23
-
-        meta = _periode_meta(
-            ref_situation_contractuelle='RSC-00000000000001',
-            debut='2024-01-01',
-            fin='2024-02-01',
-            cta_eur=999.0,
-        )
-        creees, existantes, erreurs = self._pull(client_flux_factice('meta_periodes', [meta]), self.souscription_base)
-
-        self.assertEqual(existante.cta_eur, 1.23)
-        self.assertEqual(len(existantes), 1)
-        self.assertFalse(creees)
-        self.assertFalse(erreurs)
-
     def test_releves_crees_avec_identifiant_externe_et_origine(self):
-        """AC4 : relevés créés avec identifiant externe + origine."""
+        """AC4 (#233) : relevés créés avec identifiant externe + origine."""
         self.souscription_base.ref_situation_contractuelle = 'RSC-00000000000001'
         meta = _periode_meta(
             ref_situation_contractuelle='RSC-00000000000001',
@@ -271,10 +346,156 @@ class TestPullMetaPeriodesService(SouscriptionsTestCase):
             debut=None,  # déclenche une erreur de mapping (Date invalide)
             fin='2024-02-01',
         )
-        creees, existantes, erreurs = self._pull(
+        creees, rafraichies, inchangees, conservees, erreurs = self._pull(
             client_flux_factice('meta_periodes', [meta_invalide]), self.souscription_base
         )
         self.assertEqual(len(erreurs), 1)
+
+    # --- Politique d'écriture gardée par l'empreinte (ADR 0030 décision 1, #235) ---
+
+    def test_empreinte_inchangee_naboutit_a_aucune_ecriture(self):
+        """AC1 : `source_hash` inchangé -> rien n'est touché — une correction
+        manuelle du·de la facturiste survit à la relecture de données
+        inchangées."""
+        self.souscription_base.ref_situation_contractuelle = 'RSC-00000000000001'
+        existante = self.env['souscription.periode']._amorcer_depuis_meta(
+            self.souscription_base,
+            _periode_meta(ref_situation_contractuelle='RSC-00000000000001', source_hash='H1', cta_eur=1.1),
+        )
+        existante.cta_eur = 1.99  # correction manuelle du·de la facturiste
+
+        meta = _periode_meta(ref_situation_contractuelle='RSC-00000000000001', source_hash='H1', cta_eur=999.0)
+        creees, rafraichies, inchangees, conservees, erreurs = self._pull(
+            client_flux_factice('meta_periodes', [meta]), self.souscription_base
+        )
+
+        self.assertEqual(existante.cta_eur, 1.99)  # correction manuelle intacte
+        self.assertEqual(len(inchangees), 1)
+        self.assertFalse(creees)
+        self.assertFalse(rafraichies)
+        self.assertFalse(conservees)
+        self.assertFalse(erreurs)
+
+    def test_empreinte_nouvelle_verdict_fiable_rafraichit_le_mesure_en_bloc(self):
+        """AC2/AC3 : empreinte nouvelle + verdict réelle/estimée -> le mesuré
+        v3 est rafraîchi en bloc sur une Période non facturée."""
+        self.souscription_base.ref_situation_contractuelle = 'RSC-00000000000001'
+        existante = self.env['souscription.periode']._amorcer_depuis_meta(
+            self.souscription_base,
+            _periode_meta(ref_situation_contractuelle='RSC-00000000000001', source_hash='H1', energie_base_kwh=280.0),
+        )
+        meta = _periode_meta(
+            ref_situation_contractuelle='RSC-00000000000001',
+            source_hash='H2',
+            energie_base_kwh=310.0,
+            qualite='réelle',
+        )
+        creees, rafraichies, inchangees, conservees, erreurs = self._pull(
+            client_flux_factice('meta_periodes', [meta]), self.souscription_base
+        )
+
+        self.assertEqual(existante.energie_base_kwh, 310.0)
+        self.assertEqual(existante.source_hash, 'H2')
+        self.assertEqual(len(rafraichies), 1)
+        self.assertFalse(creees)
+        self.assertFalse(inchangees)
+        self.assertFalse(conservees)
+        self.assertFalse(erreurs)
+
+    def test_empreinte_nouvelle_periode_facturee_provisions_et_releves_intacts(self):
+        """AC2 : sur une Période facturée, le mesuré est rafraîchi mais les
+        provisions et les relevés-justificatifs restent intacts — exemption
+        chirurgicale du verrou (#14), jamais la provision."""
+        self.souscription_base.ref_situation_contractuelle = 'RSC-00000000000001'
+        existante = self.env['souscription.periode']._amorcer_depuis_meta(
+            self.souscription_base,
+            _periode_meta(
+                ref_situation_contractuelle='RSC-00000000000001',
+                source_hash='H1',
+                energie_base_kwh=280.0,
+                releves_utilises=[_objet_releve(releve_id='R1', index_base_kwh=1000)],
+            ),
+        )
+        existante._creer_facture()  # facturée -> provision tamponnée (#234)
+        self.assertEqual(existante.provision_base_kwh, 280.0)
+
+        meta = _periode_meta(
+            ref_situation_contractuelle='RSC-00000000000001',
+            source_hash='H2',
+            energie_base_kwh=310.0,
+            qualite='réelle',
+            releves_utilises=[_objet_releve(releve_id='R2', index_base_kwh=1310)],
+        )
+        creees, rafraichies, inchangees, conservees, erreurs = self._pull(
+            client_flux_factice('meta_periodes', [meta]), self.souscription_base
+        )
+
+        self.assertEqual(existante.energie_base_kwh, 310.0)  # mesuré rafraîchi
+        self.assertEqual(existante.provision_base_kwh, 280.0)  # facturé gelé
+        self.assertEqual(existante.releve_ids.releve_externe_id, 'R1')  # relevé-justificatif intact
+        self.assertEqual(len(rafraichies), 1)
+
+    def test_empreinte_nouvelle_periode_non_facturee_remplace_les_releves_en_bloc(self):
+        """AC3 : sur une Période non facturée, les relevés sont remplacés en
+        bloc — le re-pull promis par ADR 0015, enfin réalisé."""
+        self.souscription_base.ref_situation_contractuelle = 'RSC-00000000000001'
+        existante = self.env['souscription.periode']._amorcer_depuis_meta(
+            self.souscription_base,
+            _periode_meta(
+                ref_situation_contractuelle='RSC-00000000000001',
+                source_hash='H1',
+                releves_utilises=[_objet_releve(releve_id='R1', index_base_kwh=1000)],
+            ),
+        )
+        meta = _periode_meta(
+            ref_situation_contractuelle='RSC-00000000000001',
+            source_hash='H2',
+            qualite='réelle',
+            releves_utilises=[_objet_releve(releve_id='R2', index_base_kwh=1310)],
+        )
+        self._pull(client_flux_factice('meta_periodes', [meta]), self.souscription_base)
+
+        self.assertEqual(len(existante.releve_ids), 1)
+        self.assertEqual(existante.releve_ids.releve_externe_id, 'R2')
+
+    def test_qualite_incalculable_conserve_et_signale(self):
+        """AC4 : verdict incalculable -> valeur stockée conservée, signalée
+        au rapport — « je ne sais pas » n'écrase pas « je savais »."""
+        self.souscription_base.ref_situation_contractuelle = 'RSC-00000000000001'
+        existante = self.env['souscription.periode']._amorcer_depuis_meta(
+            self.souscription_base,
+            _periode_meta(ref_situation_contractuelle='RSC-00000000000001', source_hash='H1', energie_base_kwh=280.0),
+        )
+        meta = _periode_meta(
+            ref_situation_contractuelle='RSC-00000000000001',
+            source_hash='H2',
+            qualite='incalculable',
+            energie_base_kwh=0.0,
+        )
+        creees, rafraichies, inchangees, conservees, erreurs = self._pull(
+            client_flux_factice('meta_periodes', [meta]), self.souscription_base
+        )
+
+        self.assertEqual(existante.energie_base_kwh, 280.0)  # conservée
+        self.assertEqual(existante.source_hash, 'H1')  # empreinte pas mise à jour non plus
+        self.assertEqual(len(conservees), 1)
+        self.assertFalse(rafraichies)
+
+    def test_mois_absent_du_flux_conserve_et_signale(self):
+        """AC4 : une Période déjà amorcée dont la RSC n'est pas revenue dans
+        le lot est conservée, signalée."""
+        self.souscription_base.ref_situation_contractuelle = 'RSC-00000000000001'
+        existante = self.env['souscription.periode']._amorcer_depuis_meta(
+            self.souscription_base,
+            _periode_meta(ref_situation_contractuelle='RSC-00000000000001', source_hash='H1', energie_base_kwh=280.0),
+        )
+        creees, rafraichies, inchangees, conservees, erreurs = self._pull(
+            client_flux_factice('meta_periodes', []), self.souscription_base
+        )
+
+        self.assertEqual(existante.energie_base_kwh, 280.0)
+        self.assertEqual(len(conservees), 1)
+        self.assertIn('mois absent', conservees[0])
 
     def test_ingestion_en_cours_mappee_en_userror_reessayable(self):
         """AC5 : IngestionEnCours -> message « réessayer plus tard »."""
@@ -310,11 +531,92 @@ class TestPullMetaPeriodesService(SouscriptionsTestCase):
         ADR 0024 §5 : la construction elle-même n'ouvre aucune socket)."""
         self.assertFalse(self.souscription_hphc.ref_situation_contractuelle)
         client = client_flux_factice('meta_periodes', [])
-        creees, existantes, erreurs = self._pull(client, self.souscription_hphc)
+        creees, rafraichies, inchangees, conservees, erreurs = self._pull(client, self.souscription_hphc)
         client.meta_periodes.assert_not_called()
         self.assertFalse(creees)
-        self.assertFalse(existantes)
+        self.assertFalse(rafraichies)
+        self.assertFalse(inchangees)
+        self.assertFalse(conservees)
         self.assertFalse(erreurs)
+
+
+# === Scope refresh (#235 AC6) : plage de mois, création désactivée — testé à
+# la couture transport (un appel de flux par mois, mêmes arguments que
+# pull()). Consommé par la Régularisation à la tranche 4 du PRD #231.
+
+
+@tagged('souscriptions', 'souscriptions_pull_meta', 'post_install', '-at_install')
+class TestPullMetaPeriodesServiceRefresh(SouscriptionsTestCase):
+    def test_appelle_le_flux_une_fois_par_mois_et_ne_cree_rien(self):
+        """AC6 : un appel de flux par mois de la plage ; aucune création même
+        si le flux renvoie une méta pour un (RSC, mois) sans Période
+        existante — la création reste l'apanage du scope facturation."""
+        self.souscription_base.ref_situation_contractuelle = 'RSC-00000000000001'
+        meta_janvier = _periode_meta(
+            ref_situation_contractuelle='RSC-00000000000001', debut='2024-01-01', fin='2024-02-01'
+        )
+        meta_fevrier = _periode_meta(
+            ref_situation_contractuelle='RSC-00000000000001', debut='2024-02-01', fin='2024-03-01'
+        )
+        client = MagicMock()
+        client.meta_periodes.side_effect = [flux_electricore([meta_janvier]), flux_electricore([meta_fevrier])]
+
+        with patcher_client_fabrique(client):
+            creees, rafraichies, inchangees, conservees, erreurs = self.env[
+                'souscription.pull.meta.periodes.service'
+            ].refresh(self.souscription_base, date(2024, 1, 1), date(2024, 2, 15))
+
+        self.assertEqual(client.meta_periodes.call_count, 2)
+        client.meta_periodes.assert_any_call(mois='2024-01-01', rsc=['RSC-00000000000001'])
+        client.meta_periodes.assert_any_call(mois='2024-02-01', rsc=['RSC-00000000000001'])
+        self.assertFalse(creees)  # scope refresh : jamais de création
+        periodes = self.env['souscription.periode'].search([('souscription_id', '=', self.souscription_base.id)])
+        self.assertFalse(periodes)
+
+    def test_rafraichit_une_periode_existante_sur_la_plage(self):
+        """AC6 : le scope refresh applique la même politique gardée par
+        l'empreinte que pull() aux Périodes déjà amorcées de la plage."""
+        self.souscription_base.ref_situation_contractuelle = 'RSC-00000000000001'
+        existante = self.env['souscription.periode']._amorcer_depuis_meta(
+            self.souscription_base,
+            _periode_meta(
+                ref_situation_contractuelle='RSC-00000000000001',
+                debut='2024-01-01',
+                fin='2024-02-01',
+                source_hash='H1',
+                energie_base_kwh=280.0,
+            ),
+        )
+        meta_rafraichie = _periode_meta(
+            ref_situation_contractuelle='RSC-00000000000001',
+            debut='2024-01-01',
+            fin='2024-02-01',
+            source_hash='H2',
+            energie_base_kwh=310.0,
+            qualite='réelle',
+        )
+        client = MagicMock()
+        client.meta_periodes.side_effect = [flux_electricore([meta_rafraichie])]
+
+        with patcher_client_fabrique(client):
+            creees, rafraichies, inchangees, conservees, erreurs = self.env[
+                'souscription.pull.meta.periodes.service'
+            ].refresh(self.souscription_base, date(2024, 1, 1), date(2024, 1, 31))
+
+        self.assertEqual(existante.energie_base_kwh, 310.0)
+        self.assertEqual(existante.source_hash, 'H2')
+        self.assertEqual(len(rafraichies), 1)
+        self.assertFalse(creees)
+
+    def test_aucune_souscription_a_rsc_naboutit_pas_a_un_appel_de_flux(self):
+        """Même garde fast-fail que pull() : aucune RSC facturable -> aucun
+        flux n'est ouvert, même sur une plage de plusieurs mois."""
+        client = MagicMock()
+        with patcher_client_fabrique(client):
+            self.env['souscription.pull.meta.periodes.service'].refresh(
+                self.souscription_hphc, date(2024, 1, 1), date(2024, 3, 1)
+            )
+        client.meta_periodes.assert_not_called()
 
 
 # === Wizard « Récupérer les périodes du mois » : coquille mince (#233) ===
@@ -341,7 +643,7 @@ class TestWizardPullMetaPeriodes(SouscriptionsTestCase):
 
     def test_delegue_au_service_et_formate_le_resultat(self):
         """AC2 : le wizard délègue au service et formate le résumé (créées /
-        déjà existantes / erreurs) — comportement observable inchangé."""
+        rafraîchies / inchangées / conservées / erreurs)."""
         self.souscription_base.ref_situation_contractuelle = 'RSC-00000000000001'
         meta = _periode_meta(
             ref_situation_contractuelle='RSC-00000000000001',
@@ -360,25 +662,33 @@ class TestWizardPullMetaPeriodes(SouscriptionsTestCase):
         self.assertEqual(wizard.state, 'done')
         client.meta_periodes.assert_called_once_with(mois='2024-01-01', rsc=['RSC-00000000000001'])
 
-    def test_ne_reecrit_jamais_une_periode_existante(self):
-        """AC2 : create-missing-only préservé bout en bout via le wizard —
-        une période déjà amorcée n'est jamais réécrite."""
+    def test_empreinte_inchangee_delegue_correctement(self):
+        """AC1 : empreinte inchangée -> aucune écriture, bout en bout via le
+        wizard — preuve que le wizard ne ré-implémente pas la garde, il la
+        délègue au service (même politique que TestPullMetaPeriodesService)."""
         self.souscription_base.ref_situation_contractuelle = 'RSC-00000000000001'
-        existante = self.create_test_periode(
-            self.souscription_base, date_debut=date(2024, 1, 1), date_fin=date(2024, 2, 1)
+        existante = self.env['souscription.periode']._amorcer_depuis_meta(
+            self.souscription_base,
+            _periode_meta(
+                ref_situation_contractuelle='RSC-00000000000001',
+                debut='2024-01-01',
+                fin='2024-02-01',
+                source_hash='H1',
+                cta_eur=1.23,
+            ),
         )
-        existante.cta_eur = 1.23
 
         meta = _periode_meta(
             ref_situation_contractuelle='RSC-00000000000001',
             debut='2024-01-01',
             fin='2024-02-01',
+            source_hash='H1',
             cta_eur=999.0,
         )
         wizard = self._lancer_avec_client(client_flux_factice('meta_periodes', [meta]))
 
         self.assertEqual(existante.cta_eur, 1.23)
-        self.assertIn('Déjà existantes : 1', wizard.resultat)
+        self.assertIn('Inchangées : 1', wizard.resultat)
         self.assertIn('Créées : 0', wizard.resultat)
 
     def test_resume_les_souscriptions_sans_rsc(self):


### PR DESCRIPTION
Closes #235

Pull unifié gardé par l'empreinte (`source_hash`) : inchangée n'écrit rien (les corrections manuelles du·de la facturiste survivent) ; nouvelle + verdict réelle/estimée rafraîchit le mesuré v3 en bloc (relevés remplacés en bloc seulement si la Période n'est pas facturée) ; incalculable/mois absent est conservé et signalé. Exemption chirurgicale du verrou de facturation sur le mesuré (jamais la provision, jours, snapshot ou relevés-justificatifs). Deux scopes sur `souscription.pull.meta.periodes.service` : `pull()` (un mois, crée les manquantes) et `refresh()` (plage de mois, ne crée rien — pour la Régularisation, tranche 4). ADR 0011/0015 amendées en conséquence.

Suite complète : `0 failed, 0 error(s) of 524 tests` (docker, base fraîche, après rebase sur main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)