### PR TITLE
fix(refacturation) : passer rsc= au pull des prestations F15 — hygiène de fil sur périmètre partagé

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -46,7 +46,7 @@ Journeys de capacités (`REQ-XXX-nn`), chacune avec un statut (✅ Proven · ⚠
 - REQ-FAC-08 ✅ relevés d'index : verrou de facturation + bloc justificatif (colonnes = union des familles réellement relevées) — preuve: tests/test_releve.py · #54, #138
 - REQ-FAC-09 ✅ composition des lignes : prorata, cadrans, TURPE, pro, solidaire, régime — preuve: tests/test_periode_composition.py · #74
 - REQ-FAC-10 ✅ facture d'énergie PDF sur template dédié — preuve: tests/test_invoice_template.py, tests/test_facture_document.py::test_facture_energie_pdf
-- REQ-FAC-11 ✅ prestations F15 synchronisées puis refacturées (TVA par nature) — preuve: tests/test_sync_prestations.py, tests/test_refacturation.py · #147
+- REQ-FAC-11 ✅ prestations F15 synchronisées (filtrées par RSC de nos souscriptions, chunké) puis refacturées (TVA par nature) — preuve: tests/test_sync_prestations.py, tests/test_refacturation.py · #147, #245
 - REQ-FAC-12 ✅ chèques énergie : imputation FIFO à la facturation — preuve: tests/test_periode_facture.py::test_fifo_par_expiration_le_plus_proche_consomme_en_premier, tests/test_cheque_energie.py · #172
 - REQ-FAC-13 ✅ Énergie facturée universelle : la provision, tamponnée `provision := energie` à la facturation pour un contrat non lissé (dé-figeage/refacturation re-tamponne), porte uniformément la quantité facturée ; backfill des non-lissées déjà facturées — preuve: tests/test_periode_composition.py::test_creer_facture_tamponne_la_provision_non_lissee, tests/test_migration_energie_facturee.py · #234
 

--- a/models/core/souscription_refacturation.py
+++ b/models/core/souscription_refacturation.py
@@ -10,6 +10,12 @@ from .electricore_client_fabrique import ContractVersionError, IngestionEnCours,
 
 _logger = logging.getLogger(__name__)
 
+# ponytail: 150 RSC/lot — ceiling arbitraire mais confortable sous les
+# limites usuelles de longueur d'URL (~8 Ko côté proxy/serveur) pour un
+# paramètre `rsc` en query string GET (#245). À relever si le parc grossit
+# au point de multiplier les allers-retours de façon sensible.
+TAILLE_LOT_RSC = 150
+
 
 class SouscriptionRefacturation(models.Model):
     """Refacturation Enedis (#8 / ADR 0009 ; renommée #38 — cf. CONTEXT.md).
@@ -97,14 +103,17 @@ class SouscriptionRefacturation(models.Model):
     # --- Sync electricore : pull-tout des prestations F15 (#147, ADR 0009 §2 amendé) ---
 
     def synchroniser_depuis_electricore(self):
-        """Tire TOUTES les prestations F15 d'electricore, insert-si-absente par `reference`.
+        """Tire les prestations F15 d'electricore sur les RSC de nos souscriptions,
+        insert-si-absente par `reference`.
 
         Pas de fenêtre temporelle : les lignes F15 arrivent en retard, datées dans
         le passé — un curseur de date les manquerait (ADR 0009 §2) ; l'idempotence
         vient de l'insert-si-absente sur la *Référence de contenu* (même référence
         = même contenu par construction, cf. CONTEXT.md) — aucun chemin d'update,
-        le gel des facturées (ADR 0009 §4) est donc automatique. Le client est
-        acquis en tête, avant tout travail (échec rapide et déterministe, ADR 0024 §5).
+        le gel des facturées (ADR 0009 §4) est donc automatique. Filtré par RSC
+        (#245) : le périmètre Enedis peut être partagé entre entités, on ne tire
+        pas sur le fil les prestations d'un tiers. Le client est acquis en tête,
+        avant tout travail (échec rapide et déterministe, ADR 0024 §5).
         """
         client = self.env['souscription.electricore.client'].client()
         try:
@@ -135,9 +144,28 @@ class SouscriptionRefacturation(models.Model):
     def _tirer_prestations(self, client):
         """Couture transport (patchée par les tests) : consomme le flux JSONL typé
         (`PrestationF15`, contrat v1) et rend des dicts plats. Seul endroit qui
-        parle réseau."""
-        with client.prestations() as flux:
-            return [presta.model_dump() for presta in flux]
+        parle réseau.
+
+        Filtre sur les RSC de nos souscriptions (#245) : les périmètres Enedis
+        sont parfois partagés entre entités — sans le filtre, on tirerait sur
+        le fil les prestations d'un tiers pour les jeter à l'insertion
+        (résolution RSC seule, ADR 0010 §4). Chunké par lots de
+        `TAILLE_LOT_RSC` : `rsc` part en query string GET, pas en corps POST
+        (`ElectricoreClient.prestations`, client 0.4.0) — ~1 000 RSC en une
+        seule requête dépasserait les limites usuelles de longueur d'URL.
+        Aucune souscription à RSC résolue -> aucun appel réseau.
+        """
+        rscs = (
+            self.env['souscription.souscription']
+            .search([('ref_situation_contractuelle', '!=', False)])
+            .mapped('ref_situation_contractuelle')
+        )
+        lignes = []
+        for debut in range(0, len(rscs), TAILLE_LOT_RSC):
+            lot = rscs[debut : debut + TAILLE_LOT_RSC]
+            with client.prestations(rsc=lot) as flux:
+                lignes.extend(presta.model_dump() for presta in flux)
+        return lignes
 
     def _inserer_prestations(self, lignes):
         """Insert-si-absente par `reference`, résolution par RSC seule.

--- a/tests/test_sync_prestations.py
+++ b/tests/test_sync_prestations.py
@@ -12,13 +12,14 @@ Décisions du grill 2026-07-08 (cf. issue #147) : résolution par RSC seule
 la *Référence de contenu* EST le contenu), `montant_ht` ignoré.
 """
 
-from unittest.mock import MagicMock
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
 
 from odoo.addons.souscriptions_odoo.models.core import souscription_refacturation as refacturation_module
 from odoo.exceptions import UserError
 from odoo.tests.common import tagged
 
-from .common import SouscriptionsTestCase, patcher_client_fabrique, patcher_transport
+from .common import SouscriptionsTestCase, flux_electricore, patcher_client_fabrique, patcher_transport
 
 
 def _ligne(**overrides):
@@ -41,6 +42,13 @@ def _ligne(**overrides):
     )
     base.update(overrides)
     return base
+
+
+def _presta_stream(*lignes):
+    """Flux factice de `PrestationF15` : objets à `.model_dump()` (contrat v1
+    réel), pas des dicts plats — `_tirer_prestations` appelle `.model_dump()`
+    sur chaque élément du flux."""
+    return flux_electricore([SimpleNamespace(model_dump=lambda l=l: l) for l in lignes])
 
 
 @tagged('souscriptions', 'souscriptions_sync_prestations', 'post_install', '-at_install')
@@ -203,3 +211,66 @@ class TestSyncPrestations(SouscriptionsTestCase):
             with self.assertRaises(UserError) as cm:
                 self.Refacturation.synchroniser_depuis_electricore()
         self.assertIn('v0', str(cm.exception))
+
+
+@tagged('souscriptions', 'souscriptions_sync_prestations', 'post_install', '-at_install')
+class TestTirerPrestations(SouscriptionsTestCase):
+    """`_tirer_prestations` elle-même (#245) : périmètre Enedis potentiellement
+    partagé entre entités — la requête ne doit demander que les RSC de nos
+    souscriptions, chunkée si le lot est gros (le paramètre `rsc` part en
+    query string GET, cf. `ElectricoreClient.prestations`). Client mocké
+    directement (méthode transport, pas la fabrique) : aucun HTTP."""
+
+    def setUp(self):
+        super().setUp()
+        self.Refacturation = self.env['souscription.refacturation']
+        self.souscription_base.with_context(rsc_automatisme=True).write(
+            {'ref_situation_contractuelle': 'RSC_SYNC_BASE'}
+        )
+        self.souscription_hphc.with_context(rsc_automatisme=True).write(
+            {'ref_situation_contractuelle': 'RSC_SYNC_HPHC'}
+        )
+
+    def test_filtre_sur_les_rsc_de_nos_souscriptions(self):
+        """AC1 (#245) : la requête ne demande que les RSC de nos souscriptions
+        — sans le filtre, on tirerait sur le fil les prestations d'un tiers
+        partageant le périmètre Enedis, pour les jeter à l'insertion."""
+        client = MagicMock()
+        client.prestations.side_effect = lambda **kwargs: _presta_stream()
+
+        self.Refacturation._tirer_prestations(client)
+
+        rsc_demandees = client.prestations.call_args.kwargs['rsc']
+        self.assertCountEqual(rsc_demandees, ['RSC_SYNC_BASE', 'RSC_SYNC_HPHC'])
+
+    def test_aucune_rsc_resolue_naboutit_pas_a_un_appel(self):
+        """Aucune souscription à RSC résolue -> aucun round-trip réseau (même
+        fast-fail que le pull méta-périodes, #245)."""
+        (self.souscription_base | self.souscription_hphc).with_context(rsc_automatisme=True).write(
+            {'ref_situation_contractuelle': False}
+        )
+        client = MagicMock()
+
+        lignes = self.Refacturation._tirer_prestations(client)
+
+        client.prestations.assert_not_called()
+        self.assertEqual(lignes, [])
+
+    def test_chunk_le_pull_par_lots_et_fusionne_les_flux(self):
+        """Point d'attention #245 : ~1 000 RSC en query string GET — chunké
+        par lots de `TAILLE_LOT_RSC`, les flux de chaque lot sont fusionnés.
+        Lot forcé à 1 ici pour exercer le chunking sans créer 150+ souscriptions."""
+        lignes_par_rsc = {
+            'RSC_SYNC_BASE': _ligne(reference='ref-base', ref_situation_contractuelle='RSC_SYNC_BASE'),
+            'RSC_SYNC_HPHC': _ligne(reference='ref-hphc', ref_situation_contractuelle='RSC_SYNC_HPHC'),
+        }
+        client = MagicMock()
+        client.prestations.side_effect = lambda *, rsc: _presta_stream(*(lignes_par_rsc[r] for r in rsc))
+
+        with patch.object(refacturation_module, 'TAILLE_LOT_RSC', 1):
+            lignes = self.Refacturation._tirer_prestations(client)
+
+        self.assertEqual(client.prestations.call_count, 2)
+        lots_demandes = [call.kwargs['rsc'] for call in client.prestations.call_args_list]
+        self.assertEqual([len(lot) for lot in lots_demandes], [1, 1])
+        self.assertEqual({ligne['reference'] for ligne in lignes}, {'ref-base', 'ref-hphc'})


### PR DESCRIPTION
Closes #245

_tirer_prestations tirait tout le périmètre Enedis (`client.prestations()` sans
argument) ; elle filtre désormais sur les RSC de nos souscriptions
(`client.prestations(rsc=[...])`, dispo depuis la 0.4.0 épinglée) — les
périmètres Enedis peuvent être partagés entre entités, on ne veut plus tirer
sur le fil les prestations d'un tiers pour les jeter à l'insertion. Le
paramètre `rsc` part en query string GET (vérifié dans la source du client
0.4.0) : chunké par lots de 150 RSC pour rester sous les limites usuelles de
longueur d'URL, les flux étant fusionnés. Insertion (insert-si-absente,
savepoint, comptage `ignorees`) strictement inchangée.

🤖 Generated with [Claude Code](https://claude.com/claude-code)