### PR TITLE
fix(souscription): bouton « Résoudre la RSC maintenant » visible seulement en instance

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -12,7 +12,7 @@ Journeys de capacités (`REQ-XXX-nn`), chacune avec un statut (✅ Proven · ⚠
 - REQ-RAC-06 ✅ mails de rassurage à l'entrée des branches F120/F130 — preuve: tests/test_mails_raccordement.py::test_entree_f120_envoie_mail_rassurage · #102
 - REQ-RAC-07 ✅ pack de bienvenue automatique à « Abonnement Validé » — preuve: tests/test_mails_raccordement.py::test_drag_en_abonnement_valide_envoie_pack_bienvenue_avec_cp_en_piece_jointe · #103
 - REQ-RAC-08 ✅ poll quotidien des affaires Enedis, alertes sans spam — preuve: tests/test_poll_affaires_enedis.py · #89
-- REQ-RAC-09 ✅ résolution RSC à la demande via electricore — preuve: tests/test_rsc_service.py · #88
+- REQ-RAC-09 ✅ résolution RSC à la demande via electricore, bouton + garde serveur limités à *en instance* (jamais résiliée/en service, même en lot) — preuve: tests/test_rsc_service.py::test_souscription_resiliee_jamais_reciblee · #88, #136
 - REQ-RAC-10 ✅ état du contrat calculé : en instance / en service / résiliée — preuve: tests/test_souscription_etat.py::test_bascule_en_service_a_lecriture_de_la_rsc · #87
 - REQ-RAC-11 ✅ mandat SEPA créé actif d'emblée via le service `souscription.sepa.mandat` (garde registre `sdd.mandate`, no-op Community) — preuve: tests/test_sepa_mandat.py, tests/test_raccordement.py::test_creer_mandat_sepa_delegue_au_service_et_recopie_le_rum · #187, #217
 

--- a/models/core/souscription.py
+++ b/models/core/souscription.py
@@ -484,10 +484,12 @@ class Souscription(models.Model):
     def action_resoudre_rsc_maintenant(self):
         """Bouton « résoudre la RSC maintenant » (#88) : résout la RSC des
         Souscriptions sélectionnées via le service electricore, en un seul
-        appel batch même pour une seule Souscription. Idempotent : une
-        Souscription déjà *en service* n'est jamais re-ciblée — aucun appel
+        appel batch même pour une seule Souscription. Idempotent : seule une
+        Souscription *en instance* est ciblée — une Souscription déjà *en
+        service* ou *résiliée* n'est jamais re-ciblée, même en lot depuis la
+        vue liste (#136, même garde que le poll quotidien #89) — aucun appel
         si le lot filtré est vide."""
-        cibles = self.filtered(lambda s: s.etat != 'en_service')
+        cibles = self.filtered(lambda s: s.etat == 'en_instance')
         if not cibles:
             return
         sans_affaire = cibles.filtered(lambda s: not s.id_affaire)

--- a/tests/test_rsc_service.py
+++ b/tests/test_rsc_service.py
@@ -9,7 +9,7 @@ pas de mock d'`electricore_client` lui-même, pas de HTTP, pas de mock du
 temps.
 """
 
-from datetime import date
+from datetime import date, timedelta
 
 from odoo.addons.souscriptions_odoo.models.core import electricore_rsc_service as service_module
 from odoo.exceptions import UserError
@@ -136,6 +136,19 @@ class TestActionResoudreRscMaintenant(SouscriptionsTestCase):
         appel si le lot filtré est vide."""
         self.souscription_base.with_context(rsc_automatisme=True).write({'ref_situation_contractuelle': 'RSC-DEJA'})
         self.assertEqual(self.souscription_base.etat, 'en_service')
+
+        with _patch_appeler() as mock_appeler:
+            self.souscription_base.action_resoudre_rsc_maintenant()
+        mock_appeler.assert_not_called()
+
+    def test_souscription_resiliee_jamais_reciblee(self):
+        """#136 : une Souscription résiliée n'est jamais re-ciblée par
+        l'action serveur, même sans RSC (résiliation avant mise en service)
+        et même appelée en lot — aucun appel au service RSC, idempotence
+        conservée (même garde que le poll quotidien #89, `etat ==
+        'en_instance'`)."""
+        self.souscription_base.write({'date_fin': date.today() - timedelta(days=1)})
+        self.assertEqual(self.souscription_base.etat, 'resiliee')
 
         with _patch_appeler() as mock_appeler:
             self.souscription_base.action_resoudre_rsc_maintenant()

--- a/views/core/souscription_views.xml
+++ b/views/core/souscription_views.xml
@@ -9,7 +9,7 @@
                     <button name="action_resoudre_rsc_maintenant"
                             string="Résoudre la RSC maintenant"
                             type="object"
-                            invisible="etat == 'en_service'"/>
+                            invisible="etat != 'en_instance'"/>
                     <field name="etat" widget="statusbar" readonly="1"/>
                 </header>
                 <sheet>


### PR DESCRIPTION
Closes #136

Le bouton « Résoudre la RSC maintenant » et sa garde serveur ne filtraient
que sur `etat != 'en_service'`, laissant une Souscription résiliée
ciblable (visible sur le formulaire, re-ciblable en lot depuis la vue
liste). Aligne les deux sur `etat == 'en_instance'`, la même condition
que le poll quotidien (#89) — idempotence conservée, aucun appel
electricore si le lot filtré est vide. Un test couvre le cas résiliée.

Suite complète verte : 0 failed, 0 error(s) of 528 tests (Docker odoo:19.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)