### PR TITLE
chore(dev): ADR 0026 accepté + auto-wrap pass-cli dans dev.sh

### DIFF
--- a/docs/adr/0026-secrets-electricore-dev-proton-pass-through-docker.md
+++ b/docs/adr/0026-secrets-electricore-dev-proton-pass-through-docker.md
@@ -1,6 +1,6 @@
 # Secrets electricore en dev : injectés depuis Proton Pass via pass-through docker-compose — le module reste `ir.config_parameter`
 
-*Statut : proposé (bascule accepté une fois `pr docker compose … config` validé — cf. Raison). Applique la décision parc-wide [electricore ADR-0056](../../../electricore/docs/adr/0056-secrets-dev-proton-pass-par-espace.md) (Proton Pass = secrets de dev consommés par CLI ; SOPS+age = prod) au seul module Odoo, qui en est l'**exception** assumée. Ne re-décide pas [ADR-0024](0024-electricore-dependance-molle-garde-import-fabrique-client-unique.md) : elle fixe déjà que la config (`ELECTRICORE_URL` / `ELECTRICORE_API_KEY`) est une **donnée runtime** lue à l'usage via `ir.config_parameter` avec repli `os.environ`.*
+*Statut : accepté (pass-through validé le 2026-07-12 — `pr docker compose … config` affiche `<concealed by Proton Pass>` pour les deux variables). Applique la décision parc-wide [electricore ADR-0056](../../../electricore/docs/adr/0056-secrets-dev-proton-pass-par-espace.md) (Proton Pass = secrets de dev consommés par CLI ; SOPS+age = prod) au seul module Odoo, qui en est l'**exception** assumée. Ne re-décide pas [ADR-0024](0024-electricore-dependance-molle-garde-import-fabrique-client-unique.md) : elle fixe déjà que la config (`ELECTRICORE_URL` / `ELECTRICORE_API_KEY`) est une **donnée runtime** lue à l'usage via `ir.config_parameter` avec repli `os.environ`.*
 
 Le module consomme electricore via deux secrets — `ELECTRICORE_URL`, `ELECTRICORE_API_KEY` — lus par la fabrique `souscription.electricore.client` : `ICP.get_param('souscriptions.electricore_*') or os.environ.get('ELECTRICORE_*', '')` (ADR-0024 §3b). En dev, le repli `os.environ` était alimenté par un `docker/.env` **en clair sur disque** — la vraie `ELECTRICORE_API_KEY` (= clé `operator` du trousseau API electricore) y traînait. C'était le **seul secret applicatif en clair du parc** (les autres repos sont passés à Proton Pass, ADR-0056 ; la prod est en SOPS+age, ADR-0044 electricore-secrets).
 
@@ -14,7 +14,7 @@ Le module consomme electricore via deux secrets — `ELECTRICORE_URL`, `ELECTRIC
 ## Conséquences
 
 - **Plus aucun secret applicatif en clair sur disque** dans le parc.
-- `pr ./scripts/dev.sh` = intégration electricore active en dev ; **sans** `pr`, les vars sont vides → l'intégration se **désactive proprement** (repli `or ''`, `UserError` actionnable au clic, ADR-0024), pas de crash. Le développeur wrappe quand il en a besoin.
+- Intégration electricore active en dev sans y penser : `dev.sh` s'auto-wrappe sous `pass-cli run` quand `ELECTRICORE_URL` manque et que `.env.pass` + pass-cli sont présents (amendement post-validation : oublier `pr` coûtait un conteneur démarré sans secrets et un redémarrage). Sans `.env.pass` ni pass-cli, les vars restent vides → l'intégration se **désactive proprement** (repli `or ''`, `UserError` actionnable au clic, ADR-0024), pas de crash.
 - `docker/.env.example` (committé, valeurs vides) reste le **template documentaire** des deux variables.
 - La clé `operator` est **dupliquée** dans l'item `souscriptions_odoo` plutôt que référencée cross-vault vers l'item `electricore` : pour deux valeurs, un item dédié évite un token cross-vault (ADR-0056, ergonomie du scope par vault).
 

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -21,9 +21,10 @@
 # (charte migration) vérifiés avant ET après chargement : crons coupés, aucun mail sortant,
 # aucun règlement SEPA groupé — une base non conforme arrête le script.
 #
-# Secrets electricore (ELECTRICORE_URL / _API_KEY) : injectés depuis Proton Pass —
-#   pr ./scripts/dev.sh              # pass-cli résout .env.pass -> env shell -> pass-through compose -> conteneur
-# Sans `pr` : vars vides -> intégration electricore désactivée (repli, ADR-0024), pas de crash.
+# Secrets electricore (ELECTRICORE_URL / _API_KEY) : injectés depuis Proton Pass.
+# Le script s'auto-wrappe sous `pass-cli run` (.env.pass) quand les vars manquent —
+# plus besoin de préfixer par `pr`. Sans .env.pass ni pass-cli : vars vides ->
+# intégration electricore désactivée (repli, ADR-0024), pas de crash.
 # Voir docs/adr/0026 + electricore ADR-0056.
 #
 # -> http://localhost:8069  (admin / admin)
@@ -38,6 +39,14 @@
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+# Auto-wrap pass-cli (ADR-0026) : si les secrets electricore manquent et que
+# .env.pass + pass-cli sont là, on se relance sous `pass-cli run` — plus besoin
+# de penser à `pr`. Échec bruyant si la session Proton est verrouillée.
+if [ -z "${ELECTRICORE_URL:-}" ] && [ -f "$REPO_ROOT/.env.pass" ] && command -v pass-cli >/dev/null 2>&1; then
+    exec pass-cli run --env-file "$REPO_ROOT/.env.pass" -- "$0" "$@"
+fi
+
 COMPOSE=(docker compose -f "$REPO_ROOT/docker/docker-compose.yml")
 # Chemin RELATIF au dépôt (contrat de layout : dépôts voisins), jamais celui du
 # worktree courant — cf. commentaire d'en-tête.


### PR DESCRIPTION
Rescue par /repo-janitor du stash « WIP hors-campagne » du 2026-07-12.

- ADR 0026 : statut « proposé » → « accepté » (pass-through Proton Pass validé le 2026-07-12, `pr docker compose … config` affiche `<concealed by Proton Pass>` pour les deux variables).
- `scripts/dev.sh` : auto-wrap sous `pass-cli run` quand `ELECTRICORE_URL` manque et que `.env.pass` + pass-cli sont présents — plus besoin de préfixer par `pr`. Sans `.env.pass` ni pass-cli : vars vides, l'intégration electricore se désactive proprement (ADR-0024).

🤖 Generated with [Claude Code](https://claude.com/claude-code)