### PR TITLE
feat(souscription): état « en attente de clôture » — quatrième état dérivé, file d'attente des sorties (tranche 2 du chantier #21)

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -13,7 +13,7 @@ Journeys de capacités (`REQ-XXX-nn`), chacune avec un statut (✅ Proven · ⚠
 - REQ-RAC-07 ✅ pack de bienvenue automatique à « Abonnement Validé » — preuve: tests/test_mails_raccordement.py::test_drag_en_abonnement_valide_envoie_pack_bienvenue_avec_cp_en_piece_jointe · #103
 - REQ-RAC-08 ✅ poll quotidien des affaires Enedis, alertes sans spam — preuve: tests/test_poll_affaires_enedis.py · #89
 - REQ-RAC-09 ✅ résolution RSC à la demande via electricore, bouton + garde serveur limités à *en instance* (jamais résiliée/en service, même en lot) — preuve: tests/test_rsc_service.py::test_souscription_resiliee_jamais_reciblee · #88, #136
-- REQ-RAC-10 ✅ état du contrat calculé : en instance / en service / résiliée — preuve: tests/test_souscription_etat.py::test_bascule_en_service_a_lecriture_de_la_rsc · #87
+- REQ-RAC-10 ✅ état du contrat calculé, quatre états dérivés (aucun statut à la main) : en instance / en service / **en attente de clôture** (date de fin passée, clôture non soldée — la file d'attente des sorties à traiter, vue en filtre) / **résiliée** (clôture soldée : Période contenant `date_fin` facturée + Régularisation de clôture émise, ou rien à solder — non-lissé, résilié migré « régularisée ») ; statut reflété au portail — preuve: tests/test_souscription_etat.py::TestEtatEnAttenteCloture · #87, #21, #247, ADR 0031
 - REQ-RAC-11 ✅ mandat SEPA créé actif d'emblée via le service `souscription.sepa.mandat` (garde registre `sdd.mandate`, no-op Community) — preuve: tests/test_sepa_mandat.py, tests/test_raccordement.py::test_creer_mandat_sepa_delegue_au_service_et_recopie_le_rum · #187, #217
 
 ## Parcours : contrat & documents

--- a/models/core/souscription.py
+++ b/models/core/souscription.py
@@ -200,15 +200,21 @@ class Souscription(models.Model):
         'quotidien des affaires Enedis (#89).',
     )
     etat = fields.Selection(
-        [('en_instance', 'En instance'), ('en_service', 'En service'), ('resiliee', 'Résiliée')],
+        [
+            ('en_instance', 'En instance'),
+            ('en_service', 'En service'),
+            ('en_attente_cloture', 'En attente de clôture'),
+            ('resiliee', 'Résiliée'),
+        ],
         string='État',
         compute='_compute_etat',
         store=True,
         tracking=True,
-        help='Cycle de vie calculé depuis les faits (ADR 0021), jamais saisi : '
+        help='Cycle de vie calculé depuis les faits (ADR 0021, ADR 0031), jamais saisi : '
         '*en instance* (RSC absente, non facturable), *en service* (RSC acquise, '
-        'facturable), *résiliée* (date de fin passée — logique minimale, chantier '
-        'dédié ultérieur). Se corrige par le fait (la RSC), jamais par ce champ.',
+        'facturable), *en attente de clôture* (date de fin passée, clôture non '
+        'soldée — la file des sorties à traiter), *résiliée* (clôture soldée). '
+        'Se corrige par le fait (la RSC, le C15 de sortie), jamais par ce champ.',
     )
     motif_resolution_rsc = fields.Char(
         string='Motif dernière résolution RSC',
@@ -230,16 +236,65 @@ class Souscription(models.Model):
         'Cette RSC est déjà portée par une autre souscription — une RSC identifie un contrat unique.',
     )
 
-    @api.depends('ref_situation_contractuelle', 'date_fin')
+    @api.depends(
+        'ref_situation_contractuelle',
+        'date_fin',
+        'periode_ids.date_debut',
+        'periode_ids.date_fin',
+        'periode_ids.facture_id',
+        'periode_ids.facture_legacy_ref',
+        'periode_ids.legacy_regularisee',
+        'periode_ids.lisse_periode',
+        'periode_ids.regularisation_id',
+    )
     def _compute_etat(self):
         today = fields.Date.context_today(self)
         for sous in self:
             if sous.date_fin and sous.date_fin < today:
-                sous.etat = 'resiliee'
+                sous.etat = 'resiliee' if sous._cloture_soldee() else 'en_attente_cloture'
             elif sous.ref_situation_contractuelle:
                 sous.etat = 'en_service'
             else:
                 sous.etat = 'en_instance'
+
+    def _periode_cloture(self):
+        """La Période mensuelle contenant `date_fin` (dernier jour servi,
+        ADR 0031 décision 2) — bornes demi-ouvertes de la Période
+        (`date_debut <= date_fin < periode.date_fin`, ADR 0031)."""
+        self.ensure_one()
+        if not self.date_fin:
+            return self.env['souscription.periode']
+        return self.periode_ids.filtered(
+            lambda p: p.date_debut and p.date_fin and p.date_debut <= self.date_fin < p.date_fin
+        )[:1]
+
+    def _cloture_soldee(self):
+        """Prédicat de faits « clôture soldée » (ADR 0031 décision 3, #247) :
+        la Période contenant `date_fin` est facturée ET (une Régularisation
+        de clôture est émise OU rien à solder). Aucun statut à la main.
+
+        « Émise » : `periode.regularisation_id` n'est posé que par
+        `souscription.regularisation._solder_provisions()`, appelée
+        uniquement depuis `account.move._post()` sur les factures qui
+        viennent d'être postées — jamais au brouillon (tranche 6, #238). Le
+        champ trace donc exactement le fait « une Régularisation qui couvre
+        cette Période a été émise », pas seulement « facturée » (`etat ==
+        'facturee'` inclut le brouillon d'une facture pas encore postée).
+
+        « Rien à solder » : non-lissé (écarts nuls par construction — le
+        tampon de facturation pose `provision := energie` à chaque
+        facturation, #234) ou résilié migré déjà réglé avant bascule (mois
+        « régularisée », `legacy_regularisee`, ADR 0023/PRD #207).
+        """
+        self.ensure_one()
+        periode = self._periode_cloture()
+        if not periode:
+            return False
+        if not (periode.facture_id or periode.facture_legacy_ref):
+            return False
+        if periode.regularisation_id:
+            return True
+        return not periode.lisse_periode or periode.legacy_regularisee
 
     @api.model
     def souscriptions_concernees(self, mois):

--- a/tests/test_campagne_signaux.py
+++ b/tests/test_campagne_signaux.py
@@ -140,11 +140,14 @@ class TestCampagneSignauxDerives(SouscriptionsTestCase):
         self.assertEqual(self._etape('pull_meta_periodes').nb_reste_a_faire, 2)
 
     def test_perimetre_inclut_souscription_en_service_pendant_le_mois_mais_resiliee_depuis(self):
-        """En service dès janvier, résiliée en juin (dans le passé par
+        """En service dès janvier, sortie posée en juin (dans le passé par
         rapport à aujourd'hui) : concernée par mars, donc dans le
-        périmètre — pas de sous-compte malgré `etat == 'resiliee'`."""
+        périmètre — pas de sous-compte malgré `etat == 'en_attente_cloture'`
+        (aucune Période ne couvre encore `date_fin` ici, clôture non soldée,
+        ADR 0031 décision 3, #247 — le périmètre lit `date_fin`, jamais
+        l'instantané vivant `etat`, quel que soit son état dérivé)."""
         resiliee = self._creer_souscription_rsc('PDL_RESILIEE', 'RSC-RESILIEE', date(2024, 1, 1), date(2024, 6, 30))
-        self.assertEqual(resiliee.etat, 'resiliee')
+        self.assertEqual(resiliee.etat, 'en_attente_cloture')
         self.campagne.invalidate_recordset()
 
         self.assertIn(resiliee, self.campagne._souscriptions_facturables())

--- a/tests/test_portal.py
+++ b/tests/test_portal.py
@@ -109,6 +109,16 @@ class PortalTestCase(SouscriptionsTestMixin, HttpCase):
         self.assertIn(self.souscription_base.name, response.text)
         self.assertIn(self.souscription_base.pdl, response.text)
 
+    def test_liste_reflete_le_statut_de_cycle_de_vie(self):
+        """Le statut reflété au portail est l'état dérivé (`etat`, critère de
+        #21, ADR 0031) — plus le générique « Active »/« Inactive » (archivage
+        Odoo, sans rapport avec le cycle de vie)."""
+        self.assertEqual(self.souscription_base.etat, 'en_instance')
+        self.authenticate(self.portal_user.login, self.portal_user.login)
+        response = self.url_open('/my/souscriptions')
+        self.assertEqual(response.status_code, 200)
+        self.assertIn('En instance', response.text)
+
     def test_apercu_via_access_token(self):
         """L'URL signée (access_token) ouvre la page à un non-propriétaire — c'est
         ce qui alimente le bouton « Aperçu » back-office. Sans token : 403."""

--- a/tests/test_pull_sorties.py
+++ b/tests/test_pull_sorties.py
@@ -16,7 +16,7 @@ Deux tranches :
 Fixtures RSC/PDL : identifiants factices (jamais des vrais échantillons).
 """
 
-from datetime import date, timedelta
+from datetime import date
 
 from odoo.addons.souscriptions_odoo.models.core import souscription_pull_meta_periodes_service as service_module
 from odoo.exceptions import UserError
@@ -33,8 +33,10 @@ class TestPullSortiesService(SouscriptionsTestCase):
 
     def test_sortie_absente_ecrit_date_fin_dernier_jour_servi_et_trace_au_chatter(self):
         """AC1 : une sortie RES au 12/06 -> date_fin = 11/06 (dernier jour
-        servi, convention de borne ADR 0031 décision 2), etat = 'resiliee'
-        dérive (compute existant), chatter posé avec le code et la date brute."""
+        servi, convention de borne ADR 0031 décision 2), etat = 'en_attente_cloture'
+        dérive (compute existant) — la clôture n'est pas soldée (aucune
+        Période ne couvre encore `date_fin`), tranche 2 #247 ; chatter posé
+        avec le code et la date brute."""
         self.souscription_base.ref_situation_contractuelle = 'RSC-00000000000001'
         client = client_sorties_factice(
             [ligne_sortie('RSC-00000000000001', date(2024, 6, 12), evenement_declencheur='RES')]
@@ -43,7 +45,7 @@ class TestPullSortiesService(SouscriptionsTestCase):
         ecrites, corrigees, inchangees, erreurs = self._pull_sorties(client, self.souscription_base)
 
         self.assertEqual(self.souscription_base.date_fin, date(2024, 6, 11))
-        self.assertEqual(self.souscription_base.etat, 'resiliee')
+        self.assertEqual(self.souscription_base.etat, 'en_attente_cloture')
         self.assertEqual(len(ecrites), 1)
         self.assertFalse(corrigees)
         self.assertFalse(inchangees)
@@ -195,7 +197,19 @@ class TestActionTirerSortiesC15(SouscriptionsTestCase):
 
     def test_perimetre_exclut_les_souscriptions_deja_resiliees(self):
         self.souscription_base.write(
-            {'ref_situation_contractuelle': 'RSC-00000000000001', 'date_fin': date.today() - timedelta(days=1)}
+            {'ref_situation_contractuelle': 'RSC-00000000000001', 'date_fin': date(2024, 1, 31)}
+        )
+        # Clôture soldée (non-lissé, écarts nuls par construction, ADR 0031
+        # décision 3, #247) : la Période contenant `date_fin` facturée suffit
+        # -> `resiliee` direct, hors périmètre du pull (même garde que la RSC
+        # déjà résolue).
+        self.env['souscription.periode'].create(
+            {
+                'souscription_id': self.souscription_base.id,
+                'date_debut': date(2024, 1, 1),
+                'date_fin': date(2024, 2, 1),
+                'facture_legacy_ref': 'LEGACY-DEJA-RESILIEE-1',
+            }
         )
         self.assertEqual(self.souscription_base.etat, 'resiliee')
         client = client_sorties_factice([])

--- a/tests/test_rsc_service.py
+++ b/tests/test_rsc_service.py
@@ -9,7 +9,7 @@ pas de mock d'`electricore_client` lui-même, pas de HTTP, pas de mock du
 temps.
 """
 
-from datetime import date, timedelta
+from datetime import date
 
 from odoo.addons.souscriptions_odoo.models.core import electricore_rsc_service as service_module
 from odoo.exceptions import UserError
@@ -146,8 +146,19 @@ class TestActionResoudreRscMaintenant(SouscriptionsTestCase):
         l'action serveur, même sans RSC (résiliation avant mise en service)
         et même appelée en lot — aucun appel au service RSC, idempotence
         conservée (même garde que le poll quotidien #89, `etat ==
-        'en_instance'`)."""
-        self.souscription_base.write({'date_fin': date.today() - timedelta(days=1)})
+        'en_instance'`). Clôture soldée (non-lissé, écarts nuls par
+        construction, ADR 0031 décision 3, #247) : la Période contenant
+        `date_fin` facturée suffit à faire basculer directement en
+        `resiliee`, sans Régularisation."""
+        self.env['souscription.periode'].create(
+            {
+                'souscription_id': self.souscription_base.id,
+                'date_debut': date(2024, 1, 1),
+                'date_fin': date(2024, 2, 1),
+                'facture_legacy_ref': 'LEGACY-RESILIEE-GUARD-1',
+            }
+        )
+        self.souscription_base.write({'date_fin': date(2024, 1, 31)})
         self.assertEqual(self.souscription_base.etat, 'resiliee')
 
         with _patch_appeler() as mock_appeler:

--- a/tests/test_souscription_etat.py
+++ b/tests/test_souscription_etat.py
@@ -2,6 +2,11 @@
 amendé) : capture de l'id_Affaire côté raccordement (avec sa date de saisie),
 recopie à la création, correction possible, RSC restreinte au groupe
 gestionnaire, état de cycle de vie calculé.
+
+Le quatrième état dérivé (`en_attente_cloture`, `resiliee` resserrée) —
+prédicat de faits « clôture soldée » — est couvert par
+`TestEtatEnAttenteCloture` (#247, ADR 0031 décision 3, tranche 2 du chantier
+#21).
 """
 
 from datetime import date, timedelta
@@ -11,7 +16,7 @@ from odoo.tests.common import tagged
 from odoo.tools import mute_logger
 from psycopg2 import IntegrityError
 
-from .common import SouscriptionsTestCase
+from .common import SouscriptionsTestCase, build_grille_lignes, client_flux_factice, patcher_client_fabrique
 
 
 @tagged('souscriptions', 'souscriptions_etat', 'post_install', '-at_install')
@@ -143,11 +148,16 @@ class TestEtatCalcule(SouscriptionsTestCase):
         self.souscription_base.write({'ref_situation_contractuelle': 'RSC-1'})
         self.assertEqual(self.souscription_base.etat, 'en_service')
 
-    def test_resiliee_si_date_fin_passee(self):
+    def test_en_attente_cloture_si_date_fin_passee_sans_cloture_soldee(self):
+        """`resiliee` s'est resserrée (#247, ADR 0031 décision 3) : date de fin
+        passée seule ne suffit plus. Sans aucune Période couvrant `date_fin`,
+        le prédicat « clôture soldée » échoue -> `en_attente_cloture` (la
+        file d'attente des sorties à traiter) — le cycle complet vers
+        `resiliee` est couvert par `TestEtatEnAttenteCloture`."""
         self.souscription_base.write(
             {'ref_situation_contractuelle': 'RSC-1', 'date_fin': date.today() - timedelta(days=1)}
         )
-        self.assertEqual(self.souscription_base.etat, 'resiliee')
+        self.assertEqual(self.souscription_base.etat, 'en_attente_cloture')
 
     def test_pas_de_vocabulaire_brouillon_dans_la_selection(self):
         """Vocabulaire du glossaire (CONTEXT.md) : jamais « brouillon », jamais
@@ -185,6 +195,21 @@ class TestFiltresEtat(SouscriptionsTestCase):
 
         self.assertEqual(par_rsc, self.souscription_base)
         self.assertEqual(par_affaire, self.souscription_hphc)
+
+    def test_filtre_en_attente_cloture_liste_exactement_cet_etat(self):
+        """La file d'attente des sorties à traiter, c'est la vue de l'état
+        `en_attente_cloture` (#247, ADR 0031 décision 3) : le filtre ne
+        retourne ni les souscriptions en service ni les résiliées."""
+        self.souscription_base.write(
+            {'ref_situation_contractuelle': 'RSC-QUEUE-1', 'date_fin': date.today() - timedelta(days=1)}
+        )
+        self.souscription_hphc.write({'ref_situation_contractuelle': 'RSC-QUEUE-2'})
+
+        Souscription = self.env['souscription.souscription']
+        resultat = Souscription.search([('etat', '=', 'en_attente_cloture')])
+
+        self.assertIn(self.souscription_base, resultat)
+        self.assertNotIn(self.souscription_hphc, resultat)
 
 
 @tagged('souscriptions', 'souscriptions_etat', 'post_install', '-at_install')
@@ -229,3 +254,137 @@ class TestRscUnique(SouscriptionsTestCase):
         self._souscription('PDL_A', False)
         self._souscription('PDL_B', False)
         self.env.flush_all()
+
+
+@tagged('souscriptions', 'souscriptions_etat', 'post_install', '-at_install')
+class TestEtatEnAttenteCloture(SouscriptionsTestCase):
+    """#247 (ADR 0031 décision 3, tranche 2 du chantier #21) : quatrième état
+    dérivé — `en_attente_cloture` / `resiliee` resserrée. Prédicat de faits
+    « clôture soldée » : la Période contenant `date_fin` est facturée ET (une
+    Régularisation de clôture est émise OU rien à solder). Aucun statut à la
+    main — dérivé des mêmes faits que `test_regularisation_tampon.py` (le
+    tampon d'émission pose `souscription.periode.regularisation_id`, jamais
+    au brouillon)."""
+
+    def _grille_moulin(self, name):
+        """Grille dédiée (régime `moulin`) : n'entre pas en collision avec
+        `cls.grille_prix` (régime standard, `common.py`) — même motif que
+        `test_regularisation.py`/`test_regularisation_tampon.py`."""
+        grille = self.env['grille.prix'].create(
+            {
+                'name': name,
+                'date_debut': date(2024, 1, 1),
+                'date_fin': date(2024, 12, 31),
+                'active': True,
+                'regime_prix': 'moulin',
+            }
+        )
+        build_grille_lignes(self.env, grille, prix_base=0.15, prix_hp=0.18, prix_hc=0.12)
+        return grille
+
+    def _souscription_lissee(self, ref, pdl):
+        return self.env['souscription.souscription'].create(
+            {
+                'partner_id': self.partner_test.id,
+                'pdl': pdl,
+                'puissance_souscrite': '6',
+                'type_tarif': 'base',
+                'date_debut': date(2023, 1, 1),
+                'lisse': True,
+                'provision_mensuelle_kwh': 200.0,
+                'regime_prix': 'moulin',
+                'ref_situation_contractuelle': ref,
+            }
+        )
+
+    def _periode(self, souscription, date_debut, date_fin, **overrides):
+        """Une Période mensuelle demi-ouverte (`date_fin` = 1er du mois
+        suivant, ADR 0031) — convention distincte du helper partagé
+        `create_test_periode` (`common.py`, bornes inclusives héritées d'un
+        usage antérieur) : le prédicat de clôture a besoin des bornes
+        v3 brutes réelles pour situer `date_fin` de la Souscription."""
+        vals = {
+            'souscription_id': souscription.id,
+            'date_debut': date_debut,
+            'date_fin': date_fin,
+            'type_periode': 'mensuelle',
+        }
+        vals.update(overrides)
+        return self.env['souscription.periode'].create(vals)
+
+    def _sans_appel_reseau(self):
+        return patcher_client_fabrique(client_flux_factice('meta_periodes', []))
+
+    # --- AC « cycle complet » ---
+
+    def test_cycle_complet_en_service_puis_en_attente_cloture_puis_resiliee(self):
+        """en_service -> en_attente_cloture (sortie posée) -> resiliee (solde
+        émis) : le cycle complet de l'ADR 0031 décision 3."""
+        souscription = self._souscription_lissee('RSC-CYCLE', 'PDL_CYCLE')
+        self._grille_moulin('Grille Cycle')
+        self.assertEqual(souscription.etat, 'en_service')
+
+        # Dernier mois facturé (janvier), écart non nul -> pas encore soldé.
+        periode = self._periode(
+            souscription,
+            date(2024, 1, 1),
+            date(2024, 2, 1),
+            provision_base_kwh=200.0,
+            energie_base_kwh=225.0,  # écart +25
+            qualite='réelle',
+            statut_communication='communicante',
+            facture_legacy_ref='LEGACY-CYCLE-1',
+        )
+        souscription.date_fin = date(2024, 1, 31)  # dernier jour servi (sortie C15 posée)
+        self.assertEqual(souscription.etat, 'en_attente_cloture')
+
+        # Solde émis : la régul de clôture est une Régularisation ordinaire
+        # (ADR 0031 décision 4) — le câblage/l'ordonnancement de campagne
+        # (tranche 3, #248) n'est pas construit ici, on émet directement pour
+        # isoler le prédicat de faits de cette tranche.
+        regularisation = self.env['souscription.regularisation'].create({'souscription_id': souscription.id})
+        with self._sans_appel_reseau():
+            regularisation._recalculer()
+        facture = regularisation._creer_facture()
+        facture.action_post()
+
+        self.assertEqual(periode.regularisation_id, regularisation)
+        self.assertEqual(souscription.etat, 'resiliee')
+
+    # --- AC « non-lissé sorti » ---
+
+    def test_non_lisse_sorti_resiliee_direct(self):
+        """Non-lissé : écarts nuls par construction (le tampon de
+        facturation pose `provision := energie`, #234) -> rien à solder,
+        `resiliee` direct dès que la Période contenant `date_fin` est
+        facturée — aucune Régularisation requise."""
+        souscription = self.souscription_base  # lisse=False (common.py)
+        souscription.write({'ref_situation_contractuelle': 'RSC-NON-LISSE'})
+        self._periode(
+            souscription,
+            date(2024, 1, 1),
+            date(2024, 2, 1),
+            facture_legacy_ref='LEGACY-NON-LISSE-1',
+        )
+        souscription.date_fin = date(2024, 1, 31)
+
+        self.assertEqual(souscription.etat, 'resiliee')
+
+    # --- AC « résilié migré » ---
+
+    def test_resilie_migre_mois_regularisee_resiliee_direct(self):
+        """Résilié migré : la Période contenant `date_fin` porte le marqueur
+        legacy « régularisée » (ADR 0023/PRD #207) -> déjà soldée avant
+        bascule, `resiliee` direct — sans Régularisation émise dans ce
+        système, y compris pour un contrat lissé."""
+        souscription = self._souscription_lissee('RSC-MIGRE', 'PDL_MIGRE')
+        self._periode(
+            souscription,
+            date(2024, 1, 1),
+            date(2024, 2, 1),
+            facture_legacy_ref='LEGACY-MIGRE-1',
+            legacy_regularisee=True,
+        )
+        souscription.date_fin = date(2024, 1, 31)
+
+        self.assertEqual(souscription.etat, 'resiliee')

--- a/views/core/souscription_views.xml
+++ b/views/core/souscription_views.xml
@@ -187,6 +187,7 @@
             <field name="etat" widget="badge"
                    decoration-warning="etat == 'en_instance'"
                    decoration-success="etat == 'en_service'"
+                   decoration-info="etat == 'en_attente_cloture'"
                    decoration-danger="etat == 'resiliee'"/>
             <field name="id_affaire" optional="hide"/>
             <field name="ref_situation_contractuelle" optional="hide"/>
@@ -230,6 +231,10 @@
                 <field name="id_affaire" string="N° d'affaire Enedis"/>
                 <filter string="En instance" name="en_instance" domain="[('etat', '=', 'en_instance')]"/>
                 <filter string="En service" name="en_service" domain="[('etat', '=', 'en_service')]"/>
+                <!-- File d'attente des sorties à traiter (#247, ADR 0031 décision 3) :
+                     la vue de l'état dérivé, aucun objet ni statut de traitement à part. -->
+                <filter string="En attente de clôture" name="en_attente_cloture"
+                        domain="[('etat', '=', 'en_attente_cloture')]"/>
                 <filter string="Résiliée" name="resiliee" domain="[('etat', '=', 'resiliee')]"/>
                 <separator/>
                 <filter string="En instance sans id_Affaire" name="en_instance_sans_id_affaire"

--- a/views/portal_templates.xml
+++ b/views/portal_templates.xml
@@ -58,8 +58,12 @@
                                         </t>
                                     </td>
                                     <td>
-                                        <span t-attf-class="badge rounded-pill text-bg-#{souscription.active and 'success' or 'secondary'}">
-                                            <t t-out="souscription.active and 'Active' or 'Inactive'"/>
+                                        <!-- Statut reflété (critère de #21, ADR 0031) : le libellé vient de
+                                             la Selection du modèle — jamais redéfini ici — seule la couleur
+                                             se choisit par état. -->
+                                        <t t-set="etat_color" t-value="{'en_instance': 'secondary', 'en_service': 'success', 'en_attente_cloture': 'warning', 'resiliee': 'danger'}.get(souscription.etat, 'secondary')"/>
+                                        <span t-attf-class="badge rounded-pill text-bg-#{etat_color}">
+                                            <t t-out="dict(souscription._fields['etat'].selection).get(souscription.etat, souscription.etat)"/>
                                         </span>
                                     </td>
                                     <td class="text-end">


### PR DESCRIPTION
Closes #247

Réalise la décision 3 de l'ADR 0031 : le travail dérive du fait, aucun statut
à la main.

- `_compute_etat` gagne `en_attente_cloture` (date de fin passée ∧ clôture
  non soldée) ; `resiliee` se resserre (clôture soldée).
- Prédicat de faits « clôture soldée » : la Période contenant `date_fin` est
  facturée ∧ (régul de clôture **émise** — lue via `periode.regularisation_id`,
  que seul `_solder_provisions()` pose au post du move, donc « émise » et pas
  seulement « facturée » — ∨ rien à solder : non-lissé ou mois « régularisée »
  legacy → `resiliee` direct).
- File d'attente des sorties = filtre de recherche `en_attente_cloture`
  (même domaine que le test qui le grave).
- Portail : la colonne « État » de `/my/souscriptions` reflète désormais le
  cycle de vie (`etat`) au lieu du générique actif/archivé (critère de #21).

Rattrapage assumé : les tests de la tranche 1 qui déduisaient `resiliee` de
`date_fin` seule passent à `en_attente_cloture` (ou reconstruits avec une
vraie Période facturée non-lissée quand l'intention exigeait `resiliee`) ;
le périmètre de campagne (lit `date_fin`, jamais `etat`) est intact et son
test le démontre mieux.

⚠️ PR **empilée sur #259** (`feat/regul-solde-tampon-238`) — à merger après
elle ; GitHub reciblera sur main au merge de la base.

Suite complète verte en docker : **0 failed, 0 error(s) of 585 tests** (+5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)