### PR TITLE
refactor(periode): purement mensuelle, unicité pleine (tranche 7 du PRD #231)

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -43,7 +43,7 @@ Journeys de capacités (`REQ-XXX-nn`), chacune avec un statut (✅ Proven · ⚠
 - REQ-FAC-04 ✅ notes de campagne reportées au mois suivant — preuve: tests/test_campagne_notes.py · #159
 - REQ-FAC-05 ✅ pull des méta-périodes electricore, idempotent — propriétaire durable extrait en service (`souscription.pull.meta.periodes.service`), wizard/Campagne en coquilles minces — preuve: tests/test_pull_meta_periodes.py · #77, #233
 - REQ-FAC-06 ✅ énergie par cadran en cascade selon le calendrier de comptage — preuve: tests/test_periode_energie.py · #26
-- REQ-FAC-07 ✅ période mensuelle unique, snapshot figé à la facturation — preuve: tests/test_periode_snapshot.py::test_periode_figee_des_la_facturation · #14
+- REQ-FAC-07 ✅ période purement mensuelle (plus de `regularisation`/`ajustement`, jamais portés par une donnée — la Régularisation est un modèle propre depuis la tranche 4), unicité `(souscription, mois)` pleine, snapshot figé à la facturation — preuve: tests/test_periode_snapshot.py::test_periode_figee_des_la_facturation, tests/test_periode_mois.py · #14, #239, ADR 0030 décision 3
 - REQ-FAC-08 ✅ relevés d'index : verrou de facturation + bloc justificatif (colonnes = union des familles réellement relevées) — preuve: tests/test_releve.py · #54, #138
 - REQ-FAC-09 ✅ composition des lignes : prorata, cadrans, TURPE, pro, solidaire, régime — preuve: tests/test_periode_composition.py · #74
 - REQ-FAC-10 ✅ facture d'énergie PDF sur template dédié — preuve: tests/test_invoice_template.py, tests/test_facture_document.py::test_facture_energie_pdf

--- a/__manifest__.py
+++ b/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Souscriptions Électricité',
-    'version': '19.0.1.14.0',
+    'version': '19.0.1.15.0',
     'depends': ['base', 'mail', 'contacts', 'account', 'base_iban', 'portal'],
     'author': 'Virgile Daugé',
     'category': 'Energy',

--- a/docs/adr/0020-alignement-contrat-meta-periodes-v3.md
+++ b/docs/adr/0020-alignement-contrat-meta-periodes-v3.md
@@ -35,6 +35,14 @@ là-bas ; ici on acte la cible.
    **`(souscription, mois)` scopée aux périodes mensuelles** : les
    régularisations/ajustements restent libres (plusieurs par mois possibles).
 
+   > **Amendé (2026-07,
+   > [ADR-0030](0030-facture-gele-mesure-vivant-regularisation-modele-propre-solde-tampon.md)
+   > décision 3, #239)** : la Période redevient **purement mensuelle** — `type_periode`
+   > perd `regularisation`/`ajustement` (jamais portés par une donnée, la Régularisation
+   > étant un modèle propre depuis la tranche 4, #236). L'unicité `(souscription, mois)`
+   > devient **pleine** : l'index unique perd sa clause `WHERE type_periode = 'mensuelle'`,
+   > exprimable en `models.Constraint` UNIQUE ordinaire.
+
 3. **Identité : la *Période* snapshotte la RSC.** `ref_situation_contractuelle` est recopiée
    de la *Souscription* à la création — même logique que le snapshot des paramètres
    contractuels ([ADR-0006](0006-snapshot-periode-fait-autorite-facturation.md)). La
@@ -97,7 +105,8 @@ là-bas ; ici on acte la cible.
 - **Table de correspondance nom-fil → nom-Odoo** : une couche de traduction à maintenir,
   que l'alignement des noms rend inutile.
 - **Unicité `(souscription, mois)` globale** : bloquerait régularisations et ajustements —
-  d'où le scope aux seules périodes mensuelles.
+  d'où le scope aux seules périodes mensuelles. *(Devenu le cas nominal — amendement de
+  juillet 2026 ci-dessus : la Régularisation n'étant plus une Période, plus rien ne bloque.)*
 - **Renvoyer la puissance souscrite dans le payload** : reste exclu — la frontière
   d'[ADR-0002](0002-deux-sources-de-verite-marge-en-analytique.md)/0011 sur les paramètres
   contractuels tient ; seule la grandeur *physique* (moyenne C15) traverse le fil.

--- a/migrations/19.0.1.15.0/post-migrate.py
+++ b/migrations/19.0.1.15.0/post-migrate.py
@@ -1,0 +1,16 @@
+"""Purge de l'ancien index unique partiel (#239, ADR 0030 décision 3).
+
+`souscription_periode_mois_mensuelle_unique` était posé à la main dans
+`init()` (raw SQL — hors du vocabulaire `models.Constraint`, qui ne sait pas
+exprimer de clause `WHERE`). La Période étant désormais purement mensuelle,
+il est redondant avec `_unique_mois` — la contrainte UNIQUE pleine que le
+nouveau `models.Constraint` fait poser par Odoo lui-même au chargement du
+module. Créé hors ORM, cet index n'est jamais tracké par
+`ir_model_constraint` — jamais nettoyé automatiquement, on le droppe donc à
+la main. Idempotent (`IF EXISTS`), no-op sur install neuve ou base déjà
+migrée.
+"""
+
+
+def migrate(cr, version):
+    cr.execute('DROP INDEX IF EXISTS souscription_periode_mois_mensuelle_unique')

--- a/migrations/19.0.1.15.0/pre-migrate.py
+++ b/migrations/19.0.1.15.0/pre-migrate.py
@@ -1,0 +1,24 @@
+"""Garde de nettoyage avant suppression des types morts de `type_periode`
+(#239, ADR 0030 décision 3 — la Période redevient purement mensuelle).
+
+`regularisation` et `ajustement` n'ont **jamais été portés par une donnée** :
+la Régularisation est un modèle propre (`souscription.regularisation`) depuis
+la tranche 4 (#236), et ces valeurs de sélection n'ont jamais été écrites par
+le système en place. La sélection Python passe à `mensuelle` seul dans cette
+même version — si une ligne existe malgré tout avec l'un de ces types, c'est
+une anomalie qui doit être nettoyée à la main *avant* l'upgrade, pas absorbée
+silencieusement. Échec bruyant : on lève avant que le schéma ne change, pour
+que l'anomalie remonte plutôt que de laisser une donnée orpheline hors
+sélection.
+"""
+
+
+def migrate(cr, version):
+    cr.execute("SELECT COUNT(*) FROM souscription_periode WHERE type_periode IN ('regularisation', 'ajustement')")
+    (nb,) = cr.fetchone()
+    if nb:
+        raise Exception(
+            f'{nb} souscription.periode porte(nt) encore un type_periode mort '
+            "('regularisation'/'ajustement') — nettoyage manuel requis avant l'upgrade "
+            'vers 19.0.1.15.0 (#239, ADR 0030 décision 3).'
+        )

--- a/models/core/souscription_periode.py
+++ b/models/core/souscription_periode.py
@@ -129,9 +129,13 @@ class SouscriptionPeriode(models.Model):
         'distincte de la puissance souscrite (paramètre contractuel snapshotté).',
     )
 
-    # Métadonnées période
+    # Métadonnées période. La Période est **purement mensuelle** (ADR 0030
+    # décision 3, #239) : `regularisation`/`ajustement` n'ont jamais porté de
+    # donnée (la Régularisation est un modèle propre depuis la tranche 4,
+    # #236) — sélection réduite en conséquence, garde de nettoyage en
+    # pre-migrate (migrations/19.0.1.15.0).
     type_periode = fields.Selection(
-        [('mensuelle', 'Mensuelle'), ('regularisation', 'Régularisation'), ('ajustement', 'Ajustement')],
+        [('mensuelle', 'Mensuelle')],
         default='mensuelle',
         string='Type de période',
     )
@@ -276,21 +280,16 @@ class SouscriptionPeriode(models.Model):
             factures = periode.move_ids.filtered(lambda m: m.move_type == 'out_invoice')
             periode.facture_id = factures[:1]
 
-    def init(self):
-        """Unicité `(souscription, mois)` scopée aux périodes **mensuelles**
-        (ADR 0020 §2) : support de la clé d'idempotence `(RSC, mois)` du pull
-        electricore, sans bloquer régularisations/ajustements (libres, plusieurs
-        par mois possibles). Un index unique partiel — hors du vocabulaire de
-        `models.Constraint`, qui ne sait pas exprimer de clause `WHERE` — est la
-        façon idiomatique Odoo d'imposer une contrainte SQL conditionnelle."""
-        self.env.cr.execute(
-            """
-            CREATE UNIQUE INDEX IF NOT EXISTS souscription_periode_mois_mensuelle_unique
-            ON souscription_periode (souscription_id, mois)
-            WHERE type_periode = 'mensuelle'
-            """
-        )
-        super().init()
+    # Unicité `(souscription, mois)` (ADR 0020 §2, amendé par ADR 0030 décision
+    # 3 / #239) : support de la clé d'idempotence `(RSC, mois)` du pull
+    # electricore. La Période étant désormais purement mensuelle (plus de
+    # `regularisation`/`ajustement`), l'unicité est **pleine** — un
+    # `models.Constraint` UNIQUE ordinaire suffit, plus besoin de l'index
+    # partiel `WHERE type_periode = 'mensuelle'` (raw SQL en `init()`).
+    _unique_mois = models.Constraint(
+        'UNIQUE(souscription_id, mois)',
+        'Une période existe déjà pour cette souscription sur ce mois.',
+    )
 
     @api.model_create_multi
     def create(self, vals_list):

--- a/tests/test_periode_mois.py
+++ b/tests/test_periode_mois.py
@@ -66,7 +66,7 @@ class TestPeriodeMoisCanonique(SouscriptionsTestCase):
     # créer de période 'regularisation'/'ajustement' via l'ORM (Selection).
 
 
-@tagged('souscriptions', 'souscriptions_mois', 'post_install', '-at_install')
+@tagged('souscriptions', 'souscriptions_mois', 'souscriptions_migration', 'post_install', '-at_install')
 class TestMigrationTypesPeriodeMorts(SouscriptionsTestCase):
     """AC1 : garde de nettoyage (migrations/19.0.1.15.0/pre-migrate.py) —
     l'upgrade échoue bruyamment si une Période porte encore un type mort.

--- a/tests/test_periode_mois.py
+++ b/tests/test_periode_mois.py
@@ -1,10 +1,13 @@
 """
-Tests du `mois` canonique de la Période (#76, ADR 0020 §2).
+Tests du `mois` canonique de la Période (#76, ADR 0020 §2) et de son unicité
+(#239, ADR 0030 décision 3).
 
 `mois` est un `Date` au 1er du mois, dérivé stocké de `date_debut` — support
 local de la clé d'idempotence `(RSC, mois)` du pull electricore (ADR 0011).
-Unicité `(souscription, mois)` scopée aux périodes **mensuelles** :
-régularisations et ajustements restent libres.
+La Période est **purement mensuelle** : `type_periode` ne porte plus que
+`mensuelle` (la Régularisation est un modèle propre depuis la tranche 4,
+#236) — l'unicité `(souscription, mois)` est donc **pleine**, portée par un
+`models.Constraint` UNIQUE ordinaire (plus d'index partiel scopé au type).
 """
 
 from datetime import date
@@ -39,8 +42,10 @@ class TestPeriodeMoisCanonique(SouscriptionsTestCase):
         self.assertEqual(periode.mois, date(2024, 3, 1))
 
     def test_unicite_mensuelle_meme_mois_rejetee(self):
-        """Deux périodes mensuelles de la même souscription sur le même mois
-        canonique sont rejetées (clé d'idempotence (RSC, mois), ADR 0020 §2)."""
+        """AC2 : deux mensuelles de la même souscription sur le même mois
+        canonique sont toujours rejetées — unicité **pleine** (clé
+        d'idempotence (RSC, mois), ADR 0020 §2 amendé par ADR 0030 décision 3,
+        #239)."""
         self._periode(self.souscription_base)
         with self.assertRaises(IntegrityError), mute_logger('odoo.sql_db'), self.cr.savepoint():
             self._periode(self.souscription_base)
@@ -52,16 +57,8 @@ class TestPeriodeMoisCanonique(SouscriptionsTestCase):
         p2 = self._periode(self.souscription_base, date_debut=date(2024, 4, 1), date_fin=date(2024, 5, 1))
         self.assertNotEqual(p1.mois, p2.mois)
 
-    def test_regularisations_libres_meme_mois(self):
-        """Les régularisations/ajustements restent libres : plusieurs par mois
-        possibles, hors du scope de l'unicité (ADR 0020 §2)."""
-        self._periode(self.souscription_base, type_periode='regularisation')
-        # Ne lève rien : les périodes non-mensuelles ne sont pas contraintes.
-        self._periode(self.souscription_base, type_periode='regularisation')
-
-    def test_ajustement_ne_bloque_pas_la_mensuelle_du_meme_mois(self):
-        """Une régularisation/ajustement sur un mois n'empêche pas la période
-        mensuelle correspondante (le scope est bien restreint au type mensuel)."""
-        self._periode(self.souscription_base, type_periode='ajustement')
-        # La mensuelle du même mois reste créable.
-        self._periode(self.souscription_base, type_periode='mensuelle')
+    # `test_regularisations_libres_meme_mois` et
+    # `test_ajustement_ne_bloque_pas_la_mensuelle_du_meme_mois` (unicité
+    # scopée aux seules mensuelles) sont retirés : sans objet depuis que
+    # `type_periode` ne porte plus que `mensuelle` (#239) — on ne peut plus
+    # créer de période 'regularisation'/'ajustement' via l'ORM (Selection).

--- a/tests/test_periode_mois.py
+++ b/tests/test_periode_mois.py
@@ -10,6 +10,8 @@ La Période est **purement mensuelle** : `type_periode` ne porte plus que
 `models.Constraint` UNIQUE ordinaire (plus d'index partiel scopé au type).
 """
 
+import os
+import runpy
 from datetime import date
 
 from odoo.tests.common import tagged
@@ -62,3 +64,45 @@ class TestPeriodeMoisCanonique(SouscriptionsTestCase):
     # scopée aux seules mensuelles) sont retirés : sans objet depuis que
     # `type_periode` ne porte plus que `mensuelle` (#239) — on ne peut plus
     # créer de période 'regularisation'/'ajustement' via l'ORM (Selection).
+
+
+@tagged('souscriptions', 'souscriptions_mois', 'post_install', '-at_install')
+class TestMigrationTypesPeriodeMorts(SouscriptionsTestCase):
+    """AC1 : garde de nettoyage (migrations/19.0.1.15.0/pre-migrate.py) —
+    l'upgrade échoue bruyamment si une Période porte encore un type mort.
+    Écrit en SQL brut (`cr.execute`) : ces valeurs ne sont plus dans la
+    sélection Python, l'ORM les refuserait à la création (même idiome que
+    `test_migration_energie_facturee.py`, script chargé par chemin via
+    `runpy` — le dossier de version n'est pas un identifiant Python)."""
+
+    @staticmethod
+    def _migrer(cr):
+        chemin = os.path.join(os.path.dirname(os.path.dirname(__file__)), 'migrations', '19.0.1.15.0', 'pre-migrate.py')
+        module = runpy.run_path(chemin)
+        module['migrate'](cr, None)
+
+    def _periode(self, souscription, **vals):
+        base = {
+            'souscription_id': souscription.id,
+            'date_debut': date(2024, 3, 1),
+            'date_fin': date(2024, 4, 1),
+            'type_periode': 'mensuelle',
+        }
+        base.update(vals)
+        return self.env['souscription.periode'].create(base)
+
+    def test_type_mort_leve_bruyamment(self):
+        """Une ligne portant encore 'regularisation'/'ajustement' fait
+        échouer l'upgrade bruyamment plutôt que d'être absorbée en silence."""
+        periode = self._periode(self.souscription_base)
+        self.env.cr.execute(
+            "UPDATE souscription_periode SET type_periode = 'regularisation' WHERE id = %s", (periode.id,)
+        )
+        with self.assertRaises(Exception):
+            self._migrer(self.env.cr)
+
+    def test_aucune_donnee_morte_ne_leve_rien(self):
+        """Sans ligne portant un type mort (le cas nominal, #239), la garde
+        est un no-op — l'upgrade se poursuit normalement."""
+        self._periode(self.souscription_base)
+        self._migrer(self.env.cr)  # ne lève rien


### PR DESCRIPTION
Closes #239

La Période redevient purement mensuelle (ADR 0030 décision 3, tranche 7 du
PRD #231) : `type_periode` perd `regularisation`/`ajustement` (jamais portés
par une donnée — la Régularisation est un modèle propre depuis la tranche 4,
#236), et l'unicité `(souscription, mois)` devient pleine (`models.Constraint`
UNIQUE, remplace l'ancien index partiel `WHERE type_periode = 'mensuelle'`) —
ADR 0020 §2 amendé en place. Garde de migration bruyante (19.0.1.15.0) si des
données portent encore un type mort, avec purge de l'ancien index redondant
en post-migrate. `test_periode_mois` ajusté : cas « régularisations libres du
même mois » retirés (sans objet), garde de migration couverte par deux
nouveaux tests.

Suite complète verte en docker : **0 failed, 0 error(s) of 583 tests**
(`TestMigrationTypesPeriodeMorts` découvert).

🤖 Generated with [Claude Code](https://claude.com/claude-code)