### PR TITLE
feat(portail): factures de régularisation émises visibles et téléchargeables (tranche 8 du PRD #231)

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -64,8 +64,8 @@ Journeys de capacités (`REQ-XXX-nn`), chacune avec un statut (✅ Proven · ⚠
 
 - REQ-POR-01 ✅ accès sécurisé : login, token d'aperçu, cloisonnement entre usagers — preuve: tests/test_portal.py::test_securite_autre_usager
 - REQ-POR-02 ✅ historique de consommation inline (factures émises seulement) — preuve: tests/test_portal.py::test_detail_affiche_historique_inline_sans_bouton · #24
-- REQ-POR-03 ✅ bloc justificatif des relevés, brouillons non fuités — preuve: tests/test_portal.py::test_releves_periode_emise_visibles
-- REQ-POR-04 ✅ factures de régularisation émises visibles et téléchargeables, brouillons non fuités, cloisonnées par souscripteur·rice — preuve: tests/test_portal.py::PortalRegularisationTestCase · #240, ADR 0030 · #57
+- REQ-POR-03 ✅ bloc justificatif des relevés, brouillons non fuités — preuve: tests/test_portal.py::test_releves_periode_emise_visibles · #57
+- REQ-POR-04 ✅ factures de régularisation émises visibles et téléchargeables, brouillons non fuités, cloisonnées par souscripteur·rice — preuve: tests/test_portal.py::PortalRegularisationTestCase · #240, ADR 0030
 
 ## Parcours : reprise de l'existant
 

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -64,7 +64,8 @@ Journeys de capacités (`REQ-XXX-nn`), chacune avec un statut (✅ Proven · ⚠
 
 - REQ-POR-01 ✅ accès sécurisé : login, token d'aperçu, cloisonnement entre usagers — preuve: tests/test_portal.py::test_securite_autre_usager
 - REQ-POR-02 ✅ historique de consommation inline (factures émises seulement) — preuve: tests/test_portal.py::test_detail_affiche_historique_inline_sans_bouton · #24
-- REQ-POR-03 ✅ bloc justificatif des relevés, brouillons non fuités — preuve: tests/test_portal.py::test_releves_periode_emise_visibles · #57
+- REQ-POR-03 ✅ bloc justificatif des relevés, brouillons non fuités — preuve: tests/test_portal.py::test_releves_periode_emise_visibles
+- REQ-POR-04 ✅ factures de régularisation émises visibles et téléchargeables, brouillons non fuités, cloisonnées par souscripteur·rice — preuve: tests/test_portal.py::PortalRegularisationTestCase · #240, ADR 0030 · #57
 
 ## Parcours : reprise de l'existant
 

--- a/controllers/portal.py
+++ b/controllers/portal.py
@@ -62,9 +62,18 @@ class SouscriptionPortal(CustomerPortal):
             'date_debut', reverse=True
         )
 
+        # Factures de régularisation ÉMISES (tranche 8 du PRD #231, #240,
+        # ADR 0030) : même règle que les périodes — un brouillon ne fuite
+        # jamais côté usager·ère. Pas de fusion avec `periodes` (le group_by
+        # mensuelles/réguls est hors périmètre, ADR 0030) : section propre.
+        regularisations = souscription.regularisation_ids.filtered(
+            lambda r: r.facture_id and r.facture_id.state == 'posted'
+        ).sorted('date_fin', reverse=True)
+
         values = {
             'souscription': souscription,
             'periodes': periodes,
+            'regularisations': regularisations,
             'page_name': 'souscription',
         }
 

--- a/tests/test_portal.py
+++ b/tests/test_portal.py
@@ -440,3 +440,90 @@ class PortalReleveTestCase(SouscriptionsTestMixin, HttpCase):
         self.assertEqual(response.status_code, 200)
 
         self.assertNotIn('99999', response.text)
+
+
+@tagged('post_install', '-at_install', 'portal', 'souscriptions_regularisation')
+class PortalRegularisationTestCase(SouscriptionsTestMixin, HttpCase):
+    """Factures de régularisation ÉMISES au portail (tranche 8 du PRD #231,
+    #240, ADR 0030 conséquences) : même règle que l'historique des périodes
+    — une facture de régul en brouillon ne fuite jamais côté usager·ère, et
+    seul·e le·la souscripteur·rice concerné·e y accède."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.setUpSouscriptionsData()
+
+        cls.portal_user = cls.env['res.users'].create(
+            {
+                'name': 'Portal Regul User',
+                'login': 'portal_regul',
+                'email': 'portal_regul@test.com',
+                'group_ids': [(6, 0, [cls.env.ref('base.group_portal').id])],
+            }
+        )
+        cls.partner_test.user_ids = [(6, 0, [cls.portal_user.id])]
+
+        cls.regularisation_emise = cls._creer_regularisation_facturee(
+            cls.souscription_base, date(2024, 1, 1), date(2024, 2, 1), poster=True
+        )
+        cls.regularisation_brouillon = cls._creer_regularisation_facturee(
+            cls.souscription_base, date(2024, 3, 1), date(2024, 4, 1), poster=False
+        )
+
+    @classmethod
+    def _creer_regularisation_facturee(cls, souscription, date_debut, date_fin, ecart_kwh=50.0, poster=True):
+        """Régularisation minimale, sa ligne directement construite (grille ×
+        cadran) — même isolation que test_regularisation_facture.py : la
+        sélection des candidats (`_recalculer`, appel electricore) n'est pas
+        nécessaire pour tester la surface portail."""
+        regularisation = cls.env['souscription.regularisation'].create(
+            {'souscription_id': souscription.id, 'date_debut': date_debut, 'date_fin': date_fin}
+        )
+        cls.env['souscription.regularisation.ligne'].create(
+            {
+                'regularisation_id': regularisation.id,
+                'grille_id': cls.grille_prix.id,
+                'cadran': 'base',
+                'ecart_kwh': ecart_kwh,
+                'prix_kwh': 0.15,
+                'detail': f'{date_debut.strftime("%B %Y")} : {ecart_kwh:.2f} kWh',
+            }
+        )
+        facture = regularisation._creer_facture()
+        if poster:
+            facture.action_post()
+        return regularisation
+
+    def _detail_url(self, souscription=None):
+        souscription = souscription or self.souscription_base
+        return f'/my/souscription/{souscription.id}'
+
+    def test_facture_regularisation_emise_visible_et_telechargeable(self):
+        """Une facture de régularisation émise est listée dans une section
+        dédiée et son lien pointe vers la route de téléchargement portail
+        native, qui répond effectivement."""
+        self.authenticate(self.portal_user.login, self.portal_user.login)
+        response = self.url_open(self._detail_url())
+        self.assertEqual(response.status_code, 200)
+
+        self.assertIn('Factures de régularisation', response.text)
+        facture = self.regularisation_emise.facture_id
+        self.assertEqual(facture.state, 'posted')
+        self.assertIn(facture.name, response.text)
+        self.assertIn(f'/my/invoices/{facture.id}', response.text)
+
+        telechargement = self.url_open(f'/my/invoices/{facture.id}')
+        self.assertEqual(telechargement.status_code, 200)
+
+    def test_facture_regularisation_brouillon_invisible(self):
+        """Une régularisation dont la facture reste en brouillon ne fuite pas
+        (ni son lien, ni sa référence) — même garde que les périodes."""
+        facture_brouillon = self.regularisation_brouillon.facture_id
+        self.assertEqual(facture_brouillon.state, 'draft')
+
+        self.authenticate(self.portal_user.login, self.portal_user.login)
+        response = self.url_open(self._detail_url())
+        self.assertEqual(response.status_code, 200)
+
+        self.assertNotIn(f'/my/invoices/{facture_brouillon.id}', response.text)

--- a/tests/test_portal.py
+++ b/tests/test_portal.py
@@ -527,3 +527,25 @@ class PortalRegularisationTestCase(SouscriptionsTestMixin, HttpCase):
         self.assertEqual(response.status_code, 200)
 
         self.assertNotIn(f'/my/invoices/{facture_brouillon.id}', response.text)
+
+    def test_acces_facture_regularisation_reserve_au_souscripteur(self):
+        """Un·e autre usager·ère ne voit ni la page de la souscription
+        d'autrui, ni ne peut télécharger sa facture de régularisation."""
+        other_partner = self.env['res.partner'].create({'name': 'Autre Régul', 'email': 'autre_regul@test.com'})
+        other_user = self.env['res.users'].create(
+            {
+                'name': 'Other Regul Portal User',
+                'login': 'other_regul_portal',
+                'email': 'other_regul_portal@test.com',
+                'group_ids': [(6, 0, [self.env.ref('base.group_portal').id])],
+            }
+        )
+        other_partner.user_ids = [(6, 0, [other_user.id])]
+
+        self.authenticate(other_user.login, other_user.login)
+        response = self.url_open(self._detail_url())
+        self.assertEqual(response.status_code, 403)
+
+        facture = self.regularisation_emise.facture_id
+        telechargement = self.url_open(f'/my/invoices/{facture.id}')
+        self.assertEqual(telechargement.status_code, 403)

--- a/tests/test_portal.py
+++ b/tests/test_portal.py
@@ -513,7 +513,9 @@ class PortalRegularisationTestCase(SouscriptionsTestMixin, HttpCase):
         self.assertIn(facture.name, response.text)
         self.assertIn(f'/my/invoices/{facture.id}', response.text)
 
-        telechargement = self.url_open(f'/my/invoices/{facture.id}')
+        # Sans suivre les redirections : un 200 après redirect vers /my serait
+        # un refus déguisé, pas un téléchargement.
+        telechargement = self.url_open(f'/my/invoices/{facture.id}', allow_redirects=False)
         self.assertEqual(telechargement.status_code, 200)
 
     def test_facture_regularisation_brouillon_invisible(self):
@@ -546,6 +548,10 @@ class PortalRegularisationTestCase(SouscriptionsTestMixin, HttpCase):
         response = self.url_open(self._detail_url())
         self.assertEqual(response.status_code, 403)
 
+        # La route portail native ne renvoie pas 403 : sur AccessError elle
+        # REDIRIGE vers /my. C'est la redirection qui est le refus — un 200
+        # direct serait la fuite.
         facture = self.regularisation_emise.facture_id
-        telechargement = self.url_open(f'/my/invoices/{facture.id}')
-        self.assertEqual(telechargement.status_code, 403)
+        telechargement = self.url_open(f'/my/invoices/{facture.id}', allow_redirects=False)
+        self.assertIn(telechargement.status_code, (302, 303))
+        self.assertNotIn('/my/invoices', telechargement.headers.get('Location', ''))

--- a/views/portal_templates.xml
+++ b/views/portal_templates.xml
@@ -299,57 +299,6 @@
                                     </div>
                                 </t>
 
-                                <!-- Factures de régularisation ÉMISES (tranche 8 du PRD #231, #240,
-                                     ADR 0030) : `regularisations` est déjà filtré aux factures
-                                     postées par le contrôleur — aucun brouillon ne fuite côté
-                                     usager. Section propre plutôt que fusionnée à l'historique des
-                                     périodes : le group_by mensuelles/réguls est hors périmètre. -->
-                                <t t-if="regularisations">
-                                    <h5 class="mt-4">Factures de régularisation</h5>
-                                    <div class="table-responsive">
-                                        <table class="table table-sm table-striped align-middle">
-                                            <thead>
-                                                <tr>
-                                                    <th>Période couverte</th>
-                                                    <th class="text-end">Montant</th>
-                                                    <th class="text-center">Paiement</th>
-                                                    <th class="text-center">Facture</th>
-                                                </tr>
-                                            </thead>
-                                            <tbody>
-                                                <t t-foreach="regularisations" t-as="regularisation">
-                                                    <tr>
-                                                        <td>
-                                                            <t t-out="regularisation.date_debut.strftime('%d/%m/%Y') if regularisation.date_debut else '-'"/> -
-                                                            <t t-out="regularisation.date_fin.strftime('%d/%m/%Y') if regularisation.date_fin else '-'"/>
-                                                        </td>
-                                                        <td class="text-end">
-                                                            <strong><t t-out="'%.2f' % (regularisation.facture_id.amount_total or 0)"/> €</strong>
-                                                        </td>
-                                                        <td class="text-center">
-                                                            <t t-if="regularisation.facture_id.payment_state == 'paid'">
-                                                                <span class="badge rounded-pill text-bg-success"><i class="fa fa-check"/> Payée</span>
-                                                            </t>
-                                                            <t t-elif="regularisation.facture_id.payment_state == 'partial'">
-                                                                <span class="badge rounded-pill text-bg-warning">Partielle</span>
-                                                            </t>
-                                                            <t t-else="">
-                                                                <span class="badge rounded-pill text-bg-danger">Impayée</span>
-                                                            </t>
-                                                        </td>
-                                                        <td class="text-center">
-                                                            <a t-attf-href="/my/invoices/#{regularisation.facture_id.id}"
-                                                               class="btn btn-sm btn-outline-primary" title="Voir la facture">
-                                                                <i class="fa fa-file-text-o"/> <t t-out="regularisation.facture_id.name"/>
-                                                            </a>
-                                                        </td>
-                                                    </tr>
-                                                </t>
-                                            </tbody>
-                                        </table>
-                                    </div>
-                                </t>
-
                                 <!-- Justificatif — relevés d'index utilisés (#57 / ADR 0015).
                                      Même source que le PDF (periode_id.releve_ids). `periodes`
                                      est déjà filtré aux factures ÉMISES (postées) par le
@@ -432,6 +381,58 @@
                                             </div>
                                         </div>
                                     </div>
+                                </div>
+                            </t>
+
+                            <!-- Factures de régularisation ÉMISES (tranche 8 du PRD #231, #240,
+                                 ADR 0030) : `regularisations` est déjà filtré aux factures
+                                 postées par le contrôleur — aucun brouillon ne fuite côté
+                                 usager. Hors du bloc `periodes` : une régul émise se montre
+                                 même sans période visible. Section propre plutôt que fusionnée
+                                 (le group_by mensuelles/réguls est hors périmètre). -->
+                            <t t-if="regularisations">
+                                <h5 class="mt-4">Factures de régularisation</h5>
+                                <div class="table-responsive">
+                                    <table class="table table-sm table-striped align-middle">
+                                        <thead>
+                                            <tr>
+                                                <th>Période couverte</th>
+                                                <th class="text-end">Montant</th>
+                                                <th class="text-center">Paiement</th>
+                                                <th class="text-center">Facture</th>
+                                            </tr>
+                                        </thead>
+                                        <tbody>
+                                            <t t-foreach="regularisations" t-as="regularisation">
+                                                <tr>
+                                                    <td>
+                                                        <t t-out="regularisation.date_debut.strftime('%d/%m/%Y') if regularisation.date_debut else '-'"/> -
+                                                        <t t-out="regularisation.date_fin.strftime('%d/%m/%Y') if regularisation.date_fin else '-'"/>
+                                                    </td>
+                                                    <td class="text-end">
+                                                        <strong><t t-out="'%.2f' % (regularisation.facture_id.amount_total or 0)"/> €</strong>
+                                                    </td>
+                                                    <td class="text-center">
+                                                        <t t-if="regularisation.facture_id.payment_state == 'paid'">
+                                                            <span class="badge rounded-pill text-bg-success"><i class="fa fa-check"/> Payée</span>
+                                                        </t>
+                                                        <t t-elif="regularisation.facture_id.payment_state == 'partial'">
+                                                            <span class="badge rounded-pill text-bg-warning">Partielle</span>
+                                                        </t>
+                                                        <t t-else="">
+                                                            <span class="badge rounded-pill text-bg-danger">Impayée</span>
+                                                        </t>
+                                                    </td>
+                                                    <td class="text-center">
+                                                        <a t-attf-href="/my/invoices/#{regularisation.facture_id.id}"
+                                                           class="btn btn-sm btn-outline-primary" title="Voir la facture">
+                                                            <i class="fa fa-file-text-o"/> <t t-out="regularisation.facture_id.name"/>
+                                                        </a>
+                                                    </td>
+                                                </tr>
+                                            </t>
+                                        </tbody>
+                                    </table>
                                 </div>
                             </t>
 

--- a/views/portal_templates.xml
+++ b/views/portal_templates.xml
@@ -299,6 +299,57 @@
                                     </div>
                                 </t>
 
+                                <!-- Factures de régularisation ÉMISES (tranche 8 du PRD #231, #240,
+                                     ADR 0030) : `regularisations` est déjà filtré aux factures
+                                     postées par le contrôleur — aucun brouillon ne fuite côté
+                                     usager. Section propre plutôt que fusionnée à l'historique des
+                                     périodes : le group_by mensuelles/réguls est hors périmètre. -->
+                                <t t-if="regularisations">
+                                    <h5 class="mt-4">Factures de régularisation</h5>
+                                    <div class="table-responsive">
+                                        <table class="table table-sm table-striped align-middle">
+                                            <thead>
+                                                <tr>
+                                                    <th>Période couverte</th>
+                                                    <th class="text-end">Montant</th>
+                                                    <th class="text-center">Paiement</th>
+                                                    <th class="text-center">Facture</th>
+                                                </tr>
+                                            </thead>
+                                            <tbody>
+                                                <t t-foreach="regularisations" t-as="regularisation">
+                                                    <tr>
+                                                        <td>
+                                                            <t t-out="regularisation.date_debut.strftime('%d/%m/%Y') if regularisation.date_debut else '-'"/> -
+                                                            <t t-out="regularisation.date_fin.strftime('%d/%m/%Y') if regularisation.date_fin else '-'"/>
+                                                        </td>
+                                                        <td class="text-end">
+                                                            <strong><t t-out="'%.2f' % (regularisation.facture_id.amount_total or 0)"/> €</strong>
+                                                        </td>
+                                                        <td class="text-center">
+                                                            <t t-if="regularisation.facture_id.payment_state == 'paid'">
+                                                                <span class="badge rounded-pill text-bg-success"><i class="fa fa-check"/> Payée</span>
+                                                            </t>
+                                                            <t t-elif="regularisation.facture_id.payment_state == 'partial'">
+                                                                <span class="badge rounded-pill text-bg-warning">Partielle</span>
+                                                            </t>
+                                                            <t t-else="">
+                                                                <span class="badge rounded-pill text-bg-danger">Impayée</span>
+                                                            </t>
+                                                        </td>
+                                                        <td class="text-center">
+                                                            <a t-attf-href="/my/invoices/#{regularisation.facture_id.id}"
+                                                               class="btn btn-sm btn-outline-primary" title="Voir la facture">
+                                                                <i class="fa fa-file-text-o"/> <t t-out="regularisation.facture_id.name"/>
+                                                            </a>
+                                                        </td>
+                                                    </tr>
+                                                </t>
+                                            </tbody>
+                                        </table>
+                                    </div>
+                                </t>
+
                                 <!-- Justificatif — relevés d'index utilisés (#57 / ADR 0015).
                                      Même source que le PDF (periode_id.releve_ids). `periodes`
                                      est déjà filtré aux factures ÉMISES (postées) par le


### PR DESCRIPTION
Closes #240

Les factures de régularisation **émises** (postées) remontent désormais dans
une section dédiée de la page portail « détail souscription », aux côtés de
l'historique des périodes — même garde que partout ailleurs (ADR 0030) : un
brouillon ne fuite jamais côté usager·ère. Le téléchargement réutilise la
route portail native `/my/invoices/<id>`, dont le contrôle d'accès
(cloisonnement par souscripteur·rice) est natif à Odoo. Section séparée
plutôt que fusionnée au tableau des périodes (le group_by mensuelles/réguls
est noté hors périmètre par l'ADR).

Corrections post-suite (commit `2d0a30b`) : la section vit **hors** du bloc
`periodes` (une régul émise se montre même sans période visible) ; les
assertions d'accès suivent le contrat réel de la route native (sur
AccessError elle **redirige** vers /my — pas de 403 ; 200 direct exigé pour
l'ayant droit, un 200 post-redirect serait un refus déguisé).

Rebasée sur main frais (post-merges #260/#261). Suite complète verte en
docker : **0 failed, 0 error(s) of 601 tests** (3 tests
`PortalRegularisationTestCase` découverts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)