### PR TITLE
feat(facture): section « Prestations Enedis » sur les Refacturations rassemblées + catégorie produit (#279)

### DIFF
--- a/data/produits_prestation.xml
+++ b/data/produits_prestation.xml
@@ -1,5 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <odoo noupdate="1">
+    <!-- Catégorie purement organisationnelle (#279) : regroupe les 4 produits de
+         refacturation au catalogue produits. L'isolation comptable standard/solidaire
+         reste portée par les comptes/TVA des produits eux-mêmes (ADR 0013) — cette
+         catégorie ne joue aucun rôle fiscal. -->
+    <record id="souscriptions_product_category_prestations_enedis" model="product.category">
+        <field name="name">Prestations Enedis</field>
+    </record>
+
     <!-- Produit générique de refacturation des prestations Enedis (#8 / ADR 0009).
          Porte la plomberie comptable ; chaque ligne de prestation surcharge
          name/price_unit/quantity depuis la souscription.refacturation. Pas de catalogue
@@ -7,6 +15,7 @@
     <record id="souscriptions_product_prestation_enedis" model="product.product">
         <field name="name">Prestation Enedis</field>
         <field name="type">service</field>
+        <field name="categ_id" ref="souscriptions_product_category_prestations_enedis"/>
         <field name="sale_ok" eval="True"/>
         <field name="purchase_ok" eval="False"/>
         <field name="list_price">0.0</field>
@@ -23,6 +32,7 @@
     <record id="souscriptions_product_indemnite_enedis" model="product.product">
         <field name="name">Indemnité Enedis</field>
         <field name="type">service</field>
+        <field name="categ_id" ref="souscriptions_product_category_prestations_enedis"/>
         <field name="sale_ok" eval="True"/>
         <field name="purchase_ok" eval="False"/>
         <field name="list_price">0.0</field>
@@ -37,6 +47,7 @@
     <record id="souscriptions_product_prestation_enedis_solidaire" model="product.product">
         <field name="name">Prestation Enedis solidaire</field>
         <field name="type">service</field>
+        <field name="categ_id" ref="souscriptions_product_category_prestations_enedis"/>
         <field name="sale_ok" eval="True"/>
         <field name="purchase_ok" eval="False"/>
         <field name="list_price">0.0</field>
@@ -47,6 +58,7 @@
     <record id="souscriptions_product_indemnite_enedis_solidaire" model="product.product">
         <field name="name">Indemnité Enedis solidaire</field>
         <field name="type">service</field>
+        <field name="categ_id" ref="souscriptions_product_category_prestations_enedis"/>
         <field name="sale_ok" eval="True"/>
         <field name="purchase_ok" eval="False"/>
         <field name="list_price">0.0</field>

--- a/models/core/account_move.py
+++ b/models/core/account_move.py
@@ -159,7 +159,7 @@ class AccountMove(models.Model):
             grille = self.env['grille.prix'].get_grille_active(periode.date_fin, regime=periode.regime_prix_periode)
             lignes = periode._composer_lignes(grille)
             prestas = periode.souscription_id._refacturations_a_rassembler(self)
-            return lignes + [presta._composer_ligne() for presta in prestas]
+            return lignes + prestas._composer_lignes_groupees()
         if self.regularisation_id:
             return self.regularisation_id._composer_lignes()
         return []

--- a/models/core/souscription.py
+++ b/models/core/souscription.py
@@ -931,7 +931,7 @@ class Souscription(models.Model):
         prestas = self._refacturations_a_rassembler(facture)
         if not prestas:
             return
-        facture.write({'invoice_line_ids': [p._composer_ligne() for p in prestas]})
+        facture.write({'invoice_line_ids': prestas._composer_lignes_groupees()})
         prestas.facture_id = facture
 
     @api.model

--- a/models/core/souscription_refacturation.py
+++ b/models/core/souscription_refacturation.py
@@ -287,3 +287,28 @@ class SouscriptionRefacturation(models.Model):
                 'souscription_ligne_generee': True,
             },
         )
+
+    def _composer_lignes_groupees(self):
+        """Compose les lignes de CE recordset rassemblé, précédées d'UNE
+        section « Prestations Enedis » (#279) — langue client, indemnités
+        comprises (la distinction fiscale reste portée par les produits, ADR
+        0009 §5 / ADR 0013). Vide si le recordset est vide : pas de section
+        sans presta à rassembler.
+
+        Point d'entrée unique appelé par les deux chemins de rassemblement
+        (création : `souscription._facturer_refacturations`, re-génération à
+        l'émission : `account.move._composer_lignes_generees`) — un seul
+        endroit pose la section, jamais dupliquée.
+
+        La section porte `souscription_ligne_generee = True` explicitement,
+        comme les sections Abonnement/Énergie (`souscription_periode.
+        _composer_lignes`) : une ligne générée, supprimée/recomposée par la
+        recompose préservante (#266)."""
+        if not self:
+            return []
+        section = (
+            0,
+            0,
+            {'display_type': 'line_section', 'name': 'Prestations Enedis', 'souscription_ligne_generee': True},
+        )
+        return [section] + [presta._composer_ligne() for presta in self]

--- a/tests/test_catalogue.py
+++ b/tests/test_catalogue.py
@@ -68,3 +68,19 @@ class TestCatalogueProduit(TransactionCase):
         chuter le compte sous 12 — donc ce test garde l'isolation (ADR 0013)."""
         requis = self.env['souscription.produit'].produits_requis()
         self.assertEqual(len(requis), 12)
+
+    def test_produits_refacturation_portent_la_categorie_prestations_enedis(self):
+        """#279 : les 4 produits de refacturation (standard + solidaire ×
+        prestation + indemnité) portent la catégorie « Prestations Enedis »
+        sur une install fraîche — purement organisationnel (ADR 0013 :
+        l'isolation comptable reste sur les comptes/TVA des produits)."""
+        categorie = self._ref('souscriptions_product_category_prestations_enedis')
+        self.assertEqual(categorie.name, 'Prestations Enedis')
+        for xmlid in (
+            'souscriptions_product_prestation_enedis',
+            'souscriptions_product_indemnite_enedis',
+            'souscriptions_product_prestation_enedis_solidaire',
+            'souscriptions_product_indemnite_enedis_solidaire',
+        ):
+            produit = self._ref(xmlid)
+            self.assertEqual(produit.categ_id, categorie, f'{xmlid} doit porter la catégorie Prestations Enedis')

--- a/tests/test_periode_facture.py
+++ b/tests/test_periode_facture.py
@@ -201,6 +201,63 @@ class TestPeriodeFactureRegenerationEmission(SouscriptionsTestCase):
         presta = self.souscription_base.refacturation_ids.filtered(lambda p: p.reference == 'F15-PRECOCE')
         self.assertEqual(presta.facture_id, facture)
 
+    def test_section_prestations_enedis_non_dupliquee_a_la_regeneration(self):
+        """#279 : une Refacturation déjà rassemblée à la création garde une
+        section « Prestations Enedis » UNIQUE après la re-génération à
+        l'émission — la recompose supprime puis recompose, pas d'empilement."""
+        self.env['souscription.refacturation'].create(
+            {
+                'souscription_id': self.souscription_base.id,
+                'reference': 'F15-SECDUP',
+                'libelle': 'Déplacement',
+                'prix': 25.0,
+                'quantite': 1.0,
+            }
+        )
+        self.create_test_periode(self.souscription_base, provision_base_kwh=100.0)
+        self.souscription_base.creer_factures()
+        facture = self.souscription_base.facture_ids
+
+        facture.action_post()
+
+        sections = facture.invoice_line_ids.filtered(
+            lambda l: l.display_type == 'line_section' and l.name == 'Prestations Enedis'
+        )
+        self.assertEqual(len(sections), 1, 'une seule section après re-génération')
+
+    def test_section_prestations_enedis_disparait_quand_la_file_se_vide(self):
+        """#279 : si la Refacturation quitte la file (mise en attente) avant
+        une recompose, la section disparaît — elle ne survit pas comme une
+        ligne orpheline."""
+        presta = self.env['souscription.refacturation'].create(
+            {
+                'souscription_id': self.souscription_base.id,
+                'reference': 'F15-SECVIDE',
+                'libelle': 'Déplacement',
+                'prix': 25.0,
+                'quantite': 1.0,
+            }
+        )
+        self.create_test_periode(self.souscription_base, provision_base_kwh=100.0)
+        self.souscription_base.creer_factures()
+        facture = self.souscription_base.facture_ids
+        self.assertTrue(
+            facture.invoice_line_ids.filtered(
+                lambda l: l.display_type == 'line_section' and l.name == 'Prestations Enedis'
+            )
+        )
+
+        presta.facture_id = False
+        presta.en_attente = True
+        facture._recomposer_lignes_generees()
+
+        self.assertFalse(
+            facture.invoice_line_ids.filtered(
+                lambda l: l.display_type == 'line_section' and l.name == 'Prestations Enedis'
+            ),
+            'la section disparaît quand plus aucune presta à rassembler',
+        )
+
     def test_suppression_directe_ligne_generee_refusee_en_brouillon(self):
         """Garde `ondelete` (#266) : suppression directe d'une ligne générée
         d'une facture d'énergie en brouillon refusée."""

--- a/tests/test_refacturation.py
+++ b/tests/test_refacturation.py
@@ -161,6 +161,55 @@ class TestRefacturation(SouscriptionsTestCase):
         self.assertEqual(ligne_neg.price_unit, -30.0)
         self.assertLess(ligne_neg.price_subtotal, 0, 'la ligne réduit le total')
 
+    def test_facture_rassemblee_porte_une_section_prestations_enedis(self):
+        """#279 : une facture avec des Refacturations rassemblées porte UNE
+        section « Prestations Enedis », en tête des lignes de prestations."""
+        self._presta(self.souscription_base, reference='F15-SEC1', libelle='Mise en service')
+        self._presta(self.souscription_base, reference='F15-SEC2', libelle='Déplacement technicien')
+        self.create_test_periode(self.souscription_base, provision_base_kwh=100.0)
+
+        self.souscription_base.creer_factures()
+
+        facture = self.souscription_base.refacturation_ids.mapped('facture_id')
+        self.assertEqual(len(facture), 1)
+        sections = facture.invoice_line_ids.filtered(
+            lambda l: l.display_type == 'line_section' and l.name == 'Prestations Enedis'
+        )
+        self.assertEqual(len(sections), 1, 'une seule section Prestations Enedis')
+        noms = facture.invoice_line_ids.mapped('name')
+        idx_section = noms.index('Prestations Enedis')
+        idx_p1 = noms.index('Mise en service')
+        idx_p2 = noms.index('Déplacement technicien')
+        self.assertLess(idx_section, idx_p1, 'la section précède les lignes de prestations')
+        self.assertLess(idx_section, idx_p2, 'la section précède les lignes de prestations')
+
+    def test_facture_sans_refacturation_ne_porte_pas_de_section(self):
+        """#279 : pas de Refacturation à rassembler → pas de section
+        « Prestations Enedis » sur la facture."""
+        periode = self.create_test_periode(self.souscription_base, provision_base_kwh=100.0)
+
+        self.souscription_base.creer_factures()
+
+        sections = periode.facture_id.invoice_line_ids.filtered(
+            lambda l: l.display_type == 'line_section' and l.name == 'Prestations Enedis'
+        )
+        self.assertFalse(sections, 'aucune Refacturation → aucune section')
+
+    def test_composer_lignes_groupees_vide_sur_recordset_vide(self):
+        """#279 : le helper est correct standalone — un recordset vide ne
+        compose aucune section (pas seulement grâce au garde-fou appelant)."""
+        vide = self.env['souscription.refacturation']
+        self.assertEqual(vide._composer_lignes_groupees(), [])
+
+    def test_composer_lignes_groupees_pose_le_flag_sur_la_section(self):
+        """#279 : la section porte le flag de provenance, comme les sections
+        Abonnement/Énergie — recomposable par la recompose préservante."""
+        presta = self._presta(self.souscription_base, reference='F15-SECFLAG')
+        _cmd, _id, vals_section = presta._composer_lignes_groupees()[0]
+        self.assertEqual(vals_section['display_type'], 'line_section')
+        self.assertEqual(vals_section['name'], 'Prestations Enedis')
+        self.assertTrue(vals_section['souscription_ligne_generee'])
+
     def test_presta_facturee_une_seule_fois_sur_plusieurs_periodes(self):
         """Deux périodes facturées en un run : la presta n'atterrit que sur UNE
         facture, jamais dupliquée (pas de double facturation)."""


### PR DESCRIPTION
## Résumé

Les *Refacturations* rassemblées sur une facture apparaissaient comme des lignes brutes après la section « Énergie », sans en-tête propre. Deux ajouts :

- **Section de facture** « Prestations Enedis » (langue client, indemnités comprises) composée dans un **helper unique** `souscription.refacturation._composer_lignes_groupees` (recordset → `[section] + lignes`), appelé par les **deux** chemins de rassemblement : création (`souscription._facturer_refacturations`) et re-génération à l'émission (`account.move._composer_lignes_generees`, #266). La section n'apparaît que si la file est non vide et porte le flag `souscription_ligne_generee` — supprimée/recomposée par la recompose préservante, jamais dupliquée.
- **`product.category` « Prestations Enedis »** déclarée en `data/`, posée sur les 4 produits de refacturation (standard + solidaire × prestation + indemnité). Purement organisationnelle : l'isolation comptable reste portée par les comptes/TVA (ADR 0013).

Pas de migration (bases de dev reset, install fraîche). Suite complète : **0 failed, 0 error(s) of 653 tests** (7 nouveaux tests #279 découverts et verts).

Closes #279

🤖 Generated with [Claude Code](https://claude.com/claude-code)