### PR TITLE
feat(campagne): drill-down « Créer/Émettre factures » ouvre les factures du mois groupées par statut (#282)

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -38,7 +38,7 @@ Journeys de capacités (`REQ-XXX-nn`), chacune avec un statut (✅ Proven · ⚠
 ## Parcours : cycle mensuel de facturation
 
 - REQ-FAC-01 ✅ campagne mensuelle : DAG d'étapes + portes de vérification — preuve: tests/test_campagne_facturation.py · #156
-- REQ-FAC-02 ✅ signaux : statut par souscription, reste-à-faire, drill-down — preuve: tests/test_campagne_signaux.py · #157
+- REQ-FAC-02 ✅ signaux : statut par souscription, reste-à-faire, drill-down — souscriptions restantes pour les étapes dérivées, sauf « Créer factures »/« Émettre factures » qui ouvrent les factures du mois (`account.move`) groupées par statut, même action partagée — preuve: tests/test_campagne_signaux.py · #157, #282
 - REQ-FAC-03 ✅ boutons d'étape : pulls, créer puis émettre les factures — preuve: tests/test_campagne_etapes_actions.py · #158
 - REQ-FAC-04 ✅ notes de campagne reportées au mois suivant — preuve: tests/test_campagne_notes.py · #159
 - REQ-FAC-05 ✅ pull des méta-périodes electricore, idempotent — propriétaire durable extrait en service (`souscription.pull.meta.periodes.service`), consommé par la Campagne (coquille mince) ; le wizard ad-hoc a été retiré, la Campagne est le seul chemin de pull — preuve: tests/test_pull_meta_periodes.py · #77, #233, #278

--- a/models/core/souscription_campagne.py
+++ b/models/core/souscription_campagne.py
@@ -680,10 +680,27 @@ class SouscriptionCampagneEtape(models.Model):
 
     # --- Drill-down (#157) : la liste filtrée des souscriptions concernées
     # par cette étape (pour les étapes à signal dérivé) ou, à défaut, toutes
-    # les souscriptions facturables du mois. ---
+    # les souscriptions facturables du mois. Exception (#282) : « Créer
+    # factures »/« Émettre factures » affichent un reste-à-faire côté
+    # souscriptions, mais la facturiste y travaille sur des FACTURES — le
+    # drill-down y ouvre donc les factures du mois plutôt que les
+    # souscriptions, groupées par statut (brouillon à émettre / comptabilisé
+    # déjà émis). Même action pour les deux étapes. ---
+
+    _CODES_DRILL_DOWN_FACTURES = ('creer_factures', 'emettre_factures')
 
     def action_drill_down(self):
         self.ensure_one()
+        if self.code in self._CODES_DRILL_DOWN_FACTURES:
+            factures = self.campagne_id._factures_du_mois()
+            return {
+                'type': 'ir.actions.act_window',
+                'name': ETAPES_CAMPAGNE.get(self.code, {}).get('label', self.code),
+                'res_model': 'account.move',
+                'view_mode': 'list,form',
+                'domain': [('id', 'in', factures.ids)],
+                'context': {'group_by': 'state'},
+            }
         if self.type_etape == 'derive':
             souscriptions = self.campagne_id._reste_a_faire(self.code)
         else:

--- a/tests/test_campagne_signaux.py
+++ b/tests/test_campagne_signaux.py
@@ -205,6 +205,37 @@ class TestCampagneSignauxDerives(SouscriptionsTestCase):
         action = self._etape('pull_meta_periodes').action_drill_down()
         self.assertEqual(action['domain'][0][2], [self.souscription_hphc.id])
 
+    def test_drill_down_creer_factures_ouvre_les_factures_du_mois_groupees_par_etat(self):
+        """#282 : « Créer factures » n'ouvre plus le reste-à-faire
+        souscriptions mais les factures du mois (account.move), groupées par
+        statut — brouillon (reste à émettre) vs comptabilisé (émis) d'un
+        coup d'œil."""
+        p1 = self._periode(self.souscription_base)
+        p2 = self._periode(self.souscription_hphc)
+        p1._creer_facture()
+        p2._creer_facture().action_post()
+        self.campagne.invalidate_recordset()
+
+        action = self._etape('creer_factures').action_drill_down()
+
+        self.assertEqual(action['res_model'], 'account.move')
+        self.assertEqual(set(action['domain'][0][2]), set(self.campagne._factures_du_mois().ids))
+        group_by = action['context'].get('group_by')
+        self.assertIn('state', [group_by] if isinstance(group_by, str) else group_by)
+
+    def test_drill_down_emettre_factures_meme_action_que_creer_factures(self):
+        """#282 : les deux étapes partagent la même action de drill-down."""
+        p1 = self._periode(self.souscription_base)
+        p1._creer_facture()
+        self.campagne.invalidate_recordset()
+
+        action = self._etape('emettre_factures').action_drill_down()
+
+        self.assertEqual(action['res_model'], 'account.move')
+        self.assertEqual(set(action['domain'][0][2]), set(self.campagne._factures_du_mois().ids))
+        group_by = action['context'].get('group_by')
+        self.assertIn('state', [group_by] if isinstance(group_by, str) else group_by)
+
     # --- Décompte factures créées / émises du mois (AC) ---
 
     def test_compte_factures_creees_et_emises_du_mois(self):


### PR DESCRIPTION
Closes #282

Le bouton « Voir » de la Campagne de facturation ouvrait toujours une liste de souscriptions, y compris pour « Créer factures » et « Émettre factures » — où la facturiste travaille en réalité sur des factures. Ces deux étapes ouvrent désormais `account.move` (domaine = `campagne_id._factures_du_mois()`), groupées par statut (Brouillon = à émettre, Comptabilisé = émis), via un seul branchement partagé dans `action_drill_down`. Les autres étapes gardent leur drill-down souscriptions inchangé.

Test : `tests/test_campagne_signaux.py` couvre la branche factures (res_model, domaine, group_by) pour les deux codes, et les tests drill-down existants (dont `pull_meta_periodes`) restent verts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)