### PR TITLE
fix(campagne): les périodes d'ouverture (facture_legacy_ref) bloquent Créer/Émettre factures à vie

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -97,6 +97,18 @@ catégorie`) ; la *Facture* en est une **projection** (dérive manuelle bornée 
 _Éviter_ : méta-période (concept amont, côté electricore), mois ; « instantané fidèle » (la Période
 est un brouillon facturable, pas une copie figée d'electricore).
 
+**Période d'ouverture** :
+Une *Période* backfillée par la migration (#107, ADR 0023 décision 3) pour un mois non
+régularisé d'un contrat *lissé*, dont la facture vit dans l'ancien système (Odoo 17) : le champ
+`facture_legacy_ref` la marque, **aucun** `account.move` n'est créé ici (pas de move fictif, ADR
+0004 — `facture_id` reste dérivé de `move_ids` et donc vide). Elle reste `type_periode='mensuelle'`
+— même périmètre qu'une Période facturée normale (régularisation #20). Une facture legacy est déjà
+**créée et émise** dans l'ancien système : la Période d'ouverture est donc **terminale** — statut
+`émise` — dans le **statut de facturation** dérivé par la *Campagne* (à tirer → à facturer →
+facturée → émise, cf. *Campagne de facturation*), exclue des deux reste-à-faire (créer, émettre)
+comme `creer_factures()` l'excluait déjà de la création (#284).
+_Éviter_ : la classer `à facturer` (bloque « Créer factures » et « Émettre factures » à vie, #284).
+
 **Énergie facturée** :
 La quantité d'énergie, par cadran facturé, que les *Factures* émises ont réellement portée pour
 une *Période* — le « facturé ». **N'évolue que par l'émission d'une facture qui la porte** :

--- a/models/core/souscription_campagne.py
+++ b/models/core/souscription_campagne.py
@@ -250,6 +250,13 @@ class SouscriptionCampagneFacturation(models.Model):
         )
         if not periode:
             return 'a_tirer'
+        # Période d'ouverture (#107, ADR 0023 décision 3) : facture legacy déjà
+        # créée ET émise dans l'ancien système (Odoo 17), sans account.move ici
+        # (`facture_id` restera vide, ADR 0004). Statut terminal — sinon elle
+        # reste comptée « à facturer » à vie, comme `creer_factures()` le sait
+        # déjà côté action (#284) mais le compteur dérivé l'ignorait.
+        if periode.facture_legacy_ref:
+            return 'emise'
         if not periode.facture_id:
             return 'a_facturer'
         return 'emise' if periode.facture_state == 'posted' else 'facturee'

--- a/tests/test_campagne_etapes_actions.py
+++ b/tests/test_campagne_etapes_actions.py
@@ -501,6 +501,39 @@ class TestCampagneEtapeEmettreFactures(SouscriptionsTestCase):
 
 
 @tagged('souscriptions', 'souscriptions_campagne', 'post_install', '-at_install')
+class TestCampagneStatutFacturationPeriodeOuverture(SouscriptionsTestCase):
+    """#284 : une Période d'ouverture (`facture_legacy_ref`, #107) porte une
+    facture déjà créée ET émise dans l'ancien système (Odoo 17) — statut
+    terminal `émise`, jamais `à facturer`. `creer_factures()` le savait déjà
+    (anti-doublon, #107) ; `_statut_facturation` doit converger au même
+    endroit, sinon les deux compteurs dérivés (Créer, Émettre) restent
+    bloqués à vie sur ces souscriptions."""
+
+    MOIS = date(2024, 3, 1)
+    FIN_MOIS = date(2024, 3, 31)
+
+    def setUp(self):
+        super().setUp()
+        self.souscription_base.with_context(rsc_automatisme=True).write(
+            {'ref_situation_contractuelle': 'RSC-CAMPAGNE-OUVERTURE'}
+        )
+        self.campagne = self.env['souscription.campagne.facturation'].create({'mois': self.MOIS})
+        self.create_test_periode(
+            self.souscription_base,
+            date_debut=self.MOIS,
+            date_fin=self.FIN_MOIS,
+            facture_legacy_ref='FACT-PROD-2024-0099',
+        )
+
+    def test_periode_ouverture_classee_emise(self):
+        self.assertEqual(self.campagne._statut_facturation(self.souscription_base), 'emise')
+
+    def test_periode_ouverture_absente_du_reste_a_faire_creer_et_emettre(self):
+        self.assertNotIn(self.souscription_base, self.campagne._reste_a_faire('creer_factures'))
+        self.assertNotIn(self.souscription_base, self.campagne._reste_a_faire('emettre_factures'))
+
+
+@tagged('souscriptions', 'souscriptions_campagne', 'post_install', '-at_install')
 class TestCampagneEtapePreparerPrelevements(SouscriptionsTestCase):
     """#186, PRD #183 : étape après « Émettre factures », son domaine
     s'appuie sur `account.move.mode_paiement` porté par la Facture (#185,


### PR DESCRIPTION
Une Période d'ouverture (backfill legacy Odoo-17, `facture_legacy_ref`) était
classée « à facturer » par `_statut_facturation` alors que `creer_factures()`
la sait déjà réglée et l'exclut — « Créer factures » et « Émettre factures »
restaient donc bloqués à vie sur ces souscriptions.

Une facture legacy est déjà créée ET émise dans l'ancien système : une garde
au point partagé de `_statut_facturation` la classe désormais « émise »,
terminale, ce qui répare les deux compteurs dérivés d'un coup.
`creer_factures()` n'est pas touché — il l'excluait déjà correctement.

Suite de tests complète verte (649 tests) ; 2 nouveaux tests couvrent
l'exclusion des deux compteurs.

Closes #284
