### PR TITLE
feat(campagne): porte « Gestes commerciaux » garde l'émission (#287)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -366,6 +366,8 @@ comme distinct de la réalité *physique* mesurée par electricore. Deux maisons
 en **quantités/jours**, il s'applique à la *Période* (tant qu'elle n'est pas gelée) ; en
 **euros**, c'est une **ligne manuelle** du brouillon de *Facture* — traçable telle quelle sur la
 facture émise.
+Sur la *Campagne*, une **porte** « Gestes commerciaux » garde l'**émission** : le·la *facturiste*
+confirme les avoir appliqués avant le gel.
 _Éviter_ : maquiller une ligne **générée** ou une quantité pour porter une remise en euros (le
 geste reste une ligne identifiable).
 

--- a/__manifest__.py
+++ b/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Souscriptions Électricité',
-    'version': '19.0.1.16.0',
+    'version': '19.0.1.17.0',
     'depends': ['base', 'mail', 'contacts', 'account', 'base_iban', 'portal'],
     'author': 'Virgile Daugé',
     'category': 'Energy',

--- a/migrations/19.0.1.17.0/post-migrate.py
+++ b/migrations/19.0.1.17.0/post-migrate.py
@@ -1,0 +1,41 @@
+"""Heal des campagnes en vol : porte « Gestes commerciaux » (#287, ADR 0025).
+
+`gestes_commerciaux` s'insère entre `creer_factures` et `emettre_factures`
+dans `ETAPES_CAMPAGNE` (souscription_campagne.py) — `emettre_factures` gagne
+`gestes_commerciaux` comme second prérequis. Mais `_seed_etapes` n'amorce les
+lignes d'étape qu'à la CRÉATION de la campagne : une campagne déjà ouverte
+avant cette version n'a pas de ligne `souscription.campagne.etape` pour ce
+code. `_compute_etat_prerequis` d'`emettre_factures` lit alors
+`freres.get('gestes_commerciaux')` -> None (absent du dict, pas juste
+« pas fait ») -> `all(...)` False -> bloquée à vie : les factures en attente
+ne partent plus, sans script pour réparer.
+
+`sequence=65`, volontairement entre `creer_factures` (60) et
+`emettre_factures` (70) — les séquences qu'une campagne en vol tient déjà
+depuis SA création, avec l'ancien catalogue à 9 étapes. On n'y touche PAS
+(pas de re-séquençage des lignes existantes) : seule la ligne manquante est
+insérée, à la bonne place visuelle entre les deux.
+
+SQL direct (comme 19.0.1.14.0/19.0.1.16.0/post-migrate.py) : `type_etape` est
+posé à la valeur que `_compute_type_etape` calculerait de toute façon pour ce
+code ('porte', cf. ETAPES_CAMPAGNE) — un backfill SQL brut d'un champ stocké
+compute n'est jamais recalculé tout seul par un simple accès ORM ultérieur.
+`valide`/`lance` à FALSE (porte non validée, jamais lancée) : l'état de
+départ normal d'une porte fraîchement seedée. Idempotent : n'insère que pour
+les campagnes qui n'ont pas encore la ligne.
+"""
+
+
+def migrate(cr, version):
+    cr.execute(
+        """
+        INSERT INTO souscription_campagne_etape
+            (campagne_id, code, sequence, type_etape, valide, lance, create_uid, write_uid, create_date, write_date)
+        SELECT c.id, 'gestes_commerciaux', 65, 'porte', FALSE, FALSE, 1, 1, NOW(), NOW()
+        FROM souscription_campagne_facturation c
+        WHERE NOT EXISTS (
+            SELECT 1 FROM souscription_campagne_etape e
+            WHERE e.campagne_id = c.id AND e.code = 'gestes_commerciaux'
+        )
+        """
+    )

--- a/models/core/souscription_campagne.py
+++ b/models/core/souscription_campagne.py
@@ -88,10 +88,21 @@ ETAPES_CAMPAGNE = {
         'type': 'derive',
         'prerequis': ('verif_periodes', 'verif_refacturations'),
     },
+    # Porte manuelle (#287, ADR 0025 §2 — même grain que les vérifs) : la
+    # fenêtre du geste commercial (CONTEXT.md « Geste commercial », ADR 0032)
+    # se referme consciemment ici, AVANT le gel irréversible de l'émission —
+    # aucun reste-à-faire (pas de signal dérivé), aucune action, son « Voir »
+    # ouvre les mêmes factures du mois que Créer/Émettre (#282,
+    # _CODES_DRILL_DOWN_FACTURES).
+    'gestes_commerciaux': {
+        'label': 'Gestes commerciaux',
+        'type': 'porte',
+        'prerequis': ('creer_factures',),
+    },
     'emettre_factures': {
         'label': 'Émettre factures',
         'type': 'derive',
-        'prerequis': ('creer_factures',),
+        'prerequis': ('creer_factures', 'gestes_commerciaux'),
     },
     'regulariser_clotures': {
         'label': 'Régulariser les clôtures',
@@ -694,7 +705,10 @@ class SouscriptionCampagneEtape(models.Model):
     # souscriptions, groupées par statut (brouillon à émettre / comptabilisé
     # déjà émis). Même action pour les deux étapes. ---
 
-    _CODES_DRILL_DOWN_FACTURES = ('creer_factures', 'emettre_factures')
+    # gestes_commerciaux (#287) : même drill-down — la porte n'a pas de
+    # reste-à-faire propre, c'est sur CES factures du mois que se pose la
+    # ligne € manuelle avant que l'émission ne gèle le brouillon.
+    _CODES_DRILL_DOWN_FACTURES = ('creer_factures', 'gestes_commerciaux', 'emettre_factures')
 
     def action_drill_down(self):
         self.ensure_one()

--- a/tests/test_campagne_etapes_actions.py
+++ b/tests/test_campagne_etapes_actions.py
@@ -252,12 +252,22 @@ class TestCampagneEtapeEmettreFactures(SouscriptionsTestCase):
             {'ref_situation_contractuelle': 'RSC-CAMPAGNE-EMETTRE'}
         )
         self.campagne = self.env['souscription.campagne.facturation'].create({'mois': self.MOIS})
+        # emettre_factures gagne gestes_commerciaux comme second prérequis
+        # (#287) : pré-validé ici pour que cette classe continue à couvrir
+        # exactement ce qu'elle testait (le gate creer_factures) — la porte
+        # elle-même (blocage/déblocage) est testée dédiée,
+        # TestCampagneEtapeGestesCommerciaux ci-dessous.
+        self._valider('gestes_commerciaux')
+
+    def _valider(self, code):
+        self.campagne.etape_ids.filtered(lambda e: e.code == code).write({'valide': True})
 
     def test_emettre_factures_bloque_si_creer_factures_pas_fait(self):
         """`creer_factures` n'est « fait » que si 0 souscription facturable
         reste « à facturer » (#157). Ici souscription_base a une période sans
         facture (« à facturer ») : creer_factures reste non fait, emettre
-        reste bloquée."""
+        reste bloquée (gestes_commerciaux, l'autre prérequis, est déjà
+        validée par setUp — seul creer_factures manque ici)."""
         self.create_test_periode(self.souscription_base, date_debut=self.MOIS, date_fin=self.FIN_MOIS)
         self.campagne.etape_ids.invalidate_recordset()
         with self.assertRaises(UserError):
@@ -663,3 +673,71 @@ class TestCampagneEtapePreparerPrelevements(SouscriptionsTestCase):
         for modele in ('souscription.periode', 'account.move'):
             for nom_champ in self.env[modele]._fields:
                 self.assertNotIn('prelevement', nom_champ.lower(), f'{modele}.{nom_champ} : champ inattendu')
+
+
+@tagged('souscriptions', 'souscriptions_campagne', 'post_install', '-at_install')
+class TestCampagneEtapeGestesCommerciaux(SouscriptionsTestCase):
+    """#287, ADR 0025 : porte manuelle entre Créer et Émettre — garde
+    l'émission, même mécanique que Vérif périodes/Vérif refacturations
+    (coche Validé + validé_par/validé_le, aucune action, aucun
+    reste-à-faire)."""
+
+    MOIS = date(2024, 3, 1)
+    FIN_MOIS = date(2024, 3, 31)
+
+    def setUp(self):
+        super().setUp()
+        self.souscription_base.with_context(rsc_automatisme=True).write(
+            {'ref_situation_contractuelle': 'RSC-CAMPAGNE-GESTES'}
+        )
+        self.campagne = self.env['souscription.campagne.facturation'].create({'mois': self.MOIS})
+
+    def _etape(self, code):
+        return self.campagne.etape_ids.filtered(lambda e: e.code == code)
+
+    def _facture_creee(self):
+        periode = self.create_test_periode(self.souscription_base, date_debut=self.MOIS, date_fin=self.FIN_MOIS)
+        return periode._creer_facture()
+
+    def test_gestes_commerciaux_se_place_entre_creer_et_emettre(self):
+        """AC : insérée entre creer_factures et emettre_factures dans l'ordre
+        du catalogue (ordre topologique/d'affichage, ADR 0025 §1)."""
+        codes = [code for code, _ in self.env['souscription.campagne.etape']._selection_code()]
+        self.assertEqual(codes.index('gestes_commerciaux'), codes.index('creer_factures') + 1)
+        self.assertEqual(codes.index('emettre_factures'), codes.index('gestes_commerciaux') + 1)
+
+    def test_gestes_commerciaux_se_valide_comme_les_autres_portes(self):
+        """Même mécanique que Vérif périodes/Vérif refacturations : coche +
+        validé_par/validé_le estampillés au write, jamais saisis à la main."""
+        etape = self._etape('gestes_commerciaux')
+        self.assertEqual(etape.type_etape, 'porte')
+        self.assertFalse(etape.fait)
+        self.assertEqual(etape.nb_reste_a_faire, 0, 'une porte ne porte aucun reste-à-faire dérivé')
+
+        etape.write({'valide': True})
+
+        self.assertTrue(etape.fait)
+        self.assertEqual(etape.valide_par_id, self.env.user)
+        self.assertTrue(etape.valide_le)
+
+    def test_emettre_factures_bloquee_tant_que_gestes_commerciaux_non_validee(self):
+        """AC : Émettre factures reste bloquée tant que la porte n'est pas
+        validée, même une fois Créer factures fait (facture déjà créée)."""
+        self._facture_creee()
+        self.campagne.etape_ids.invalidate_recordset()
+        self.assertTrue(self._etape('creer_factures').fait, 'facture déjà créée : créer factures est faite')
+        self.assertEqual(self._etape('emettre_factures').etat_prerequis, 'bloquee')
+
+        with self.assertRaises(UserError):
+            self.campagne.action_emettre_factures()
+
+    def test_emettre_factures_debloquee_une_fois_gestes_commerciaux_validee(self):
+        """AC : une fois la porte validée, Émettre factures tourne."""
+        facture = self._facture_creee()
+        self._etape('gestes_commerciaux').write({'valide': True})
+        self.campagne.etape_ids.invalidate_recordset()
+
+        self.assertEqual(self._etape('emettre_factures').etat_prerequis, 'prete')
+        self.campagne.action_emettre_factures()
+
+        self.assertEqual(facture.state, 'posted')

--- a/tests/test_campagne_etapes_actions.py
+++ b/tests/test_campagne_etapes_actions.py
@@ -9,6 +9,8 @@ exactement comme dans ces suites. Créer/émettre factures délèguent à
 Dates dans la couverture de la grille de prix fixture (2024, tests/common.py).
 """
 
+import os
+import runpy
 from datetime import date
 from types import SimpleNamespace
 from unittest.mock import MagicMock
@@ -741,3 +743,87 @@ class TestCampagneEtapeGestesCommerciaux(SouscriptionsTestCase):
         self.campagne.action_emettre_factures()
 
         self.assertEqual(facture.state, 'posted')
+
+
+@tagged('souscriptions', 'souscriptions_migration', 'post_install', '-at_install')
+class TestMigrationGestesCommerciaux(SouscriptionsTestCase):
+    """Migration `19.0.1.17.0` (#287) : soigne les campagnes déjà ouvertes
+    avant l'ajout de la porte « Gestes commerciaux » — `_seed_etapes` ne
+    s'exécute qu'à la création, donc une campagne en vol n'a pas la ligne
+    d'étape `gestes_commerciaux` ; `_compute_etat_prerequis` d'`emettre_factures`
+    lit alors un prérequis absent (`freres.get('gestes_commerciaux')` -> None)
+    -> bloquée à vie. Charge le script par chemin (`runpy.run_path`, même
+    idiome que `test_migration_energie_facturee.py`/`test_facture_provenance.py`
+    — le dossier de version n'est pas un identifiant Python importable)."""
+
+    MOIS = date(2024, 3, 1)
+    FIN_MOIS = date(2024, 3, 31)
+
+    @staticmethod
+    def _migrer(cr):
+        chemin = os.path.join(
+            os.path.dirname(os.path.dirname(__file__)), 'migrations', '19.0.1.17.0', 'post-migrate.py'
+        )
+        module = runpy.run_path(chemin)
+        module['migrate'](cr, None)
+
+    def _campagne_en_vol(self):
+        """Simule une campagne créée AVANT #287 : la ligne d'étape
+        `gestes_commerciaux` existe (posée par `_seed_etapes`, le code est
+        déjà déployé dans ce dépôt) puis on la supprime pour retrouver l'état
+        pré-migration d'une campagne en vol."""
+        campagne = self.env['souscription.campagne.facturation'].create({'mois': self.MOIS})
+        campagne.etape_ids.filtered(lambda e: e.code == 'gestes_commerciaux').unlink()
+        return campagne
+
+    def test_migration_insere_la_ligne_manquante(self):
+        campagne = self._campagne_en_vol()
+        self.assertFalse(campagne.etape_ids.filtered(lambda e: e.code == 'gestes_commerciaux'))
+
+        self._migrer(self.env.cr)
+        campagne.invalidate_recordset()
+
+        etape = campagne.etape_ids.filtered(lambda e: e.code == 'gestes_commerciaux')
+        self.assertEqual(len(etape), 1)
+        self.assertEqual(etape.sequence, 65, 'entre creer_factures=60 et emettre_factures=70 déjà tenus par le vol')
+        self.assertEqual(etape.type_etape, 'porte')
+        self.assertFalse(etape.valide)
+
+    def test_migration_debloque_emettre_factures(self):
+        """La ligne manquante bloquait `emettre_factures` à vie ; la
+        migration lève le blocage — mais n'auto-valide rien : la porte
+        insérée reste à valider par le·la facturiste."""
+        campagne = self._campagne_en_vol()
+        self.souscription_base.with_context(rsc_automatisme=True).write(
+            {'ref_situation_contractuelle': 'RSC-MIGRATION-GESTES'}
+        )
+        periode = self.create_test_periode(self.souscription_base, date_debut=self.MOIS, date_fin=self.FIN_MOIS)
+        periode._creer_facture()
+        campagne.etape_ids.invalidate_recordset()
+
+        etape_emettre = campagne.etape_ids.filtered(lambda e: e.code == 'emettre_factures')
+        self.assertEqual(etape_emettre.etat_prerequis, 'bloquee', 'gestes_commerciaux absente : bloquée à vie')
+
+        self._migrer(self.env.cr)
+        campagne.invalidate_recordset()
+        campagne.etape_ids.invalidate_recordset()
+
+        etape_emettre = campagne.etape_ids.filtered(lambda e: e.code == 'emettre_factures')
+        self.assertEqual(etape_emettre.etat_prerequis, 'bloquee', 'insérée mais pas encore validée : toujours bloquée')
+
+        campagne.etape_ids.filtered(lambda e: e.code == 'gestes_commerciaux').write({'valide': True})
+        campagne.invalidate_recordset()
+        campagne.etape_ids.invalidate_recordset()
+
+        etape_emettre = campagne.etape_ids.filtered(lambda e: e.code == 'emettre_factures')
+        self.assertEqual(etape_emettre.etat_prerequis, 'prete', 'validée : le blocage à vie est levé')
+
+    def test_migration_idempotente(self):
+        campagne = self._campagne_en_vol()
+
+        self._migrer(self.env.cr)
+        self._migrer(self.env.cr)  # rejoué : no-op
+        campagne.invalidate_recordset()
+
+        etapes = campagne.etape_ids.filtered(lambda e: e.code == 'gestes_commerciaux')
+        self.assertEqual(len(etapes), 1, 'idempotent : pas de doublon')

--- a/tests/test_campagne_signaux.py
+++ b/tests/test_campagne_signaux.py
@@ -236,6 +236,23 @@ class TestCampagneSignauxDerives(SouscriptionsTestCase):
         group_by = action['context'].get('group_by')
         self.assertIn('state', [group_by] if isinstance(group_by, str) else group_by)
 
+    def test_drill_down_gestes_commerciaux_ouvre_les_factures_du_mois_groupees_par_etat(self):
+        """#287 : la porte « Gestes commerciaux » ouvre le même drill-down que
+        Créer/Émettre — c'est sur ces brouillons du mois que la facturiste
+        pose la ligne € manuelle avant que l'émission ne les gèle (ADR 0032)."""
+        p1 = self._periode(self.souscription_base)
+        p2 = self._periode(self.souscription_hphc)
+        p1._creer_facture()
+        p2._creer_facture().action_post()
+        self.campagne.invalidate_recordset()
+
+        action = self._etape('gestes_commerciaux').action_drill_down()
+
+        self.assertEqual(action['res_model'], 'account.move')
+        self.assertEqual(set(action['domain'][0][2]), set(self.campagne._factures_du_mois().ids))
+        group_by = action['context'].get('group_by')
+        self.assertIn('state', [group_by] if isinstance(group_by, str) else group_by)
+
     # --- Décompte factures créées / émises du mois (AC) ---
 
     def test_compte_factures_creees_et_emises_du_mois(self):


### PR DESCRIPTION
Closes #287

- Insère `gestes_commerciaux` (type porte, prérequis `creer_factures`) dans `ETAPES_CAMPAGNE` ; `emettre_factures` gagne ce prérequis en plus de `creer_factures`.
- Même mécanique que Vérif périodes / Vérif refacturations (toggle Validé + validé_par/le, aucune action, aucun reste-à-faire) ; son « Voir » ouvre les factures du mois groupées par statut, comme Créer / Émettre.
- Migration `19.0.1.17.0` (manifest bumpé) soigne les campagnes en vol qui n'ont pas la ligne d'étape — sans elle, Émettre restait bloquée à vie ; insertion idempotente à `sequence=65`, sans re-séquencer l'existant.
- CONTEXT.md : une ligne ajoutée à l'entrée *Geste commercial*.

Suite complète : `0 failed, 0 error(s) of 657 tests` (les 8 nouveaux tests + les tests `TestCampagneEtapeEmettreFactures` ajustés au 2ᵉ prérequis).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
