### PR TITLE
feat(paiement): encaissement une-clic — modes attestation-pure (monnaie locale / espèces) (#290)

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -61,6 +61,7 @@ Journeys de capacités (`REQ-XXX-nn`), chacune avec un statut (✅ Proven · ⚠
 
 - REQ-REG-01 ✅ mode de paiement porté par la facture (dérivé de la souscription) ; vue « Règlements en attente » : postées à reste-à-payer, hors prélèvement, groupées par mode — preuve: tests/test_paiements_reglements_attente.py · #185
 - REQ-REG-02 ✅ étape de campagne « Préparer les prélèvements » après l'émission : toutes les factures prélèvement ouvertes (rattrapages compris), « fait » dérivé — preuve: tests/test_campagne_etapes_actions.py::TestCampagneEtapePreparerPrelevements · #186
+- REQ-REG-03 ✅ encaissement une-clic pour les modes attestation-pure (monnaie locale / espèces, aucune trace bancaire jamais) : bouton sur la vue « Règlements en attente », crée/poste/lettre un `account.payment` du reste-à-payer intégral via le wizard natif `account.payment.register`, journal résolu jamais par nom (`res.company.journal_monnaie_locale_id` ou journal `cash` unique) ; prélèvement/virement/chèque restent 100 % natifs — preuve: tests/test_encaissement_une_clic.py · #290, ADR 0033
 
 ## Parcours : espace usager (portail)
 

--- a/models/core/__init__.py
+++ b/models/core/__init__.py
@@ -4,6 +4,7 @@ from . import (
     electricore_client_fabrique,
     electricore_rsc_service,
     grille_prix,
+    res_company,
     res_partner,
     souscription,
     souscription_campagne,

--- a/models/core/account_move.py
+++ b/models/core/account_move.py
@@ -1,4 +1,4 @@
-from odoo import api, fields, models
+from odoo import _, api, fields, models
 from odoo.exceptions import UserError, ValidationError
 
 
@@ -240,3 +240,78 @@ class AccountMove(models.Model):
         if self.is_facture_energie:
             return 'souscriptions_odoo.report_facture_energie'
         return super()._get_name_invoice_report()
+
+    # === Encaissement une-clic pour les modes attestation-pure (#290, ADR 0033) ===
+    #
+    # `monnaie_locale` et `especes` n'ont **aucune** trace bancaire, jamais
+    # (CONTEXT.md « Mode de paiement ») : la facturiste est l'unique source de
+    # vérité de l'encaissement. Prélèvement, virement et chèque restent 100 %
+    # natifs — pas de bouton, pas de résolveur pour eux.
+
+    def _resoudre_journal_encaissement(self):
+        """Résout le journal cible de l'encaissement une-clic selon
+        `mode_paiement` — jamais par nom (même idiome que
+        `souscription.sepa.mandat._resoudre_journal_sdd`) :
+        - `monnaie_locale` -> pointeur société `journal_monnaie_locale_id`
+          (calqué sur `res.company.currency_exchange_journal_id`) ;
+        - `especes` -> journal `type='cash'` unique de la société, résolu à
+          la volée (pas de champ stocké, idiome de
+          `account.move._search_default_journal`).
+        Erreur explicite si le journal est absent ou ambigu — jamais de
+        journal deviné sur un chemin monétaire."""
+        self.ensure_one()
+        if self.mode_paiement == 'monnaie_locale':
+            journal = self.company_id.journal_monnaie_locale_id
+            if not journal:
+                raise UserError(
+                    _(
+                        'Aucun journal « monnaie locale » configuré pour %(societe)s : renseignez le champ '
+                        "Journal monnaie locale de la société avant d'encaisser.",
+                        societe=self.company_id.name,
+                    )
+                )
+            return journal
+        if self.mode_paiement == 'especes':
+            journaux = self.env['account.journal'].search(
+                [('type', '=', 'cash'), ('company_id', '=', self.company_id.id)]
+            )
+            if not journaux:
+                raise UserError(
+                    _(
+                        'Aucun journal de caisse (type « Espèces ») configuré pour %(societe)s : '
+                        "configurez-en un avant d'encaisser.",
+                        societe=self.company_id.name,
+                    )
+                )
+            if len(journaux) > 1:
+                raise UserError(
+                    _(
+                        'Plusieurs journaux de caisse existent pour %(societe)s, ambiguïté à résoudre avant '
+                        "d'encaisser : %(journaux)s.",
+                        societe=self.company_id.name,
+                        journaux=', '.join(journaux.mapped('name')),
+                    )
+                )
+            return journaux
+        raise UserError(
+            _(
+                'Encaissement une-clic indisponible pour le mode de paiement « %(mode)s ».',
+                mode=dict(self._fields['mode_paiement'].selection).get(self.mode_paiement, self.mode_paiement),
+            )
+        )
+
+    def action_encaisser(self):
+        """Le bouton une-clic de la vue « Règlements en attente » (#290, ADR
+        0033) : crée, poste et lettre un `account.payment` entrant du
+        reste-à-payer intégral sur le journal résolu — même gate que
+        `action_valider()` du chèque énergie (ADR 0026), en déléguant le
+        lettrage au wizard natif `account.payment.register._create_payments()`
+        plutôt qu'en le réimplémentant. Le paiement naît ICI, au clic —
+        jamais pré-créé à l'émission (ADR 0033) : sans l'Enterprise
+        `account_accountant`, l'enregistrer fait passer la facture
+        directement à `paid`, donc le créer c'est affirmer « encaissé »."""
+        self.ensure_one()
+        journal = self._resoudre_journal_encaissement()
+        self.env['account.payment.register'].with_context(active_model='account.move', active_ids=self.ids).create(
+            {'journal_id': journal.id, 'amount': self.amount_residual}
+        )._create_payments()

--- a/models/core/account_move.py
+++ b/models/core/account_move.py
@@ -296,7 +296,7 @@ class AccountMove(models.Model):
         raise UserError(
             _(
                 'Encaissement une-clic indisponible pour le mode de paiement « %(mode)s ».',
-                mode=dict(self._fields['mode_paiement'].selection).get(self.mode_paiement, self.mode_paiement),
+                mode=self.mode_paiement,
             )
         )
 

--- a/models/core/res_company.py
+++ b/models/core/res_company.py
@@ -1,0 +1,27 @@
+from odoo import fields, models
+
+
+class ResCompany(models.Model):
+    """Pointeur de rôle « journal monnaie locale » (#290, ADR 0033).
+
+    Calqué sur `res.company.currency_exchange_journal_id` du core : « Moneko »
+    est un rôle nommé parmi plusieurs journaux `bank` que `type` seul ne sait
+    pas distinguer — jamais résolu par nom (idiome confirmé par
+    `_resoudre_journal_sdd`). Consommé par
+    `account.move._resoudre_journal_encaissement()` pour le mode de paiement
+    `monnaie_locale` de l'encaissement une-clic.
+
+    Exposition dans `res.config.settings` « Souscriptions » : hors périmètre
+    de #290, chantier propre (#291) — ce champ la prépare sans rework.
+    """
+
+    _inherit = 'res.company'
+
+    journal_monnaie_locale_id = fields.Many2one(
+        'account.journal',
+        string='Journal monnaie locale',
+        domain=[('type', '=', 'bank')],
+        check_company=True,
+        help='Journal bancaire dédié à la monnaie locale (Moneko) — cible de '
+        "l'encaissement une-clic pour le mode de paiement « monnaie locale ».",
+    )

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -10,6 +10,7 @@ from . import (
     test_cloture_campagne,
     test_documents_contractuels,
     test_electricore_client_fabrique,
+    test_encaissement_une_clic,
     test_estimation_provisions,
     test_facturation,
     test_facture_document,

--- a/tests/test_encaissement_une_clic.py
+++ b/tests/test_encaissement_une_clic.py
@@ -11,6 +11,7 @@ résolu par `account.move._resoudre_journal_encaissement()` — jamais par nom
 (même idiome que `souscription.sepa.mandat._resoudre_journal_sdd`).
 """
 
+from odoo.exceptions import UserError
 from odoo.tests.common import tagged
 
 from .common import SouscriptionsTestCase
@@ -36,3 +37,81 @@ class TestJournalMonnaieLocaleField(SouscriptionsTestCase):
         )
         self.env.company.journal_monnaie_locale_id = journal
         self.assertEqual(self.env.company.journal_monnaie_locale_id, journal)
+
+
+@tagged('souscriptions', 'souscriptions_paiements', 'post_install', '-at_install')
+class TestResoudreJournalEncaissement(SouscriptionsTestCase):
+    """`account.move._resoudre_journal_encaissement()` : résolution jamais
+    par nom, garde explicite si absent/ambigu (même idiome que
+    `souscription.sepa.mandat._resoudre_journal_sdd`)."""
+
+    def _facture_avec_mode(self, mode_paiement, **periode_kwargs):
+        self.souscription_base.mode_paiement = mode_paiement
+        periode, facture = self.create_test_invoice(self.souscription_base, **periode_kwargs)
+        facture.action_post()
+        return facture
+
+    def _isoler_journaux_cash(self):
+        """Neutralise les journaux `cash` préexistants de la société (données
+        de démo/fixtures) pour rendre le test déterministe — la garde
+        cotise ensuite les journaux qu'on pose nous-mêmes, jamais un mélange
+        avec l'état ambiant."""
+        self.env['account.journal'].search([('type', '=', 'cash'), ('company_id', '=', self.env.company.id)]).write(
+            {'active': False}
+        )
+
+    # -- monnaie_locale --
+
+    def test_monnaie_locale_resout_le_journal_configure(self):
+        journal = self.env['account.journal'].create(
+            {'name': 'Moneko', 'code': 'MNLO', 'type': 'bank', 'company_id': self.env.company.id}
+        )
+        self.env.company.journal_monnaie_locale_id = journal
+        facture = self._facture_avec_mode('monnaie_locale')
+        self.assertEqual(facture._resoudre_journal_encaissement(), journal)
+
+    def test_monnaie_locale_absent_leve_erreur_explicite(self):
+        self.assertFalse(self.env.company.journal_monnaie_locale_id)
+        facture = self._facture_avec_mode('monnaie_locale')
+        with self.assertRaises(UserError) as cm:
+            facture._resoudre_journal_encaissement()
+        self.assertIn('Journal monnaie locale', str(cm.exception))
+
+    # -- especes --
+
+    def test_especes_resout_le_journal_cash_unique(self):
+        self._isoler_journaux_cash()
+        journal = self.env['account.journal'].create(
+            {'name': 'Caisse Test', 'code': 'CAISS', 'type': 'cash', 'company_id': self.env.company.id}
+        )
+        facture = self._facture_avec_mode('especes')
+        self.assertEqual(facture._resoudre_journal_encaissement(), journal)
+
+    def test_especes_absent_leve_erreur(self):
+        self._isoler_journaux_cash()
+        facture = self._facture_avec_mode('especes')
+        with self.assertRaises(UserError) as cm:
+            facture._resoudre_journal_encaissement()
+        self.assertIn('Aucun journal de caisse', str(cm.exception))
+
+    def test_especes_ambigu_leve_erreur(self):
+        self._isoler_journaux_cash()
+        self.env['account.journal'].create(
+            {'name': 'Caisse A', 'code': 'CAA', 'type': 'cash', 'company_id': self.env.company.id}
+        )
+        self.env['account.journal'].create(
+            {'name': 'Caisse B', 'code': 'CAB', 'type': 'cash', 'company_id': self.env.company.id}
+        )
+        facture = self._facture_avec_mode('especes')
+        with self.assertRaises(UserError) as cm:
+            facture._resoudre_journal_encaissement()
+        self.assertIn('Plusieurs', str(cm.exception))
+
+    # -- mode hors attestation-pure : défensif, ne devrait jamais être appelé
+    # (le bouton ne l'exhibe pas) mais ne devine jamais un journal si un
+    # appelant le fait quand même. --
+
+    def test_mode_hors_attestation_pure_leve_erreur(self):
+        facture = self._facture_avec_mode('virement')
+        with self.assertRaises(UserError):
+            facture._resoudre_journal_encaissement()

--- a/tests/test_encaissement_une_clic.py
+++ b/tests/test_encaissement_une_clic.py
@@ -1,0 +1,38 @@
+"""Encaissement une-clic pour les modes attestation-pure (#290, ADR 0033).
+
+Le bouton « Encaisser » de la vue « Règlements en attente » n'existe que
+pour `mode_paiement ∈ {monnaie_locale, especes}` — les deux modes
+attestation-pure (CONTEXT.md « Mode de paiement ») qui n'ont **aucune** trace
+bancaire, jamais. Un clic délègue au wizard natif
+`account.payment.register._create_payments()` (jamais réimplémenté, même
+gate que `action_valider()` du chèque énergie, ADR 0026) : crée, poste et
+lettre un `account.payment` entrant du reste-à-payer intégral sur le journal
+résolu par `account.move._resoudre_journal_encaissement()` — jamais par nom
+(même idiome que `souscription.sepa.mandat._resoudre_journal_sdd`).
+"""
+
+from odoo.tests.common import tagged
+
+from .common import SouscriptionsTestCase
+
+MODES_ATTESTATION_PURE = ('monnaie_locale', 'especes')
+
+
+@tagged('souscriptions', 'souscriptions_paiements', 'post_install', '-at_install')
+class TestJournalMonnaieLocaleField(SouscriptionsTestCase):
+    """AC : `res.company.journal_monnaie_locale_id`, `Many2one('account.journal',
+    domain=[('type','=','bank')], check_company=True)`."""
+
+    def test_champ_existe_domaine_bank_check_company(self):
+        field = self.env['res.company']._fields['journal_monnaie_locale_id']
+        self.assertEqual(field.type, 'many2one')
+        self.assertEqual(field.comodel_name, 'account.journal')
+        self.assertEqual(field.domain, [('type', '=', 'bank')])
+        self.assertTrue(field.check_company)
+
+    def test_champ_se_pose_et_se_lit(self):
+        journal = self.env['account.journal'].create(
+            {'name': 'Monnaie locale', 'code': 'MNLO', 'type': 'bank', 'company_id': self.env.company.id}
+        )
+        self.env.company.journal_monnaie_locale_id = journal
+        self.assertEqual(self.env.company.journal_monnaie_locale_id, journal)

--- a/tests/test_encaissement_une_clic.py
+++ b/tests/test_encaissement_une_clic.py
@@ -11,6 +11,8 @@ résolu par `account.move._resoudre_journal_encaissement()` — jamais par nom
 (même idiome que `souscription.sepa.mandat._resoudre_journal_sdd`).
 """
 
+import ast
+
 from odoo.exceptions import UserError
 from odoo.tests.common import tagged
 
@@ -115,3 +117,93 @@ class TestResoudreJournalEncaissement(SouscriptionsTestCase):
         facture = self._facture_avec_mode('virement')
         with self.assertRaises(UserError):
             facture._resoudre_journal_encaissement()
+
+
+@tagged('souscriptions', 'souscriptions_paiements', 'post_install', '-at_install')
+class TestActionEncaisser(SouscriptionsTestCase):
+    """`account.move.action_encaisser()` : effet observable du bouton
+    une-clic (#290, ADR 0033) — paiement créé/posté/lettré, résidu à zéro,
+    sortie du domaine de l'action « Règlements en attente », et le paiement
+    ne naît qu'au clic, jamais à l'émission seule."""
+
+    def _facture_avec_mode(self, mode_paiement, **periode_kwargs):
+        self.souscription_base.mode_paiement = mode_paiement
+        periode, facture = self.create_test_invoice(self.souscription_base, **periode_kwargs)
+        facture.action_post()
+        return facture
+
+    def _isoler_journaux_cash(self):
+        self.env['account.journal'].search([('type', '=', 'cash'), ('company_id', '=', self.env.company.id)]).write(
+            {'active': False}
+        )
+
+    def _dans_la_vue(self, facture):
+        action = self.env.ref('souscriptions_odoo.action_facture_reglements_attente')
+        domaine = ast.literal_eval(action.domain)
+        return facture in self.env['account.move'].search(domaine + [('id', '=', facture.id)])
+
+    def test_especes_solde_la_facture_et_la_sort_de_la_vue(self):
+        self._isoler_journaux_cash()
+        journal = self.env['account.journal'].create(
+            {'name': 'Caisse Test', 'code': 'CAISS', 'type': 'cash', 'company_id': self.env.company.id}
+        )
+        facture = self._facture_avec_mode('especes')
+        residuel_avant = facture.amount_residual
+        self.assertGreater(residuel_avant, 0.0)
+        self.assertTrue(self._dans_la_vue(facture))
+
+        facture.action_encaisser()
+        facture.invalidate_recordset(['amount_residual', 'payment_state'])
+
+        self.assertAlmostEqual(facture.amount_residual, 0.0, places=2)
+        self.assertEqual(facture.payment_state, 'paid')
+        self.assertFalse(self._dans_la_vue(facture))
+
+        paiement = self.env['account.payment'].search([('partner_id', '=', facture.partner_id.id)])
+        self.assertEqual(len(paiement), 1)
+        self.assertEqual(paiement.journal_id, journal)
+        self.assertEqual(paiement.payment_type, 'inbound')
+        self.assertAlmostEqual(paiement.amount, residuel_avant, places=2)
+
+    def test_monnaie_locale_solde_la_facture_et_la_sort_de_la_vue(self):
+        journal = self.env['account.journal'].create(
+            {'name': 'Moneko', 'code': 'MNLO', 'type': 'bank', 'company_id': self.env.company.id}
+        )
+        self.env.company.journal_monnaie_locale_id = journal
+        facture = self._facture_avec_mode('monnaie_locale')
+        self.assertGreater(facture.amount_residual, 0.0)
+
+        facture.action_encaisser()
+        facture.invalidate_recordset(['amount_residual', 'payment_state'])
+
+        self.assertAlmostEqual(facture.amount_residual, 0.0, places=2)
+        self.assertEqual(facture.payment_state, 'paid')
+        self.assertFalse(self._dans_la_vue(facture))
+
+        paiement = self.env['account.payment'].search([('partner_id', '=', facture.partner_id.id)])
+        self.assertEqual(len(paiement), 1)
+        self.assertEqual(paiement.journal_id, journal)
+
+    def test_paiement_nait_seulement_au_clic_jamais_a_lemission(self):
+        """AC : le paiement n'existe qu'après le clic — l'émission seule
+        (action_post) ne crée ni ne réconcilie rien."""
+        self._isoler_journaux_cash()
+        self.env['account.journal'].create(
+            {'name': 'Caisse Test', 'code': 'CAISS', 'type': 'cash', 'company_id': self.env.company.id}
+        )
+        facture = self._facture_avec_mode('especes')
+
+        self.assertGreater(facture.amount_residual, 0.0)
+        self.assertFalse(self.env['account.payment'].search([('partner_id', '=', facture.partner_id.id)]))
+
+    def test_journal_absent_ne_cree_aucun_paiement(self):
+        """AC : journal cible absent -> UserError, aucun paiement créé (pas
+        de repli deviné)."""
+        self.assertFalse(self.env.company.journal_monnaie_locale_id)
+        facture = self._facture_avec_mode('monnaie_locale')
+
+        with self.assertRaises(UserError):
+            facture.action_encaisser()
+
+        self.assertFalse(self.env['account.payment'].search([('partner_id', '=', facture.partner_id.id)]))
+        self.assertGreater(facture.amount_residual, 0.0)

--- a/tests/test_encaissement_une_clic.py
+++ b/tests/test_encaissement_une_clic.py
@@ -13,6 +13,7 @@ résolu par `account.move._resoudre_journal_encaissement()` — jamais par nom
 
 import ast
 
+from lxml import etree
 from odoo.exceptions import UserError
 from odoo.tests.common import tagged
 
@@ -207,3 +208,43 @@ class TestActionEncaisser(SouscriptionsTestCase):
 
         self.assertFalse(self.env['account.payment'].search([('partner_id', '=', facture.partner_id.id)]))
         self.assertGreater(facture.amount_residual, 0.0)
+
+
+@tagged('souscriptions', 'souscriptions_paiements', 'post_install', '-at_install')
+class TestBoutonEncaisserVisibilite(SouscriptionsTestCase):
+    """AC : le bouton n'apparaît que pour `mode_paiement ∈ {monnaie_locale,
+    especes}` ET `amount_residual > 0` — absent pour prélèvement / virement /
+    chèque et pour le groupe « (vide) ». Assertion structurelle sur l'arch
+    résolu (lxml), même méthode que `test_facture_provenance.py`/
+    `test_souscription_form.py` — pas de rendu client réel."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        action = cls.env.ref('souscriptions_odoo.action_facture_reglements_attente')
+        view = cls.env['account.move'].get_view(view_id=action.view_id.id, view_type='list')
+        cls.arch = etree.fromstring(view['arch'])
+
+    def test_action_pointe_la_vue_dediee(self):
+        action = self.env.ref('souscriptions_odoo.action_facture_reglements_attente')
+        self.assertEqual(action.view_id, self.env.ref('souscriptions_odoo.view_move_reglements_attente_list'))
+
+    def test_bouton_present_avec_condition_mode_et_residuel(self):
+        bouton = self.arch.find(".//button[@name='action_encaisser']")
+        self.assertIsNotNone(bouton, 'le bouton action_encaisser doit être dans la vue liste dédiée')
+        invisible = bouton.get('invisible')
+        self.assertIn('monnaie_locale', invisible)
+        self.assertIn('especes', invisible)
+        self.assertIn('amount_residual', invisible)
+
+        # Les modes bancaire-rapprochable et le prélèvement doivent être hors
+        # de l'ensemble autorisé — jamais de bouton pour eux (100 % natif).
+        for mode in ('prelevement', 'virement', 'cheque'):
+            self.assertNotIn(f"'{mode}'", invisible)
+
+    def test_champs_conditionnants_charges_dans_la_vue(self):
+        """`mode_paiement` et `amount_residual` doivent être chargés (au
+        moins en colonne) pour que la condition `invisible` soit évaluable
+        par ligne — même garde que `test_facture_provenance.py`."""
+        self.assertTrue(self.arch.findall(".//field[@name='mode_paiement']"))
+        self.assertTrue(self.arch.findall(".//field[@name='amount_residual']"))

--- a/views/core/account_move_views.xml
+++ b/views/core/account_move_views.xml
@@ -4,14 +4,40 @@
          facturiste voit ce qui reste à encaisser hors prélèvement — postées,
          reste-à-payer > 0, mode ≠ prélèvement, groupe « (vide) » compris
          (souscription sans mode renseigné, à compléter, jamais deviné). Une
-         facture soldée (chèque énergie, 0 €) sort du domaine d'elle-même.
-         Aucune vue dédiée : les vues liste/formulaire natives de la
-         Facturation portent déjà l'action « Enregistrer un paiement » sur la
-         sélection — aucun wizard maison. -->
+         facture soldée (chèque énergie, 0 €, ou via le bouton ci-dessous)
+         sort du domaine d'elle-même. Les vues liste/formulaire natives de la
+         Facturation portent toujours l'action « Enregistrer un paiement »
+         (wizard natif) sur la sélection — reste le seul chemin pour
+         prélèvement/virement/chèque. Vue liste dédiée uniquement pour porter
+         le bouton une-clic des modes attestation-pure (#290, ADR 0033). -->
+    <record id="view_move_reglements_attente_list" model="ir.ui.view">
+        <field name="name">account.move.reglements.attente.list</field>
+        <field name="model">account.move</field>
+        <field name="arch" type="xml">
+            <list string="Règlements en attente" create="0" delete="0" default_order="invoice_date_due">
+                <field name="name"/>
+                <field name="partner_id"/>
+                <field name="invoice_date"/>
+                <field name="mode_paiement"/>
+                <field name="amount_total" widget="monetary"/>
+                <field name="amount_residual" widget="monetary"/>
+                <field name="currency_id" column_invisible="1"/>
+                <!-- Encaissement une-clic (#290, ADR 0033) : seuls les modes
+                     attestation-pure (aucune trace bancaire, jamais) ont un
+                     geste d'encaissement à affirmer ici — prélèvement,
+                     virement, chèque et le groupe « (vide) » restent 100 %
+                     natifs, pas de bouton. -->
+                <button name="action_encaisser" type="object" string="Encaisser" class="btn-link"
+                        invisible="mode_paiement not in ('monnaie_locale', 'especes') or amount_residual &lt;= 0"/>
+            </list>
+        </field>
+    </record>
+
     <record id="action_facture_reglements_attente" model="ir.actions.act_window">
         <field name="name">Règlements en attente</field>
         <field name="res_model">account.move</field>
         <field name="view_mode">list,form</field>
+        <field name="view_id" ref="view_move_reglements_attente_list"/>
         <field name="domain">[('is_facture_energie', '=', True), ('state', '=', 'posted'), ('amount_residual', '>', 0), '|', ('mode_paiement', '!=', 'prelevement'), ('mode_paiement', '=', False)]</field>
         <field name="context">{'group_by': 'mode_paiement'}</field>
     </record>


### PR DESCRIPTION
Encaissement une-clic pour les modes attestation-pure (monnaie locale / espèces) : bouton sur la vue « Règlements en attente », visible uniquement pour ces deux modes à reste-à-payer non nul. Un clic délègue au wizard natif `account.payment.register._create_payments()` pour créer, poster et lettrer un paiement entrant du reste-à-payer intégral — jamais réimplémenté (même gate que le chèque énergie, ADR 0026). Journal résolu jamais par nom : `res.company.journal_monnaie_locale_id` pour `monnaie_locale`, journal `type=cash` unique pour `especes`, avec garde `UserError` explicite si absent/ambigu. Prélèvement, virement et chèque restent 100 % natifs.

ADR 0033 + glossaire `CONTEXT.md` déjà mergés séparément (#293) ; cette PR ne porte que le code (rebasée sur `main` après le merge de #293).

Suite complète verte : `0 failed, 0 error(s) of 675 tests` (dont les 15 nouveaux de `test_encaissement_une_clic`).

Closes #290
