### PR TITLE
fix(sepa): _resoudre_journal_sdd désambiguïse les journaux sdd multiples par pointeur société (#292)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -297,6 +297,16 @@ est la porte humaine (IBAN vérifié, mandat signé exigé), pas de re-validatio
 _Éviter_ : un second circuit de validation du mandat (l'acceptation de la demande est la porte) ;
 prélever sans mandat actif ; re-saisir à la main ce que la demande de raccordement porte déjà.
 
+**Résolution du journal de prélèvement** :
+Le journal comptable portant la méthode `sdd` est résolu dynamiquement, jamais nommé en dur.
+Un seul journal `sdd` fait foi. **Plusieurs** (cas prod : `sdd` exposée sur Nef, Livret bleu,
+Crédit mutuel, Moneko — un seul mandaté) sont désambiguïsés par le pointeur société
+**`journal_prelevement_sdd_id`**, même idiome que `journal_monnaie_locale_id`
+([ADR 0033](docs/adr/0033-encaissement-une-clic-attestation-pure-reouverture-bornee-option-b.md)) :
+le rôle « journal de prélèvement » vit sur `res.company`, jamais comme marqueur sur
+`account.journal`. Pointeur absent ou hors des journaux `sdd` → erreur explicite (jamais de
+mandat rattaché au mauvais journal). Surfacé plus tard dans la config « Souscriptions » (#291).
+
 **Configuration Enedis** :
 La configuration *réseau* d'un PDL — FTA, calendrier distributeur, puissance réseau, cadrans
 réseau — propriété d'electricore (source : C15). Détermine le coût d'acheminement (TURPE).

--- a/models/core/res_company.py
+++ b/models/core/res_company.py
@@ -2,17 +2,14 @@ from odoo import fields, models
 
 
 class ResCompany(models.Model):
-    """Pointeur de rôle « journal monnaie locale » (#290, ADR 0033).
+    """Pointeurs de rôle sur journal bancaire (#290/#292, ADR 0033).
 
-    Calqué sur `res.company.currency_exchange_journal_id` du core : « Moneko »
-    est un rôle nommé parmi plusieurs journaux `bank` que `type` seul ne sait
-    pas distinguer — jamais résolu par nom (idiome confirmé par
-    `_resoudre_journal_sdd`). Consommé par
-    `account.move._resoudre_journal_encaissement()` pour le mode de paiement
-    `monnaie_locale` de l'encaissement une-clic.
+    Calqués sur `res.company.currency_exchange_journal_id` du core : un rôle
+    nommé parmi plusieurs journaux `bank` que `type` seul ne sait pas
+    distinguer — jamais résolu par nom.
 
-    Exposition dans `res.config.settings` « Souscriptions » : hors périmètre
-    de #290, chantier propre (#291) — ce champ la prépare sans rework.
+    Exposition dans `res.config.settings` « Souscriptions » : hors périmètre,
+    chantier propre (#291) — ces champs la préparent sans rework.
     """
 
     _inherit = 'res.company'
@@ -23,5 +20,16 @@ class ResCompany(models.Model):
         domain=[('type', '=', 'bank')],
         check_company=True,
         help='Journal bancaire dédié à la monnaie locale (Moneko) — cible de '
-        "l'encaissement une-clic pour le mode de paiement « monnaie locale ».",
+        "l'encaissement une-clic pour le mode de paiement « monnaie locale ». "
+        'Consommé par `account.move._resoudre_journal_encaissement()` (#290).',
+    )
+
+    journal_prelevement_sdd_id = fields.Many2one(
+        'account.journal',
+        string='Journal de prélèvement SDD',
+        domain=[('type', '=', 'bank')],
+        check_company=True,
+        help='Journal portant la méthode SDD à utiliser pour les mandats de prélèvement '
+        "quand plusieurs journaux l'exposent (#292). Consommé par "
+        '`souscription.sepa.mandat._resoudre_journal_sdd()`.',
     )

--- a/models/core/souscription_sepa_mandat.py
+++ b/models/core/souscription_sepa_mandat.py
@@ -58,8 +58,14 @@ class SouscriptionSepaMandat(models.AbstractModel):
     def _resoudre_journal_sdd(self):
         """Résout dynamiquement le journal comptable portant la méthode de
         paiement SDD (prélèvement SEPA) — jamais configuré en dur (#187).
-        Erreur explicite si aucun journal ne l'expose ou si plusieurs le
-        font : pas de mandat silencieusement rattaché au mauvais journal."""
+
+        Aucun journal ne l'expose -> erreur explicite. Un seul -> il fait
+        foi. Plusieurs (cas prod réel : `sdd` exposée sur 4 journaux, un
+        seul mandaté, #292) -> désambiguïsés par le pointeur société
+        `journal_prelevement_sdd_id` (même idiome que
+        `journal_monnaie_locale_id`, ADR 0033) : s'il est posé et fait
+        partie des journaux trouvés, il fait foi ; sinon erreur explicite —
+        jamais de mandat silencieusement rattaché au mauvais journal."""
         journaux = self.env['account.journal'].search(
             [
                 ('company_id', '=', self.env.company.id),
@@ -72,9 +78,14 @@ class SouscriptionSepaMandat(models.AbstractModel):
                 "configurez-en un dans l'outillage comptable avant de créer un mandat en prélèvement."
             )
         if len(journaux) > 1:
+            pointeur = self.env.company.journal_prelevement_sdd_id
+            if pointeur and pointeur in journaux:
+                return pointeur
             raise UserError(
                 'Plusieurs journaux comptables exposent la méthode de paiement SDD (prélèvement SEPA), '
-                f'ambiguïté à résoudre avant création du mandat : {", ".join(journaux.mapped("name"))}.'
+                f'ambiguïté à résoudre avant création du mandat : {", ".join(journaux.mapped("name"))}. '
+                'Désignez le journal de prélèvement dans la configuration Souscriptions '
+                '(société, champ « Journal de prélèvement SDD »).'
             )
         return journaux
 

--- a/models/core/souscription_sepa_mandat.py
+++ b/models/core/souscription_sepa_mandat.py
@@ -45,9 +45,10 @@ class SouscriptionSepaMandat(models.AbstractModel):
             de l'appelant se déroule à l'identique.
 
         Raises:
-            UserError: aucun ou plusieurs journaux comptables n'exposent la
-                méthode de paiement SDD (résolution interne, jamais exposée
-                à l'appelant).
+            UserError: aucun journal comptable n'expose la méthode de
+                paiement SDD, ou plusieurs l'exposent sans que le pointeur
+                société `journal_prelevement_sdd_id` ne tranche (résolution
+                interne, jamais exposée à l'appelant).
         """
         if 'sdd.mandate' not in self.env:
             return None

--- a/tests/test_sepa_mandat.py
+++ b/tests/test_sepa_mandat.py
@@ -104,7 +104,9 @@ class TestResoudreJournalSdd(SouscriptionsTestMixin, TransactionCase):
         self._donner_methode_sdd(journal)
         self.assertEqual(self.service._resoudre_journal_sdd(), journal)
 
-    def test_leve_si_journaux_ambigus(self):
+    def test_leve_si_journaux_ambigus_et_pointeur_absent(self):
+        """Ambiguïté (>1 journal sdd) sans pointeur société : lève, ne
+        devine jamais (#292)."""
         journal_a = self.env['account.journal'].create(
             {'name': 'Journal SDD A', 'code': 'SDDA', 'type': 'bank', 'company_id': self.env.company.id}
         )
@@ -113,6 +115,39 @@ class TestResoudreJournalSdd(SouscriptionsTestMixin, TransactionCase):
         )
         self._donner_methode_sdd(journal_a)
         self._donner_methode_sdd(journal_b)
+        with self.assertRaises(UserError) as cm:
+            self.service._resoudre_journal_sdd()
+        self.assertIn('Plusieurs', str(cm.exception))
+
+    def test_resout_via_pointeur_societe_si_journaux_ambigus(self):
+        """Ambiguïté (>1 journal sdd) avec pointeur société pointant vers
+        l'un d'eux : résout ce journal-là, sans lever (#292)."""
+        journal_a = self.env['account.journal'].create(
+            {'name': 'Journal SDD A', 'code': 'SDDA', 'type': 'bank', 'company_id': self.env.company.id}
+        )
+        journal_b = self.env['account.journal'].create(
+            {'name': 'Journal SDD B', 'code': 'SDDB', 'type': 'bank', 'company_id': self.env.company.id}
+        )
+        self._donner_methode_sdd(journal_a)
+        self._donner_methode_sdd(journal_b)
+        self.env.company.journal_prelevement_sdd_id = journal_b
+        self.assertEqual(self.service._resoudre_journal_sdd(), journal_b)
+
+    def test_leve_si_pointeur_societe_hors_des_journaux_sdd(self):
+        """Le pointeur société pointe vers un journal qui n'expose pas sdd :
+        lève plutôt que de retourner le mauvais journal (#292)."""
+        journal_a = self.env['account.journal'].create(
+            {'name': 'Journal SDD A', 'code': 'SDDA', 'type': 'bank', 'company_id': self.env.company.id}
+        )
+        journal_b = self.env['account.journal'].create(
+            {'name': 'Journal SDD B', 'code': 'SDDB', 'type': 'bank', 'company_id': self.env.company.id}
+        )
+        autre_journal = self.env['account.journal'].create(
+            {'name': 'Journal Sans SDD', 'code': 'NOSDD', 'type': 'bank', 'company_id': self.env.company.id}
+        )
+        self._donner_methode_sdd(journal_a)
+        self._donner_methode_sdd(journal_b)
+        self.env.company.journal_prelevement_sdd_id = autre_journal
         with self.assertRaises(UserError) as cm:
             self.service._resoudre_journal_sdd()
         self.assertIn('Plusieurs', str(cm.exception))


### PR DESCRIPTION
Closes #292

Rend `_resoudre_journal_sdd` déterministe quand plusieurs journaux exposent la méthode `sdd` (cas prod réel : 4 journaux — Nef, Livret bleu, Crédit mutuel, Moneko —, un seul mandaté), au lieu de lever inconditionnellement. Désambiguïsation via un nouveau pointeur société `journal_prelevement_sdd_id`, même idiome que `journal_monnaie_locale_id` (ADR 0033) : s'il est posé et pointe vers l'un des journaux `sdd` trouvés, il fait foi ; sinon erreur explicite — jamais de mandat rattaché au mauvais journal. Le cas 0/1 journal est inchangé. Pas d'exposition config (#291, hors périmètre).

## Critères d'acceptation
- [x] `>1` journal `sdd` → `_resoudre_journal_sdd()` résout via le pointeur société sans lever.
- [x] Mécanisme arrêté + documenté (pointeur société, CONTEXT.md + docstring ; ADR 0033 rejetait déjà le marqueur sur `account.journal`).
- [x] Cas « un seul journal `sdd` » inchangé.
- [x] Test `>1` journal `sdd` (couture pure Community, sans Enterprise `sdd.mandate`) + garde pointeur-hors-des-journaux-sdd.

Suite complète verte (677 tests, 0 failed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)