### PR TITLE
feat(paiement): pointeur société journal_especes_id — résoudre la caisse espèces sans deviner par type (#298)

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -61,7 +61,7 @@ Journeys de capacités (`REQ-XXX-nn`), chacune avec un statut (✅ Proven · ⚠
 
 - REQ-REG-01 ✅ mode de paiement porté par la facture (dérivé de la souscription) ; vue « Règlements en attente » : postées à reste-à-payer, hors prélèvement, groupées par mode — preuve: tests/test_paiements_reglements_attente.py · #185
 - REQ-REG-02 ✅ étape de campagne « Préparer les prélèvements » après l'émission : toutes les factures prélèvement ouvertes (rattrapages compris), « fait » dérivé — preuve: tests/test_campagne_etapes_actions.py::TestCampagneEtapePreparerPrelevements · #186
-- REQ-REG-03 ✅ encaissement une-clic pour les modes attestation-pure (monnaie locale / espèces, aucune trace bancaire jamais) : bouton sur la vue « Règlements en attente », crée/poste/lettre un `account.payment` du reste-à-payer intégral via le wizard natif `account.payment.register`, journal résolu jamais par nom (`res.company.journal_monnaie_locale_id` ou journal `cash` unique) ; prélèvement/virement/chèque restent 100 % natifs — preuve: tests/test_encaissement_une_clic.py · #290, ADR 0033
+- REQ-REG-03 ✅ encaissement une-clic pour les modes attestation-pure (monnaie locale / espèces, aucune trace bancaire jamais) : bouton sur la vue « Règlements en attente », crée/poste/lettre un `account.payment` du reste-à-payer intégral via le wizard natif `account.payment.register`, journal résolu jamais par `type` mais par pointeur société (`res.company.journal_monnaie_locale_id` / `journal_especes_id`, robuste au journal CHEN du chèque énergie) ; prélèvement/virement/chèque restent 100 % natifs — preuve: tests/test_encaissement_une_clic.py · #290/#298, ADR 0033
 
 ## Parcours : espace usager (portail)
 

--- a/docs/adr/0033-encaissement-une-clic-attestation-pure-reouverture-bornee-option-b.md
+++ b/docs/adr/0033-encaissement-une-clic-attestation-pure-reouverture-bornee-option-b.md
@@ -82,3 +82,32 @@ l'encaissement est un acte aval, daté du jour où l'argent arrive.
   latent de `_resoudre_journal_sdd`, qui lève dès que **plusieurs** journaux exposent la méthode
   `sdd` (le cas de la prod réelle : 4 journaux, mais un seul mandaté) (#292) ; (3) une action
   groupée « Encaisser » multi-sélection, seulement si le clic ligne-à-ligne devient une gêne.
+
+## Amendement (#298) — espèces résout aussi par pointeur société, jamais par `type`
+
+La décision initiale (section « Résolution du journal ») traitait `especes` différemment de
+`monnaie_locale` : un journal `type='cash'` **unique**, résolu **à la volée** par recherche,
+sans champ stocké. Ce raisonnement s'est révélé faux en pratique : le journal **CHEN** du
+chèque énergie ([ADR 0026](0026-cheque-energie-tiers-payeur-modele-propre-delegue-paiement.md))
+est **lui aussi** `type='cash'`, posé par le `post_init_hook` à **chaque** install. Dès qu'une
+caisse espèces réelle est configurée à côté de CHEN, la recherche « cash unique » cesse d'être
+unique et lève une ambiguïté sur un chemin qui n'en a, du point de vue métier, **aucune** — la
+facturiste sait parfaitement quelle est *sa* caisse.
+
+**Ce qui change.** `especes` résout désormais par le même idiome que `monnaie_locale` : un
+pointeur **`res.company.journal_especes_id`**
+(`Many2one('account.journal', domain=[('type','=','cash')], check_company=True)`). Le `search`
+« cash unique » et ses deux `UserError` (absence, ambiguïté) sont **supprimés** — remplacés par
+la seule garde « pointeur non renseigné ». `monnaie_locale` et le journal CHEN sont inchangés.
+
+**Le principe, gravé pour ne plus être redécouvert au prix d'un bug** : un rôle de journal
+**possédé par la société** est **toujours** un pointeur `Many2one` sur `res.company`, **jamais**
+résolu par `type` — `type` classe une **famille** de journaux (`bank`, `cash`, `sale`…), il ne
+nomme **jamais** un rôle singulier au sein de cette famille. C'était déjà l'idiome de
+`monnaie_locale` (calqué sur `res.company.currency_exchange_journal_id` du core) ; ce n'était,
+à tort, pas encore celui d'`especes`. Deux précédents core le confirment sans ambiguïté :
+`res.company.currency_exchange_journal_id` (`type='bank'` groupe des journaux bancaires, un
+seul est *le* journal d'écart de change) et `res.company.tax_cash_basis_journal_id` (`type` ne
+distingue pas non plus *le* journal de la comptabilité d'engagement). Toute future extension
+d'un rôle de journal société (prélèvement compris, #292) suit ce même principe — jamais une
+résolution ad hoc par `type`.

--- a/models/core/account_move.py
+++ b/models/core/account_move.py
@@ -250,15 +250,19 @@ class AccountMove(models.Model):
 
     def _resoudre_journal_encaissement(self):
         """Résout le journal cible de l'encaissement une-clic selon
-        `mode_paiement` — jamais par nom (même idiome que
-        `souscription.sepa.mandat._resoudre_journal_sdd`) :
+        `mode_paiement` — jamais par `type` (même idiome que
+        `souscription.sepa.mandat._resoudre_journal_sdd`, gravé par ADR 0033
+        amendé : un rôle de journal possédé par la société est un pointeur
+        `res.company`, `type` n'est jamais un discriminateur de rôle) :
         - `monnaie_locale` -> pointeur société `journal_monnaie_locale_id`
           (calqué sur `res.company.currency_exchange_journal_id`) ;
-        - `especes` -> journal `type='cash'` unique de la société, résolu à
-          la volée (pas de champ stocké, idiome de
-          `account.move._search_default_journal`).
-        Erreur explicite si le journal est absent ou ambigu — jamais de
-        journal deviné sur un chemin monétaire."""
+        - `especes` -> pointeur société `journal_especes_id` (#298, calqué
+          sur le même idiome — robuste au journal CHEN du chèque énergie,
+          un autre journal `type='cash'` posé par le `post_init_hook` à
+          chaque install, qui cassait la résolution « cash unique »
+          précédente).
+        Erreur explicite si le journal est absent — jamais de journal
+        deviné sur un chemin monétaire."""
         self.ensure_one()
         if self.mode_paiement == 'monnaie_locale':
             journal = self.company_id.journal_monnaie_locale_id
@@ -272,27 +276,16 @@ class AccountMove(models.Model):
                 )
             return journal
         if self.mode_paiement == 'especes':
-            journaux = self.env['account.journal'].search(
-                [('type', '=', 'cash'), ('company_id', '=', self.company_id.id)]
-            )
-            if not journaux:
+            journal = self.company_id.journal_especes_id
+            if not journal:
                 raise UserError(
                     _(
-                        'Aucun journal de caisse (type « Espèces ») configuré pour %(societe)s : '
-                        "configurez-en un avant d'encaisser.",
+                        'Aucun journal « espèces » configuré pour %(societe)s : renseignez le champ '
+                        "Journal espèces de la société avant d'encaisser.",
                         societe=self.company_id.name,
                     )
                 )
-            if len(journaux) > 1:
-                raise UserError(
-                    _(
-                        'Plusieurs journaux de caisse existent pour %(societe)s, ambiguïté à résoudre avant '
-                        "d'encaisser : %(journaux)s.",
-                        societe=self.company_id.name,
-                        journaux=', '.join(journaux.mapped('name')),
-                    )
-                )
-            return journaux
+            return journal
         raise UserError(
             _(
                 'Encaissement une-clic indisponible pour le mode de paiement « %(mode)s ».',

--- a/models/core/res_company.py
+++ b/models/core/res_company.py
@@ -2,17 +2,25 @@ from odoo import fields, models
 
 
 class ResCompany(models.Model):
-    """Pointeur de rôle « journal monnaie locale » (#290, ADR 0033).
+    """Pointeurs de rôle « journal encaissement attestation-pure » (#290/#298,
+    ADR 0033).
 
-    Calqué sur `res.company.currency_exchange_journal_id` du core : « Moneko »
-    est un rôle nommé parmi plusieurs journaux `bank` que `type` seul ne sait
-    pas distinguer — jamais résolu par nom (idiome confirmé par
-    `_resoudre_journal_sdd`). Consommé par
-    `account.move._resoudre_journal_encaissement()` pour le mode de paiement
-    `monnaie_locale` de l'encaissement une-clic.
+    Calqués sur `res.company.currency_exchange_journal_id` / `res.company.
+    tax_cash_basis_journal_id` du core : un rôle de journal possédé par la
+    société est un pointeur `Many2one` sur `res.company`, jamais résolu par
+    `type` (idiome confirmé par `_resoudre_journal_sdd`) — `type` regroupe
+    une FAMILLE de journaux, il ne nomme pas un rôle singulier. « Moneko »
+    est un rôle nommé parmi plusieurs journaux `bank` que `type` ne sait pas
+    distinguer ; la caisse espèces est un rôle nommé parmi plusieurs journaux
+    `cash` (le journal CHEN du chèque énergie, posé par le `post_init_hook`
+    à chaque install, en est un autre) que `type` ne sait pas distinguer non
+    plus. Consommés par `account.move._resoudre_journal_encaissement()` pour
+    les modes de paiement `monnaie_locale` / `especes` de l'encaissement
+    une-clic.
 
     Exposition dans `res.config.settings` « Souscriptions » : hors périmètre
-    de #290, chantier propre (#291) — ce champ la prépare sans rework.
+    de #290/#298, chantier propre (#291) — ces champs la préparent sans
+    rework.
     """
 
     _inherit = 'res.company'
@@ -24,4 +32,15 @@ class ResCompany(models.Model):
         check_company=True,
         help='Journal bancaire dédié à la monnaie locale (Moneko) — cible de '
         "l'encaissement une-clic pour le mode de paiement « monnaie locale ».",
+    )
+
+    journal_especes_id = fields.Many2one(
+        'account.journal',
+        string='Journal espèces',
+        domain=[('type', '=', 'cash')],
+        check_company=True,
+        help="Journal de caisse dédié aux espèces — cible de l'encaissement "
+        'une-clic pour le mode de paiement « espèces ». Robuste au journal '
+        "CHEN du chèque énergie (autre journal type='cash' de la société) "
+        'car ce pointeur nomme LE journal, jamais deviné par type.',
     )

--- a/tests/test_encaissement_une_clic.py
+++ b/tests/test_encaissement_une_clic.py
@@ -43,6 +43,27 @@ class TestJournalMonnaieLocaleField(SouscriptionsTestCase):
 
 
 @tagged('souscriptions', 'souscriptions_paiements', 'post_install', '-at_install')
+class TestJournalEspecesField(SouscriptionsTestCase):
+    """AC : `res.company.journal_especes_id`, `Many2one('account.journal',
+    domain=[('type','=','cash')], check_company=True)` (#298, ADR 0033
+    amendé) — même idiome que `journal_monnaie_locale_id`."""
+
+    def test_champ_existe_domaine_cash_check_company(self):
+        field = self.env['res.company']._fields['journal_especes_id']
+        self.assertEqual(field.type, 'many2one')
+        self.assertEqual(field.comodel_name, 'account.journal')
+        self.assertEqual(field.domain, [('type', '=', 'cash')])
+        self.assertTrue(field.check_company)
+
+    def test_champ_se_pose_et_se_lit(self):
+        journal = self.env['account.journal'].create(
+            {'name': 'Caisse Test', 'code': 'CAISS', 'type': 'cash', 'company_id': self.env.company.id}
+        )
+        self.env.company.journal_especes_id = journal
+        self.assertEqual(self.env.company.journal_especes_id, journal)
+
+
+@tagged('souscriptions', 'souscriptions_paiements', 'post_install', '-at_install')
 class TestResoudreJournalEncaissement(SouscriptionsTestCase):
     """`account.move._resoudre_journal_encaissement()` : résolution jamais
     par nom, garde explicite si absent/ambigu (même idiome que

--- a/tests/test_encaissement_une_clic.py
+++ b/tests/test_encaissement_une_clic.py
@@ -75,15 +75,6 @@ class TestResoudreJournalEncaissement(SouscriptionsTestCase):
         facture.action_post()
         return facture
 
-    def _isoler_journaux_cash(self):
-        """Neutralise les journaux `cash` préexistants de la société (données
-        de démo/fixtures) pour rendre le test déterministe — la garde
-        cotise ensuite les journaux qu'on pose nous-mêmes, jamais un mélange
-        avec l'état ambiant."""
-        self.env['account.journal'].search([('type', '=', 'cash'), ('company_id', '=', self.env.company.id)]).write(
-            {'active': False}
-        )
-
     # -- monnaie_locale --
 
     def test_monnaie_locale_resout_le_journal_configure(self):
@@ -101,35 +92,47 @@ class TestResoudreJournalEncaissement(SouscriptionsTestCase):
             facture._resoudre_journal_encaissement()
         self.assertIn('Journal monnaie locale', str(cm.exception))
 
-    # -- especes --
+    # -- especes (#298, ADR 0033 amendé) : pointeur société, plus de search
+    # « cash unique » — jamais bousculé par le journal CHEN ambiant. --
 
-    def test_especes_resout_le_journal_cash_unique(self):
-        self._isoler_journaux_cash()
+    def test_especes_resout_le_journal_pointe(self):
         journal = self.env['account.journal'].create(
             {'name': 'Caisse Test', 'code': 'CAISS', 'type': 'cash', 'company_id': self.env.company.id}
         )
+        self.env.company.journal_especes_id = journal
         facture = self._facture_avec_mode('especes')
         self.assertEqual(facture._resoudre_journal_encaissement(), journal)
 
-    def test_especes_absent_leve_erreur(self):
-        self._isoler_journaux_cash()
+    def test_especes_absent_leve_erreur_explicite(self):
+        self.assertFalse(self.env.company.journal_especes_id)
         facture = self._facture_avec_mode('especes')
         with self.assertRaises(UserError) as cm:
             facture._resoudre_journal_encaissement()
-        self.assertIn('Aucun journal de caisse', str(cm.exception))
+        self.assertIn('Journal espèces', str(cm.exception))
 
-    def test_especes_ambigu_leve_erreur(self):
-        self._isoler_journaux_cash()
-        self.env['account.journal'].create(
-            {'name': 'Caisse A', 'code': 'CAA', 'type': 'cash', 'company_id': self.env.company.id}
+    def test_especes_non_regression_chen_pointeur_resout_sans_ambiguite(self):
+        """Non-régression CHEN (#298) : le journal « Chèques énergie »
+        (`type='cash'`, posé par le `post_init_hook` à chaque install —
+        code réel `CHEN`, ici un second journal cash qui en tient lieu pour
+        ne dépendre d'aucun état ambiant) coexiste avec la caisse ; le
+        pointeur société désigne la caisse sans AUCUNE erreur d'ambiguïté —
+        la résolution ne passe plus par `type`, donc n'est plus cassée par
+        un second journal `cash` quel qu'il soit."""
+        chen = self.env['account.journal'].create(
+            {
+                'name': 'Chèque énergie (tient lieu de CHEN)',
+                'code': 'CHENSIM',
+                'type': 'cash',
+                'company_id': self.env.company.id,
+            }
         )
-        self.env['account.journal'].create(
-            {'name': 'Caisse B', 'code': 'CAB', 'type': 'cash', 'company_id': self.env.company.id}
+        caisse = self.env['account.journal'].create(
+            {'name': 'Caisse Test', 'code': 'CAISS', 'type': 'cash', 'company_id': self.env.company.id}
         )
+        self.env.company.journal_especes_id = caisse
         facture = self._facture_avec_mode('especes')
-        with self.assertRaises(UserError) as cm:
-            facture._resoudre_journal_encaissement()
-        self.assertIn('Plusieurs', str(cm.exception))
+        self.assertEqual(facture._resoudre_journal_encaissement(), caisse)
+        self.assertNotEqual(facture._resoudre_journal_encaissement(), chen)
 
     # -- mode hors attestation-pure : défensif, ne devrait jamais être appelé
     # (le bouton ne l'exhibe pas) mais ne devine jamais un journal si un
@@ -154,21 +157,16 @@ class TestActionEncaisser(SouscriptionsTestCase):
         facture.action_post()
         return facture
 
-    def _isoler_journaux_cash(self):
-        self.env['account.journal'].search([('type', '=', 'cash'), ('company_id', '=', self.env.company.id)]).write(
-            {'active': False}
-        )
-
     def _dans_la_vue(self, facture):
         action = self.env.ref('souscriptions_odoo.action_facture_reglements_attente')
         domaine = ast.literal_eval(action.domain)
         return facture in self.env['account.move'].search(domaine + [('id', '=', facture.id)])
 
     def test_especes_solde_la_facture_et_la_sort_de_la_vue(self):
-        self._isoler_journaux_cash()
         journal = self.env['account.journal'].create(
             {'name': 'Caisse Test', 'code': 'CAISS', 'type': 'cash', 'company_id': self.env.company.id}
         )
+        self.env.company.journal_especes_id = journal
         facture = self._facture_avec_mode('especes')
         residuel_avant = facture.amount_residual
         self.assertGreater(residuel_avant, 0.0)
@@ -209,10 +207,10 @@ class TestActionEncaisser(SouscriptionsTestCase):
     def test_paiement_nait_seulement_au_clic_jamais_a_lemission(self):
         """AC : le paiement n'existe qu'après le clic — l'émission seule
         (action_post) ne crée ni ne réconcilie rien."""
-        self._isoler_journaux_cash()
-        self.env['account.journal'].create(
+        journal = self.env['account.journal'].create(
             {'name': 'Caisse Test', 'code': 'CAISS', 'type': 'cash', 'company_id': self.env.company.id}
         )
+        self.env.company.journal_especes_id = journal
         facture = self._facture_avec_mode('especes')
 
         self.assertGreater(facture.amount_residual, 0.0)


### PR DESCRIPTION
Closes #298

Ajoute `res.company.journal_especes_id` (`Many2one`, domaine `type=cash`, `check_company`) et réoriente la branche `especes` de `account.move._resoudre_journal_encaissement()` pour **lire ce pointeur** au lieu de chercher « le journal cash unique » à la volée — recherche que le journal **CHEN** du chèque énergie (posé par le `post_init_hook` à chaque install, lui aussi `type=cash`) cassait silencieusement dès qu'une vraie caisse coexistait.

Supprime le hack de test `_isoler_journaux_cash()` et les `UserError` d'absence/ambiguïté du `search` ; ajoute un test de **non-régression CHEN** prouvant que le pointeur résout proprement avec ≥ 2 journaux `cash` présents. **ADR 0033 amendé** pour graver le principe : un rôle de journal possédé par la société est toujours un pointeur `res.company`, jamais résolu par `type` — même idiome que le core (`currency_exchange_journal_id` / `tax_cash_basis_journal_id`).

Branches `monnaie_locale` et défensive inchangées ; `res.config.settings` (#291) et `journal_prelevement_id`/sdd (#292) hors périmètre.

**Suite complète Odoo 19 verte** : `0 failed, 0 error(s) of 677 tests` (docker, orchestrateur — le build agent sandboxé ne pouvait pas l'exécuter).