### PR TITLE
fix(catalogue): unités de facturation en kWh / jours (fin du placeholder kg)

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -34,6 +34,7 @@ Journeys de capacités (`REQ-XXX-nn`), chacune avec un statut (✅ Proven · ⚠
 - REQ-GRI-03 ✅ régime de prix standard | Moulin par souscription — preuve: tests/test_grille_prix.py::test_get_grille_active_par_regime · #105
 - REQ-GRI-04 ✅ duplication en brouillon inactif sans périmer la grille en cours — preuve: tests/test_grille_prix.py::test_dupliquer_grille_ne_perime_pas_la_sœur
 - REQ-GRI-05 ✅ catalogue de produits résolu par univers (standard/solidaire) — preuve: tests/test_catalogue.py
+- REQ-GRI-06 ✅ unités de facturation : les 6 produits d'énergie facturent en kWh (`uom.product_uom_kwh`), les 2 produits d'abonnement en jours (`uom.product_uom_day`) — fin du placeholder kg/Units ; `post-migrate` idempotent et gardé re-pointe les 8 produits déjà en prod, sans toucher les factures déjà comptabilisées (snapshot figé sur la ligne) — preuve: tests/test_unites_facturation.py · #304
 
 ## Parcours : cycle mensuel de facturation
 

--- a/__manifest__.py
+++ b/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Souscriptions Électricité',
-    'version': '19.0.1.17.0',
+    'version': '19.0.1.18.0',
     'depends': ['base', 'mail', 'contacts', 'account', 'base_iban', 'portal'],
     'author': 'Virgile Daugé',
     'category': 'Energy',

--- a/data/produits_abonnement_simple.xml
+++ b/data/produits_abonnement_simple.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <odoo noupdate="1">
     <!-- Produits d'abonnement simplifiés -->
-    
+
     <!-- Abonnement standard -->
     <record id="souscriptions_product_abonnement_standard" model="product.product">
         <field name="name">Abonnement</field>
@@ -10,6 +10,7 @@
         <field name="purchase_ok" eval="False"/>
         <field name="list_price">0.0</field>
         <field name="standard_price">0.0</field>
+        <field name="uom_id" ref="uom.product_uom_day"/>
     </record>
 
     <!-- Abonnement solidaire -->
@@ -20,6 +21,7 @@
         <field name="purchase_ok" eval="False"/>
         <field name="list_price">0.0</field>
         <field name="standard_price">0.0</field>
+        <field name="uom_id" ref="uom.product_uom_day"/>
         <field name="taxes_id" eval="[(6, 0, [])]"/>
     </record>
 </odoo>

--- a/data/produits_energie.xml
+++ b/data/produits_energie.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <odoo noupdate="1">
     <!-- Produits d'énergie -->
-    
+
     <!-- Énergie Base -->
     <record id="souscriptions_product_energie_base" model="product.product">
         <field name="name">Énergie Base</field>
@@ -10,7 +10,7 @@
         <field name="purchase_ok" eval="False"/>
         <field name="list_price">0.0</field>
         <field name="standard_price">0.0</field>
-        <field name="uom_id" ref="uom.product_uom_kgm"/>
+        <field name="uom_id" ref="uom.product_uom_kwh"/>
     </record>
 
     <!-- Énergie Heures Pleines -->
@@ -21,7 +21,7 @@
         <field name="purchase_ok" eval="False"/>
         <field name="list_price">0.0</field>
         <field name="standard_price">0.0</field>
-        <field name="uom_id" ref="uom.product_uom_kgm"/>
+        <field name="uom_id" ref="uom.product_uom_kwh"/>
     </record>
 
     <!-- Énergie Heures Creuses -->
@@ -32,7 +32,7 @@
         <field name="purchase_ok" eval="False"/>
         <field name="list_price">0.0</field>
         <field name="standard_price">0.0</field>
-        <field name="uom_id" ref="uom.product_uom_kgm"/>
+        <field name="uom_id" ref="uom.product_uom_kwh"/>
     </record>
 
     <!-- Énergie solidaire (ADR 0013 : isolation comptable standard / solidaire).
@@ -46,7 +46,7 @@
         <field name="purchase_ok" eval="False"/>
         <field name="list_price">0.0</field>
         <field name="standard_price">0.0</field>
-        <field name="uom_id" ref="uom.product_uom_kgm"/>
+        <field name="uom_id" ref="uom.product_uom_kwh"/>
         <field name="taxes_id" eval="[(6, 0, [])]"/>
     </record>
 
@@ -57,7 +57,7 @@
         <field name="purchase_ok" eval="False"/>
         <field name="list_price">0.0</field>
         <field name="standard_price">0.0</field>
-        <field name="uom_id" ref="uom.product_uom_kgm"/>
+        <field name="uom_id" ref="uom.product_uom_kwh"/>
         <field name="taxes_id" eval="[(6, 0, [])]"/>
     </record>
 
@@ -68,7 +68,7 @@
         <field name="purchase_ok" eval="False"/>
         <field name="list_price">0.0</field>
         <field name="standard_price">0.0</field>
-        <field name="uom_id" ref="uom.product_uom_kgm"/>
+        <field name="uom_id" ref="uom.product_uom_kwh"/>
         <field name="taxes_id" eval="[(6, 0, [])]"/>
     </record>
 

--- a/migrations/19.0.1.18.0/post-migrate.py
+++ b/migrations/19.0.1.18.0/post-migrate.py
@@ -1,0 +1,69 @@
+"""Repointe les 8 produits de facturation sur leur vraie unité de mesure —
+fin du placeholder kg / Units (#304).
+
+Les 6 produits d'énergie (Base/HP/HC × standard/solidaire) sont créés en
+`kg` (`uom.product_uom_kgm`, placeholder jamais voulu) et les 2 produits
+d'abonnement n'ont pas d'unité (défaut Odoo `Units`,
+`uom.product_uom_unit`) : une ligne de facture d'énergie se lisait
+« 1234 kg » au lieu de « 1234 kWh ». `data/produits_energie.xml` et
+`data/produits_abonnement_simple.xml` pointent désormais sur les bonnes
+unités (`uom.product_uom_kwh` / `uom.product_uom_day`, livrées par le module
+core `uom` — rien à créer), mais ces fichiers sont `noupdate="1"` : seules
+les installations neuves en profitent. Ce script re-pointe les 8 produits
+déjà présents en prod.
+
+Produits de type `service` (pas de stock) : la garde d'Odoo contre un
+changement de `uom_id` (`stock.product.product._update_uom`, clé sur
+`stock.move`/`stock.move.line` existants) ne s'applique qu'aux produits
+stockables — jamais déclenchée ici, écrire `uom_id` directement est sûr même
+après facturation. Les lignes de facture déjà postées gardent leur propre
+`product_uom_id` (snapshot pris à la composition) : elles ne sont PAS
+retouchées par ce script, volontairement — c'est le figement voulu par
+l'AC "les factures déjà comptabilisées ne sont pas modifiées".
+
+Gardé sur l'unité ACTUELLE (encore le placeholder) : rejouable sans effet
+(idempotent) et sans écraser un repointage manuel déjà fait en prod avant
+cette migration. `env.ref(..., raise_if_not_found=False)` : un produit
+supprimé/absent est ignoré, pas fatal.
+
+`_repointer_unites(env)` est une fonction pure prenant `env` (pas `cr`) pour
+être appelable directement depuis un test — `migrate(cr, version)` ne fait
+que construire l'environnement et déléguer.
+"""
+
+from odoo import SUPERUSER_ID, api
+
+PRODUITS_ENERGIE = (
+    'souscriptions_product_energie_base',
+    'souscriptions_product_energie_hp',
+    'souscriptions_product_energie_hc',
+    'souscriptions_product_energie_base_solidaire',
+    'souscriptions_product_energie_hp_solidaire',
+    'souscriptions_product_energie_hc_solidaire',
+)
+PRODUITS_ABONNEMENT = (
+    'souscriptions_product_abonnement_standard',
+    'souscriptions_product_abonnement_solidaire',
+)
+
+
+def _repointer_unites(env):
+    kwh = env.ref('uom.product_uom_kwh')
+    jour = env.ref('uom.product_uom_day')
+    placeholder_energie = env.ref('uom.product_uom_kgm')
+    placeholder_abonnement = env.ref('uom.product_uom_unit')
+
+    for xmlid in PRODUITS_ENERGIE:
+        produit = env.ref(f'souscriptions_odoo.{xmlid}', raise_if_not_found=False)
+        if produit and produit.uom_id == placeholder_energie:
+            produit.uom_id = kwh
+
+    for xmlid in PRODUITS_ABONNEMENT:
+        produit = env.ref(f'souscriptions_odoo.{xmlid}', raise_if_not_found=False)
+        if produit and produit.uom_id == placeholder_abonnement:
+            produit.uom_id = jour
+
+
+def migrate(cr, version):
+    env = api.Environment(cr, SUPERUSER_ID, {})
+    _repointer_unites(env)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -54,4 +54,5 @@ from . import (
     test_souscription_etat,
     test_souscription_form,
     test_sync_prestations,
+    test_unites_facturation,
 )

--- a/tests/test_unites_facturation.py
+++ b/tests/test_unites_facturation.py
@@ -1,0 +1,112 @@
+"""Unités de facturation : énergie en kWh, abonnement en jours (#304).
+
+Les 6 produits d'énergie (Base/HP/HC × standard/solidaire) pointaient sur
+`kg` (placeholder) et les 2 produits d'abonnement n'avaient pas d'unité
+(défaut Odoo `Units`) : une ligne de facture d'énergie se lisait
+« 1234 kg » au lieu de « 1234 kWh ». Deux surfaces à couvrir :
+
+- AC1 : une installation neuve résout directement les bonnes unités
+  (`data/produits_energie.xml`, `data/produits_abonnement_simple.xml`) ;
+- AC2 : le helper de migration `_repointer_unites`
+  (`migrations/19.0.1.18.0/post-migrate.py`, pour les 8 produits déjà en
+  prod) est idempotent et gardé — il ne re-pointe que ce qui est encore sur
+  le placeholder d'origine, jamais un choix manuel déjà fait.
+
+Chargé par chemin (`runpy.run_path`, même idiome que
+`test_migration_energie_facturee.py` / `test_releve.py` : le dossier de
+version n'est pas un identifiant Python importable) et appelé directement
+sur le helper `_repointer_unites(env)` — pas `migrate(cr, version)` — pour
+tester la logique sans passer par le SQL brut de `api.Environment`.
+"""
+
+import os
+import runpy
+
+from odoo.tests.common import TransactionCase, tagged
+
+from .common import SouscriptionsTestCase
+
+PRODUITS_ENERGIE = (
+    'souscriptions_product_energie_base',
+    'souscriptions_product_energie_hp',
+    'souscriptions_product_energie_hc',
+    'souscriptions_product_energie_base_solidaire',
+    'souscriptions_product_energie_hp_solidaire',
+    'souscriptions_product_energie_hc_solidaire',
+)
+PRODUITS_ABONNEMENT = (
+    'souscriptions_product_abonnement_standard',
+    'souscriptions_product_abonnement_solidaire',
+)
+
+
+@tagged('souscriptions', 'souscriptions_catalogue', 'post_install', '-at_install')
+class TestUnitesFacturationInstallNeuve(TransactionCase):
+    """AC1 : install fraîche — la data pointe déjà sur les bonnes unités."""
+
+    def _ref(self, xmlid):
+        return self.env.ref(f'souscriptions_odoo.{xmlid}')
+
+    def test_produits_energie_en_kwh(self):
+        kwh = self.env.ref('uom.product_uom_kwh')
+        for xmlid in PRODUITS_ENERGIE:
+            self.assertEqual(self._ref(xmlid).uom_id, kwh, f'{xmlid} doit être en kWh')
+
+    def test_produits_abonnement_en_jours(self):
+        jour = self.env.ref('uom.product_uom_day')
+        for xmlid in PRODUITS_ABONNEMENT:
+            self.assertEqual(self._ref(xmlid).uom_id, jour, f'{xmlid} doit être en jours')
+
+
+@tagged('souscriptions', 'souscriptions_migration', 'post_install', '-at_install')
+class TestMigrationUnitesFacturation(SouscriptionsTestCase):
+    """AC2 : le helper de migration `_repointer_unites` est idempotent et
+    gardé sur le placeholder d'origine."""
+
+    @staticmethod
+    def _repointer(env):
+        chemin = os.path.join(
+            os.path.dirname(os.path.dirname(__file__)), 'migrations', '19.0.1.18.0', 'post-migrate.py'
+        )
+        module = runpy.run_path(chemin)
+        module['_repointer_unites'](env)
+
+    def test_energie_idempotent_repointe_puis_rejoue_sans_effet(self):
+        produit = self.env.ref('souscriptions_odoo.souscriptions_product_energie_base')
+        kg = self.env.ref('uom.product_uom_kgm')
+        kwh = self.env.ref('uom.product_uom_kwh')
+        produit.uom_id = kg
+
+        self._repointer(self.env)
+        produit.invalidate_recordset()
+        self.assertEqual(produit.uom_id, kwh)
+
+        self._repointer(self.env)  # rejoué : déjà en kWh — no-op
+        produit.invalidate_recordset()
+        self.assertEqual(produit.uom_id, kwh)
+
+    def test_abonnement_idempotent_repointe_puis_rejoue_sans_effet(self):
+        produit = self.env.ref('souscriptions_odoo.souscriptions_product_abonnement_standard')
+        unite = self.env.ref('uom.product_uom_unit')
+        jour = self.env.ref('uom.product_uom_day')
+        produit.uom_id = unite
+
+        self._repointer(self.env)
+        produit.invalidate_recordset()
+        self.assertEqual(produit.uom_id, jour)
+
+        self._repointer(self.env)  # rejoué : déjà en jours — no-op
+        produit.invalidate_recordset()
+        self.assertEqual(produit.uom_id, jour)
+
+    def test_guard_ne_touche_pas_une_unite_deliberement_differente(self):
+        """Un produit déjà sur une TROISIÈME unité (choix manuel en prod, ni
+        placeholder ni cible) n'est pas écrasé — le helper ne garde que le
+        placeholder d'origine, jamais « tout ce qui n'est pas la cible »."""
+        produit = self.env.ref('souscriptions_odoo.souscriptions_product_energie_base')
+        autre = self.env.ref('uom.product_uom_unit')
+        produit.uom_id = autre
+
+        self._repointer(self.env)
+        produit.invalidate_recordset()
+        self.assertEqual(produit.uom_id, autre)


### PR DESCRIPTION
Closes #304

Les 6 produits d'énergie facturaient en kg (placeholder) et les 2 produits d'abonnement n'avaient aucune unité (défaut Odoo `Units`) — une ligne d'énergie affichait « 1234 kg » au lieu de « 1234 kWh ». Les data (`noupdate="1"`) pointent désormais sur `uom.product_uom_kwh` / `uom.product_uom_day`, livrées par le core Odoo (rien à créer).

Une migration `19.0.1.18.0` (manifest bumpé) re-pointe les 8 produits déjà en prod, de façon **idempotente et gardée sur l'unité placeholder actuelle** — jamais un choix manuel déjà fait. Les produits sont de type `service` : la garde native d'Odoo sur `uom_id` ne porte que sur le stock (`stock.move`), donc l'écriture directe est sûre même après facturation ; les factures déjà comptabilisées gardent leur propre snapshot d'unité (`account.move.line.product_uom_id`), inchangées.

Hors périmètre : TURPE (jamais facturé en lignes), kVA (texte de libellé), le générateur de lignes (héritage de l'unité produit — non touché).

**À vérifier hors code (non bloquant) :**
- Rendu PDF fr_FR : le libellé natif du core Odoo est « KWH » — vérifier le rendu réel, corriger via traduction fr si besoin.
- Option `uom.group_uom` en prod : si désactivée, la colonne unité est masquée (le fix reste correct en interne mais invisible sur la facture).

Suite complète : `0 failed, 0 error(s) of 703 tests` (docker, orchestrateur).
