### PR TITLE
docs(contexte): grille de prix — borne demi-ouverte, fin dérivée, sélection sur la date de début

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -186,18 +186,29 @@ Barème **fournisseur** daté (`grille.prix`), **tout-compris** : le TURPE y est
 refacturé ligne à ligne (ADR 0002). Porte le prix d'abonnement **affine** — prix de base 3 kVA +
 coefficient par kVA supplémentaire (ADR 0018) — et le prix de l'énergie par cadran facturé.
 Chaque grille appartient à un *régime de prix* ; elle est sélectionnée par le régime de la
-*Souscription* et les dates d'une *Période*, ce qui permet de facturer une *régularisation* aux prix
-historiques. C'est aussi l'unique **moteur de prix** : la règle qui assemble barème et configuration
-— abonnement affine, prix par cadran facturé, *Majoration PRO*, choix du *Produit de facturation*
-(standard ou solidaire) — n'a qu'une implémentation, portée par la grille, que la *Facture* et les
-*conditions particulières* **projettent** chacune avec **sa** grille : historique (aux dates de la
-*Période*) pour la Facture, engagée (à la date de début) pour la CP. Les **valeurs** divergent donc
+*Souscription* et la **date de début** d'une *Période*, ce qui permet de facturer une
+*régularisation* aux prix historiques. Sa validité est **demi-ouverte** comme celle de la *Période*
+(`[début, fin)` — même convention de borne partout : une grille se termine le jour où la suivante
+commence, jamais la veille), et un changement de grille **tombe toujours un 1er du mois** : aucune
+*Période* n'enjambe donc deux grilles, et sa seule date de début suffit à la désigner — il n'existe
+pas de prix au prorata. La **fin** de validité est **dérivée** (le début de la grille suivante du
+même régime) : elle s'affiche, elle ne se saisit ni ne se stocke — une grille en vigueur est
+simplement la plus récente à avoir commencé. C'est aussi l'unique **moteur de prix** : la règle qui
+assemble barème et configuration — abonnement affine, prix par cadran facturé, *Majoration PRO*,
+choix du *Produit de facturation* (standard ou solidaire) — n'a qu'une implémentation, portée par la
+grille, que la *Facture* et les *conditions particulières* **projettent** chacune avec **sa** grille :
+historique (à la date de début de la *Période*) pour la Facture, engagée (à la date de début de la
+*Souscription*) pour la CP. Les **valeurs** divergent donc
 dans le temps — c'est le domaine ; la **règle**, jamais. Une grille incapable de prixer une
 configuration **échoue bruyamment** — jamais de prix nul par défaut sur un document.
 _Éviter_ : tarif (collision avec la FTA / tarif d'acheminement réseau), barème ; « prix par palier »
 (l'abonnement est **affine**, pas tabulé par puissance) ; « aligner » les prix de la CP sur les
 factures (la divergence de **valeurs** est voulue — seule la **règle** est unique) ; un prix à 0
-quand la grille est incomplète (échec bruyant).
+quand la grille est incomplète (échec bruyant) ; une grille qui change **en cours de mois** (la
+borne est le 1er — sinon un mois se facture en entier au mauvais prix, sans erreur) ; une **fin de
+validité saisie** ou fermée à la main (elle est dérivée de la suivante) ; sélectionner la grille sur
+la date de **fin** d'une *Période* (c'est la grille du mois **suivant** — la borne de fin est
+exclue).
 
 **Régime de prix** :
 L'axe qui désigne **quel barème** s'applique à une *Souscription* : **standard** ou **Moulin**.


### PR DESCRIPTION
Glossaire seul. Fixe la convention que la PR de mise en œuvre appliquera au code (issue à suivre).

## Le symptôme

Des Périodes migrées datées `1 juin → 30 juin` (29 jours) au lieu de `1 juin → 1 juil`. Les dates elles-mêmes appartiennent à `souscriptions_migration` et s'y corrigent. Ce qu'elles ont exposé, non.

## Ce qu'elles ont exposé

`CONTEXT.md` disait « sélectionnée par **les dates** d'une *Période* » — pluriel, sans dire laquelle. Cette imprécision a laissé `get_grille_active` dériver vers `date_fin` dans les trois chemins Période (composition, régénération à l'émission, régularisation), alors que `souscription.py` résolvait déjà sur `date_debut` — « la grille **engagée** ». Le bon usage était déjà écrit dans le dépôt ; le glossaire ne disait pas lequel des deux faisait foi.

Sur une Période bornée en demi-ouvert, `date_fin` est le 1er du mois **suivant** : l'énergie de juin se prixe à la grille de juillet dès qu'une grille change. Personne ne l'a vu parce qu'aucun mois n'avait encore enjambé un changement de grille — et parce que les Périodes legacy, fausses dans le sens compensateur, masquaient le défaut.

## La convention fixée

- **Borne demi-ouverte** pour la Grille comme pour la Période (`[début, fin)`) : une grille se termine le jour où la suivante commence, jamais la veille.
- **Un changement de grille tombe toujours un 1er du mois** : aucune Période n'enjambe deux grilles, sa seule date de début suffit à la désigner, il n'existe pas de prix au prorata. Invariant jusqu'ici purement oral — la mise en œuvre lui donnera des dents (`@api.constrains`).
- **La fin de validité est dérivée** (début de la suivante, même régime) : elle s'affiche, elle ne se stocke pas. Une grille en vigueur est simplement la plus récente à avoir commencé.

Les deux projections lisent désormais une date de **début** : la Facture celle de la Période, les CP celle de la Souscription.

## Pourquoi la fin dérivée

Le `date_fin` stocké est tenu à jour à la main par un effet de bord dans `create()`, qui mute une grille **sœur**. Quatre défauts latents en découlent, tous de la même forme :

- pas de `write()` — corriger un `date_debut` laisse le `date_fin` du prédécesseur périmé (exactement ce que `souscriptions_migration` s'apprête à faire) ;
- pas de `unlink()` — supprimer la grille la plus récente laisse la précédente fermée à jamais : « trou de période » sur toute date postérieure ;
- la fermeture auto ne cherche qu'une grille `date_fin = False` — un chargement hors ordre chronologique ne ferme rien (les données de démo contournent déjà le cas, commentaire à l'appui) ;
- le flux de duplication ne ferme jamais rien : le brouillon `active=False` saute la fermeture, et `active` n'est pas dans le déclencheur de `_check_no_overlap`.

Dériver le champ ne les corrige pas : il les rend **irreprésentables**.

## Portée

`CONTEXT.md` uniquement. Rien d'exécutable. Cette PR passe en premier pour que la PR de mise en œuvre parte d'un `main` qui porte déjà la convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)