### PR TITLE
fix(grille): borne demi-ouverte, fin dérivée, sélection sur la date de début de la Période (#309)

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -29,7 +29,7 @@ Journeys de capacités (`REQ-XXX-nn`), chacune avec un statut (✅ Proven · ⚠
 
 ## Parcours : grilles de prix & catalogue
 
-- REQ-GRI-01 ✅ grille active sélectionnée par date, chevauchement interdit — preuve: tests/test_grille_prix.py::test_get_grille_active_par_date · #16
+- REQ-GRI-01 ✅ grille active sélectionnée sur la plus récente `date_debut <= date` (borne demi-ouverte, `date_fin` dérivée de la grille suivante du même régime, jamais stockée ni saisie ; changement de grille contraint au 1er du mois, non rétroactif) — preuve: tests/test_grille_prix.py::test_get_grille_active_selectionne_la_plus_recente_a_avoir_commence, tests/test_grille_prix.py::test_date_fin_derivee_du_debut_de_la_grille_suivante, tests/test_grille_prix.py::test_supprimer_la_grille_la_plus_recente_ne_laisse_pas_de_trou, tests/test_periode_facture.py::TestPeriodeFactureSelectionGrilleSurDateDebut · #16, #309, ADR 0029/0031
 - REQ-GRI-02 ✅ abonnement affine : base 3 kVA + coefficient par kVA — preuve: tests/test_grille_prix.py::test_abonnement_affine_lineaire_dans_la_puissance · #66
 - REQ-GRI-03 ✅ régime de prix standard | Moulin par souscription — preuve: tests/test_grille_prix.py::test_get_grille_active_par_regime · #105
 - REQ-GRI-04 ✅ duplication en brouillon inactif sans périmer la grille en cours — preuve: tests/test_grille_prix.py::test_dupliquer_grille_ne_perime_pas_la_sœur

--- a/demo/grille_prix_demo.xml
+++ b/demo/grille_prix_demo.xml
@@ -64,15 +64,15 @@
         </record>
 
         <!-- ============================================================== -->
-        <!-- Grille historique 2024 : explicitement fermée (date_fin) pour  -->
-        <!-- ne pas chevaucher la grille 2025 ouverte. Démontre la sélection -->
-        <!-- par date (get_grille_active) et la régularisation aux prix      -->
-        <!-- historiques : facturer un mois 2024 utilise ces tarifs.        -->
+        <!-- Grille historique 2024 : date_fin est dérivée (2025-01-01, le   -->
+        <!-- date_debut de la grille 2025 ci-dessus) — rien à saisir ici.    -->
+        <!-- Démontre la sélection par date (get_grille_active) et la       -->
+        <!-- régularisation aux prix historiques : facturer un mois 2024    -->
+        <!-- utilise ces tarifs.                                            -->
         <!-- ============================================================== -->
         <record id="grille_prix_2024" model="grille.prix">
             <field name="name">Grille tarifaire 2024</field>
             <field name="date_debut">2024-01-01</field>
-            <field name="date_fin">2024-12-31</field>
         </record>
 
         <!-- Abonnement affine 2024 (tarifs plus bas qu'en 2025) -->

--- a/docs/adr/0029-grille-moteur-prix-unique-composants-projections.md
+++ b/docs/adr/0029-grille-moteur-prix-unique-composants-projections.md
@@ -82,3 +82,43 @@ Deux documents opposables projetaient chacun leur propre assemblage de prix ; ri
 que la discipline ne les gardait sous la même règle. Concentrer la règle dans le module qui
 possède déjà les prix — la grille — et paramétrer par la grille rend la divergence *voulue*
 (valeurs, dans le temps) structurellement distincte de la divergence *interdite* (règle).
+
+## Amendement (#309) — borne demi-ouverte, sélection sur le début, fin dérivée
+
+Décision §2 corrigée : elle décrivait la Facture prixant « avec la grille historique (active à
+`date_fin` de la Période) ». C'était le bug — pas la règle. Une *Période* est bornée en
+**demi-ouvert** (`[date_debut, date_fin)`), donc `date_fin` est le 1er du mois **suivant** :
+sélectionner dessus prixait juin à la grille de juillet dès qu'un changement de grille tombait
+entre les deux. `souscription.py` (`_prix_documents`, grille **engagée**) portait déjà la bonne
+réponse ; seuls les chemins Période (composition des lignes, régénération à l'émission,
+régularisation) avaient dérivé. CONTEXT.md « Grille de prix » (#308) porte déjà la correction ;
+cet amendement aligne l'ADR.
+
+1. **Borne demi-ouverte partout.** La *Grille de prix* adopte la même convention que la
+   *Période* : `[date_debut, date_fin)`, la fin exclue. Une grille se termine le jour où la
+   suivante commence, jamais la veille — supprime la question « inclusif ou exclusif » qui
+   permettait au bug de passer inaperçu.
+
+2. **Sélection sur la date de DÉBUT, dans les deux projections.** La Facture prixe avec la
+   grille en vigueur à `date_debut` de la Période (historique — une régularisation rejoue
+   ainsi les prix de son mois) ; la CP avec la grille en vigueur à `date_debut` de la
+   Souscription (engagée). Les deux résolvent donc la même règle : *la grille en vigueur est
+   la plus récente à avoir commencé*. Seule la date **passée** à cette règle diverge (Période
+   vs Souscription) — jamais la borne interrogée (toujours le début).
+
+3. **La fin est dérivée, jamais stockée.** `grille.prix.date_fin` se calcule (`date_debut` de
+   la grille suivante du même régime) au lieu d'être écrit par un effet de bord de `create()`.
+   Un champ stocké tenu par un effet de bord est le **défaut structurel**, pas un simple
+   symptôme du bug de sélection : il rendait `write()` (correction d'un `date_debut` sans
+   toucher le prédécesseur), `unlink()` (trou de période) et le chargement hors-ordre
+   irreprésentables sans code dédié pour chaque cas. Dériver le champ élimine la classe
+   entière — rien à fermer, rien à laisser périmé.
+
+4. **Un changement de grille tombe toujours un 1er du mois — jamais de prorata.** Contrainte
+   sur `date_debut` (1er du mois), non rétroactive par nature. Alternative écartée : prixer un
+   mois à cheval au prorata des deux grilles — aucune mesure commerciale ne justifie de
+   découper un mois d'énergie entre deux barèmes ; la contrainte au 1er rend la situation
+   structurellement impossible plutôt que de coder un cas que personne ne demande.
+
+Voir aussi l'extension symétrique de la convention de borne dans l'amendement (#309) d'
+[ADR-0031](0031-fin-souscription-gouvernee-fait-c15-sorties-tirees-cloture-campagne.md).

--- a/docs/adr/0031-fin-souscription-gouvernee-fait-c15-sorties-tirees-cloture-campagne.md
+++ b/docs/adr/0031-fin-souscription-gouvernee-fait-c15-sorties-tirees-cloture-campagne.md
@@ -113,3 +113,17 @@ deux endroits qui comptent (`_compute_etat`, périmètre de campagne).
 - Tests : cycle complet `en_service` → `en_attente_cloture` → `resiliee` ; les critères
   d'acceptation de #21 (dernière facture aux jours exacts, plus aucune période ni facture après,
   statut reflété) sont couverts par ce modèle.
+
+## Amendement (#309) — la convention de borne s'étend à la Grille de prix
+
+La *Grille de prix* adopte la même convention de borne demi-ouverte que la *Période*
+(`[date_debut, date_fin)`) — décidé dans l'amendement d'[ADR-0029](0029-grille-moteur-prix-unique-composants-projections.md),
+en corrigeant un bug de sélection qui prixait un mois à la grille du mois suivant dès qu'un
+changement de grille tombait entre les deux. Ce document ne re-décide rien sur la grille (le
+fait C15 et la clôture de campagne restent son sujet propre) ; il documente que la convention
+de borne qu'il pose pour la Période ci-dessus n'est plus locale à la Période — elle est
+partagée par tout ce qui verse le temps en `[début, fin)` dans ce module. Trois bornes
+différentes coexistent dans le domaine, chacune assumée : la Période et la Grille sont
+demi-ouvertes ; la Souscription (`date_fin`) reste **inclusive** — « dernier jour servi »,
+décision 2 ci-dessus, choisie précisément pour préserver la lecture inclusive déjà codée. Ne
+pas confondre les deux en lisant l'une des dates de l'autre convention.

--- a/models/core/account_move.py
+++ b/models/core/account_move.py
@@ -139,8 +139,9 @@ class AccountMove(models.Model):
 
         Source Période (mensuelle) : ses lignes propres (sections,
         abonnement, énergie, notes TURPE — snapshot figé, ADR 0006, même
-        grille qu'à la création : ``get_grille_active`` sur ``date_fin``/
-        ``regime_prix_periode``) + les Refacturations actuellement *à
+        grille qu'à la création : ``get_grille_active`` sur ``date_debut``/
+        ``regime_prix_periode`` — la grille engagée, en lockstep avec la
+        création, ADR 0032) + les Refacturations actuellement *à
         refacturer* de la Souscription (ADR 0009) — même règle qu'à la
         création (`souscription._facturer_refacturations`) : une Refacturation
         entrée en file après la création du brouillon est donc rassemblée ici
@@ -156,7 +157,7 @@ class AccountMove(models.Model):
         self.ensure_one()
         if self.periode_id:
             periode = self.periode_id
-            grille = self.env['grille.prix'].get_grille_active(periode.date_fin, regime=periode.regime_prix_periode)
+            grille = self.env['grille.prix'].get_grille_active(periode.date_debut, regime=periode.regime_prix_periode)
             lignes = periode._composer_lignes(grille)
             prestas = periode.souscription_id._refacturations_a_rassembler(self)
             return lignes + prestas._composer_lignes_groupees()

--- a/models/core/grille_prix.py
+++ b/models/core/grille_prix.py
@@ -28,10 +28,10 @@ class GrillePrix(models.Model):
     active = fields.Boolean('Active', default=True)
 
     # Régime de prix (CONTEXT.md « Régime de prix ») : quel barème s'applique.
-    # Chaque régime versionne ses grilles indépendamment — l'unicité et la
-    # fermeture automatique (create()) jouent PAR régime, jamais tous régimes
-    # confondus. Le Tarif Moulin n'introduit aucun produit dédié : seul ce prix
-    # change, le catalogue (souscription.produit) reste inchangé.
+    # Chaque régime versionne ses grilles indépendamment — la sélection
+    # (get_grille_active) et la dérivation de date_fin jouent PAR régime, jamais
+    # tous régimes confondus. Le Tarif Moulin n'introduit aucun produit dédié :
+    # seul ce prix change, le catalogue (souscription.produit) reste inchangé.
     regime_prix = fields.Selection(
         [('standard', 'Standard'), ('moulin', 'Moulin')],
         string='Régime de prix',
@@ -39,8 +39,8 @@ class GrillePrix(models.Model):
         required=True,
         help='Barème appliqué par cette grille. Chaque régime versionne ses '
         'grilles indépendamment : une grille Moulin ouverte coexiste avec une '
-        'grille standard ouverte (anti-chevauchement et fermeture automatique '
-        'scopés par régime).',
+        'grille standard ouverte (sélection et fin dérivée scopées par '
+        'régime).',
     )
 
     ligne_ids = fields.One2many('grille.prix.ligne', 'grille_id', string='Lignes de prix')
@@ -224,9 +224,9 @@ class GrillePrix(models.Model):
 
         La copie est créée en **brouillon (inactive)** : dupliquer sert à
         amorcer une nouvelle grille (ex. une grille Moulin) sans perturber la
-        timeline en cours. Tant qu'elle est inactive, elle ne ferme aucune
-        grille sœur et ne déclenche pas l'anti-chevauchement. L'utilisateur
-        ajuste régime/dates puis l'active.
+        timeline en cours. Tant qu'elle est inactive elle reste hors timeline :
+        `get_grille_active` et la dérivation de `date_fin` l'ignorent
+        (`active_test`). L'utilisateur ajuste régime/dates puis l'active.
         """
         self.ensure_one()
 

--- a/models/core/grille_prix.py
+++ b/models/core/grille_prix.py
@@ -1,10 +1,5 @@
-import logging
-from datetime import date, timedelta
-
 from odoo import api, fields, models
 from odoo.exceptions import UserError, ValidationError
-
-_logger = logging.getLogger(__name__)
 
 # Puissance de référence (kVA) du tarif d'abonnement affine : base à 3 kVA,
 # coefficient appliqué au-delà (ADR 0018).
@@ -23,7 +18,12 @@ class GrillePrix(models.Model):
     name = fields.Char('Nom de la grille', required=True)
     date_debut = fields.Date('Valable à partir du', required=True)
     date_fin = fields.Date(
-        "Valable jusqu'au", readonly=True, help="Calculé automatiquement lors de la création d'une nouvelle grille"
+        "Valable jusqu'au (exclu)",
+        compute='_compute_date_fin',
+        help='Dérivée, jamais saisie : le début de la grille suivante du même '
+        'régime, vide si aucune (grille encore ouverte). Borne EXCLUE — '
+        'demi-ouverte comme la Période (CONTEXT.md « Grille de prix ») : la '
+        'grille se termine le jour où la suivante commence.',
     )
     active = fields.Boolean('Active', default=True)
 
@@ -53,48 +53,38 @@ class GrillePrix(models.Model):
         for grille in self:
             grille.nb_lignes = len(grille.ligne_ids)
 
-    @api.model_create_multi
-    def create(self, vals_list):
-        for vals in vals_list:
-            # Une grille créée inactive est un brouillon hors timeline (ex. copie
-            # à retravailler en grille Moulin) : elle ne ferme aucune sœur.
-            if vals.get('active', True) is False:
+    @api.depends('date_debut', 'regime_prix')
+    def _compute_date_fin(self):
+        """Dérivée : le `date_debut` de la grille suivante du même régime, vide
+        si aucune (grille encore ouverte). Rien n'est stocké ni fermé par un
+        effet de bord (cf. CONTEXT.md « Grille de prix ») — supprimer ou
+        corriger une grille ne laisse donc jamais de trou de période ni de
+        grille périmée à retenir à jour."""
+        for grille in self:
+            if not grille.date_debut:
+                grille.date_fin = False
                 continue
-
-            date_debut_nouvelle = vals['date_debut']
-            regime = vals.get('regime_prix') or 'standard'
-
-            # Fermer la grille précédente DU MÊME RÉGIME (la plus récente avant
-            # cette date) : chaque régime versionne ses grilles indépendamment
-            # (CONTEXT.md « Régime de prix ») — une nouvelle grille Moulin ne
-            # ferme jamais une grille standard, et réciproquement.
-            grille_precedente = self.search(
+            suivante = self.search(
                 [
-                    ('date_debut', '<', date_debut_nouvelle),
-                    ('date_fin', '=', False),  # Grille ouverte
-                    ('regime_prix', '=', regime),
+                    ('regime_prix', '=', grille.regime_prix),
+                    ('date_debut', '>', grille.date_debut),
+                    ('id', '!=', grille._origin.id),
                 ],
-                order='date_debut desc',
+                order='date_debut asc',
                 limit=1,
             )
-
-            if grille_precedente:
-                # Fermer la grille précédente la veille de la nouvelle
-                date_fin_precedente = fields.Date.from_string(date_debut_nouvelle) - timedelta(days=1)
-                grille_precedente.date_fin = date_fin_precedente
-                _logger.info(f'Grille {grille_precedente.name} fermée au {date_fin_precedente}')
-
-        return super().create(vals_list)
+            grille.date_fin = suivante.date_debut if suivante else False
 
     @api.model
     def get_grille_active(self, date_facture=None, regime='standard'):
-        """Récupère la grille du régime donné dont la période de validité couvre
-        la date donnée.
+        """Récupère la grille du régime donné en vigueur à la date donnée.
 
-        La sélection se fait sur ``(régime, plage [date_debut, date_fin])``
-        (date_fin vide = grille ouverte), et non sur le drapeau ``is_current`` :
-        une facturation rétroactive utilise ainsi la grille en vigueur à la date
-        concernée, pour le régime de la Souscription/Période facturée.
+        La grille en vigueur est simplement la plus récente à avoir commencé
+        (CONTEXT.md « Grille de prix ») : sélection sur la seule
+        ``date_debut``, jamais sur ``date_fin`` (dérivée, non filtrable en
+        SQL) — une facturation rétroactive utilise ainsi la grille en vigueur
+        à la date concernée, pour le régime de la Souscription/Période
+        facturée.
         """
         if date_facture is None:
             date_facture = fields.Date.today()
@@ -103,9 +93,6 @@ class GrillePrix(models.Model):
             [
                 ('regime_prix', '=', regime),
                 ('date_debut', '<=', date_facture),
-                '|',
-                ('date_fin', '=', False),
-                ('date_fin', '>=', date_facture),
             ],
             order='date_debut desc',
             limit=1,
@@ -119,32 +106,22 @@ class GrillePrix(models.Model):
 
         return grille
 
-    @api.constrains('date_debut', 'date_fin', 'regime_prix')
-    def _check_no_overlap(self):
-        """Interdit le chevauchement des périodes de validité entre grilles DU
-        MÊME RÉGIME. Deux grilles de régimes différents (standard, Moulin) ne se
-        gênent jamais, même sur des dates identiques (CONTEXT.md « Régime de
-        prix » : chaque régime versionne ses grilles indépendamment)."""
+    @api.constrains('date_debut')
+    def _check_date_debut_premier_du_mois(self):
+        """Un changement de grille tombe toujours un 1er du mois (CONTEXT.md
+        « Grille de prix ») : aucune Période ne peut alors enjamber deux
+        grilles, sa seule date de début suffisant à la désigner — il n'existe
+        pas de prix au prorata. Non rétroactif par nature (``@api.constrains``
+        ne revalide que les grilles créées ou modifiées) : les grilles
+        existantes démarrant en cours de mois ne sont pas requalifiées ici,
+        c'est voulu (cf. issue #309, hors périmètre inter-dépôt)."""
         for grille in self:
-            # Un brouillon inactif est hors timeline (cf. create()) : il ne ferme
-            # aucune sœur et ne déclenche pas l'anti-chevauchement. Sans ce skip,
-            # dupliquer une grille ouverte lèverait un chevauchement contre elle.
-            if not grille.active:
-                continue
-            if not grille.date_debut:
-                continue
-            start_a = grille.date_debut
-            end_a = grille.date_fin or date.max
-            if start_a > end_a:
-                raise ValidationError(f"La grille '{grille.name}' a une date de fin antérieure à sa date de début.")
-            for other in self.search([('id', '!=', grille.id), ('regime_prix', '=', grille.regime_prix)]):
-                start_b = other.date_debut
-                end_b = other.date_fin or date.max
-                if start_a <= end_b and start_b <= end_a:
-                    raise ValidationError(
-                        f"La période de la grille '{grille.name}' chevauche celle de la grille '{other.name}' "
-                        f'(régime {grille.regime_prix}).'
-                    )
+            if grille.date_debut and grille.date_debut.day != 1:
+                raise ValidationError(
+                    f"La grille '{grille.name}' doit débuter un 1er du mois "
+                    f"({grille.date_debut} ne l'est pas) : un changement de "
+                    f'grille ne tombe jamais en cours de mois.'
+                )
 
     # Cadrans facturés par type de tarif : (code, libellé). Carte unique de la
     # partition (ADR 0029) — Base : un seul cadran ; HP/HC : toujours les deux,
@@ -253,8 +230,15 @@ class GrillePrix(models.Model):
         """
         self.ensure_one()
 
-        # Date de départ indicative : l'utilisateur la corrige avant activation.
+        # Date de départ indicative : le 1er du mois suivant, seule date qui ne
+        # viole jamais la contrainte « 1er du mois » (contrairement à `today`,
+        # qui la viole tout jour sauf le 1er) — l'utilisateur l'ajuste avant
+        # activation si besoin.
         today = fields.Date.today()
+        if today.month == 12:
+            date_debut_suggeree = today.replace(year=today.year + 1, month=1, day=1)
+        else:
+            date_debut_suggeree = today.replace(month=today.month + 1, day=1)
 
         # Préparer les lignes à copier
         lignes_vals = []
@@ -278,8 +262,7 @@ class GrillePrix(models.Model):
         nouvelle_grille = self.create(
             {
                 'name': f'Copie de {self.name}',
-                'date_debut': today,
-                'date_fin': False,
+                'date_debut': date_debut_suggeree,
                 'regime_prix': self.regime_prix,
                 'active': False,
                 'ligne_ids': lignes_vals,

--- a/models/core/souscription_periode.py
+++ b/models/core/souscription_periode.py
@@ -931,7 +931,10 @@ class SouscriptionPeriode(models.Model):
     def _creer_facture(self):
         """Crée la facture (``account.move``) de cette période, en **brouillon**.
 
-        Sélectionne la grille active à la date de fin, compose les lignes
+        Sélectionne la grille active à la date de DÉBUT — la grille engagée,
+        la plus récente à avoir commencé (CONTEXT.md « Grille de prix ») ; la
+        Période est demi-ouverte et sa date de fin est le 1er du mois
+        suivant, celle de la grille suivante —, compose les lignes
         (``_composer_lignes``) et crée le move en posant ``periode_id``
         (source unique du lien Période ↔ Facture, ADR 0004). Ne tamponne
         PLUS la provision ici (``_tamponner_provision`` a migré à
@@ -945,7 +948,7 @@ class SouscriptionPeriode(models.Model):
         #264, #265 ; tranche 3, #267).
         """
         self.ensure_one()
-        grille = self.env['grille.prix'].get_grille_active(self.date_fin, regime=self.regime_prix_periode)
+        grille = self.env['grille.prix'].get_grille_active(self.date_debut, regime=self.regime_prix_periode)
         return self.env['account.move'].create(
             {
                 'move_type': 'out_invoice',

--- a/models/core/souscription_regularisation.py
+++ b/models/core/souscription_regularisation.py
@@ -214,7 +214,7 @@ class SouscriptionRegularisation(models.Model):
             if not any(ecarts.values()):
                 continue  # écart nul ce mois-ci : rien à régulariser
 
-            grille = Grille.get_grille_active(periode.date_fin, regime=periode.regime_prix_periode)
+            grille = Grille.get_grille_active(periode.date_debut, regime=periode.regime_prix_periode)
             note = '' if periode.mois in fraiches else ' (estimation locale)'
             for cadran, ecart in ecarts.items():
                 if not ecart:

--- a/tests/common.py
+++ b/tests/common.py
@@ -202,11 +202,12 @@ class SouscriptionsTestMixin:
         # Grille de prix active avec lignes, pour que la facturation
         # fonctionne sans dépendre des données de démo. La grille est résolue
         # par date (get_grille_active), jamais par un drapeau (ADR 0018).
+        # date_fin est dérivée (#309) : rien à saisir, aucune grille suivante
+        # du même régime -> la grille reste ouverte.
         cls.grille_prix = cls.env['grille.prix'].create(
             {
                 'name': 'Grille Test',
                 'date_debut': date(2024, 1, 1),
-                'date_fin': date(2024, 12, 31),
                 'active': True,
             }
         )

--- a/tests/data/test_data.xml
+++ b/tests/data/test_data.xml
@@ -9,7 +9,6 @@
         <record id="test_grille_prix_complete" model="grille.prix">
             <field name="name">Grille Test Complète</field>
             <field name="date_debut">2024-01-01</field>
-            <field name="date_fin">2024-12-31</field>
             <field name="active">True</field>
         </record>
 

--- a/tests/data/test_fixtures.xml
+++ b/tests/data/test_fixtures.xml
@@ -51,7 +51,6 @@
     <record id="grille_prix_test" model="grille.prix">
         <field name="name">Grille Prix Test</field>
         <field name="date_debut">2024-01-01</field>
-        <field name="date_fin">2024-12-31</field>
         <field name="active">True</field>
     </record>
 

--- a/tests/test_campagne_etapes_actions.py
+++ b/tests/test_campagne_etapes_actions.py
@@ -353,7 +353,6 @@ class TestCampagneEtapeEmettreFactures(SouscriptionsTestCase):
             {
                 'name': 'Grille Moulin Test',
                 'date_debut': date(2024, 1, 1),
-                'date_fin': date(2024, 12, 31),
                 'regime_prix': 'moulin',
                 'active': True,
             }

--- a/tests/test_cloture_campagne.py
+++ b/tests/test_cloture_campagne.py
@@ -97,11 +97,11 @@ class TestPeriodeClotureAuReel(SouscriptionsTestCase):
         )
 
     def _grille_moulin(self, name):
+        # date_fin est dérivée (#309) : jamais passée en création.
         grille = self.env['grille.prix'].create(
             {
                 'name': name,
                 'date_debut': date(2024, 1, 1),
-                'date_fin': date(2024, 12, 31),
                 'active': True,
                 'regime_prix': 'moulin',
             }
@@ -215,11 +215,11 @@ class TestRegulariserClotures(SouscriptionsTestCase):
         )
 
     def _grille_moulin(self, name):
+        # date_fin est dérivée (#309) : jamais passée en création.
         grille = self.env['grille.prix'].create(
             {
                 'name': name,
                 'date_debut': date(2024, 1, 1),
-                'date_fin': date(2024, 12, 31),
                 'active': True,
                 'regime_prix': 'moulin',
             }

--- a/tests/test_documents_contractuels.py
+++ b/tests/test_documents_contractuels.py
@@ -251,7 +251,6 @@ class TestConditionsParticulieres(SouscriptionsTestMixin, HttpCase):
             {
                 'name': 'Grille Moulin CP',
                 'date_debut': date(2024, 1, 1),
-                'date_fin': date(2024, 12, 31),
                 'regime_prix': 'moulin',
             }
         )

--- a/tests/test_facturation.py
+++ b/tests/test_facturation.py
@@ -17,11 +17,11 @@ class TestFacturation(TransactionCase):
         )
 
         # Grille de test résolue par date (get_grille_active), pas par drapeau.
+        # date_fin est dérivée (#309) : pas de grille suivante, elle reste ouverte.
         self.grille_prix = self.env['grille.prix'].create(
             {
                 'name': 'Grille Test',
                 'date_debut': date(2024, 1, 1),
-                'date_fin': date(2024, 12, 31),
                 'active': True,
             }
         )

--- a/tests/test_grille_prix.py
+++ b/tests/test_grille_prix.py
@@ -18,11 +18,13 @@ from .common import (
 class TestGrillePrix(TransactionCase):
     def setUp(self):
         super().setUp()
+        # date_fin est dérivée (#309) : jamais saisie à la création — cette
+        # grille reste ouverte tant qu'aucune grille standard plus récente
+        # n'existe.
         self.grille = self.env['grille.prix'].create(
             {
                 'name': 'Grille Test 2024',
                 'date_debut': date(2024, 1, 1),
-                'date_fin': date(2024, 12, 31),
                 'active': True,
             }
         )
@@ -56,7 +58,6 @@ class TestGrillePrix(TransactionCase):
             {
                 'name': 'Grille 2023',
                 'date_debut': date(2023, 1, 1),
-                'date_fin': date(2023, 12, 31),
             }
         )
         build_grille_lignes(
@@ -73,6 +74,73 @@ class TestGrillePrix(TransactionCase):
         self.assertEqual(
             self.env['grille.prix'].get_grille_active(date(2024, 5, 1)),
             self.grille,
+        )
+
+    def test_get_grille_active_selectionne_la_plus_recente_a_avoir_commence(self):
+        """« La grille en vigueur est la plus récente à avoir commencé » : une
+        date qui tombe APRÈS le début de deux grilles du même régime résout
+        toujours sur celle dont le début est le plus proche (le plus grand,
+        toujours <= la date), jamais sur une notion de fin stockée."""
+        grille_2025 = self.env['grille.prix'].create({'name': 'Grille 2025', 'date_debut': date(2025, 1, 1)})
+        build_grille_lignes(self.env, grille_2025, prix_base=0.30, prix_hp=0.30, prix_hc=0.30)
+
+        self.assertEqual(self.env['grille.prix'].get_grille_active(date(2024, 12, 31)), self.grille)
+        self.assertEqual(self.env['grille.prix'].get_grille_active(date(2025, 1, 1)), grille_2025)
+        self.assertEqual(self.env['grille.prix'].get_grille_active(date(2030, 1, 1)), grille_2025)
+
+    # === date_fin dérivée (#309) : plus stockée, plus fermée par create() ===
+
+    def test_date_fin_vide_quand_aucune_grille_suivante(self):
+        """Sans grille plus récente du même régime, date_fin reste vide (grille
+        encore ouverte) — jamais saisie ni fermée par un effet de bord."""
+        self.assertFalse(self.grille.date_fin)
+
+    def test_date_fin_derivee_du_debut_de_la_grille_suivante(self):
+        """date_fin d'une grille = date_debut de la grille suivante du même
+        régime — recalculée à la volée, jamais stockée ni fermée à la main."""
+        grille_2025 = self.env['grille.prix'].create({'name': 'Grille 2025', 'date_debut': date(2025, 1, 1)})
+
+        self.assertEqual(self.grille.date_fin, date(2025, 1, 1))
+        self.assertFalse(grille_2025.date_fin, 'la plus récente reste ouverte')
+
+    def test_date_fin_derivee_scopee_par_regime(self):
+        """La dérivation ne regarde que les grilles DU MÊME RÉGIME : une
+        grille Moulin n'influence jamais la date_fin dérivée d'une grille
+        standard, et réciproquement (CONTEXT.md « Régime de prix »)."""
+        standard_ouverte = self.env['grille.prix'].create({'name': 'Standard 2025', 'date_debut': date(2025, 1, 1)})
+        moulin_1 = self.env['grille.prix'].create(
+            {'name': 'Moulin 2025', 'date_debut': date(2025, 1, 1), 'regime_prix': 'moulin'}
+        )
+        self.assertFalse(standard_ouverte.date_fin, "la grille Moulin n'affecte pas la grille standard")
+
+        self.env['grille.prix'].create(
+            {'name': 'Moulin 2025 bis', 'date_debut': date(2025, 6, 1), 'regime_prix': 'moulin'}
+        )
+        self.assertEqual(moulin_1.date_fin, date(2025, 6, 1))
+        self.assertFalse(standard_ouverte.date_fin)
+
+    def test_creer_une_grille_plus_recente_ne_leve_jamais_de_chevauchement(self):
+        """Sans date_fin saisi, le chevauchement est irreprésentable (#309) :
+        créer une seconde grille standard ne lève plus jamais — elle prend
+        simplement le relais à sa date de début (anti-chevauchement, ancien
+        comportement, supprimé)."""
+        grille_bis = self.env['grille.prix'].create({'name': 'Grille 2024 Bis', 'date_debut': date(2024, 6, 1)})
+        self.assertEqual(self.env['grille.prix'].get_grille_active(date(2024, 3, 1)), self.grille)
+        self.assertEqual(self.env['grille.prix'].get_grille_active(date(2024, 6, 1)), grille_bis)
+
+    def test_supprimer_la_grille_la_plus_recente_ne_laisse_pas_de_trou(self):
+        """Supprimer la grille la plus récente ne laisse pas de trou de
+        période — la précédente redevient en vigueur (#309 : plus de
+        date_fin stockée à rouvrir manuellement)."""
+        grille_recente = self.env['grille.prix'].create({'name': 'Grille 2025', 'date_debut': date(2025, 1, 1)})
+        self.assertEqual(self.env['grille.prix'].get_grille_active(date(2025, 3, 1)), grille_recente)
+
+        grille_recente.unlink()
+
+        self.assertEqual(
+            self.env['grille.prix'].get_grille_active(date(2025, 3, 1)),
+            self.grille,
+            'la grille précédente redevient en vigueur, aucun trou de période',
         )
 
     # === composants() — l'unique règle d'assemblage des prix (ADR 0029) ===
@@ -137,17 +205,6 @@ class TestGrillePrix(TransactionCase):
         with self.assertRaises(UserError):
             self.grille.composants('hphc', 6.0)
 
-    def test_chevauchement_grilles_interdit(self):
-        """Deux grilles aux périodes qui se chevauchent sont refusées."""
-        with self.assertRaises(ValidationError):
-            self.env['grille.prix'].create(
-                {
-                    'name': 'Grille 2024 Bis',
-                    'date_debut': date(2024, 6, 1),
-                    'date_fin': date(2024, 12, 31),
-                }
-            )
-
     def test_produit_unique_par_grille(self):
         """Un même produit ne peut apparaître qu'une fois par grille (plus de palier)."""
         produit = self.env.ref('souscriptions_odoo.souscriptions_product_abonnement_standard')
@@ -163,6 +220,18 @@ class TestGrillePrix(TransactionCase):
             )
             self.env.flush_all()
 
+    # === Contrainte 1er du mois (#309) ===
+
+    def test_date_debut_doit_etre_le_premier_du_mois(self):
+        """Un changement de grille tombe toujours un 1er du mois : aucune
+        Période ne l'enjambe alors jamais (CONTEXT.md « Grille de prix »)."""
+        with self.assertRaises(ValidationError):
+            self.env['grille.prix'].create({'name': 'Grille mi-mois', 'date_debut': date(2025, 3, 15)})
+
+    def test_date_debut_premier_du_mois_accepte(self):
+        grille = self.env['grille.prix'].create({'name': 'Grille 1er', 'date_debut': date(2025, 3, 1)})
+        self.assertEqual(grille.date_debut, date(2025, 3, 1))
+
     # === Régime de prix (standard | Moulin) — #105 ===
 
     def test_regime_prix_defaut_standard(self):
@@ -171,69 +240,17 @@ class TestGrillePrix(TransactionCase):
 
     def test_grilles_moulin_et_standard_coexistent(self):
         """Deux grilles ouvertes de régimes différents, mêmes dates, coexistent :
-        l'anti-chevauchement joue par régime (CONTEXT.md « Régime de prix »)."""
+        chaque régime se sélectionne indépendamment (CONTEXT.md « Régime de prix »)."""
         grille_moulin = self.env['grille.prix'].create(
             {
                 'name': 'Grille Moulin 2024',
                 'date_debut': date(2024, 1, 1),
-                'date_fin': date(2024, 12, 31),
                 'regime_prix': 'moulin',
             }
         )
         self.assertEqual(grille_moulin.regime_prix, 'moulin')
         # La grille standard n'a pas été affectée par la création de la Moulin.
-        self.assertEqual(self.grille.date_fin, date(2024, 12, 31))
-
-    def test_chevauchement_meme_regime_toujours_interdit(self):
-        """Deux grilles Moulin qui se chevauchent restent interdites (l'anti-
-        chevauchement joue toujours au sein d'un même régime)."""
-        self.env['grille.prix'].create(
-            {
-                'name': 'Grille Moulin A',
-                'date_debut': date(2024, 1, 1),
-                'date_fin': date(2024, 6, 30),
-                'regime_prix': 'moulin',
-            }
-        )
-        with self.assertRaises(ValidationError):
-            self.env['grille.prix'].create(
-                {
-                    'name': 'Grille Moulin B',
-                    'date_debut': date(2024, 6, 1),
-                    'date_fin': date(2024, 12, 31),
-                    'regime_prix': 'moulin',
-                }
-            )
-
-    def test_fermeture_automatique_scopee_par_regime(self):
-        """La création d'une grille ne ferme que la grille OUVERTE précédente du
-        même régime — jamais une grille ouverte d'un autre régime."""
-        standard_ouverte = self.env['grille.prix'].create(
-            {
-                'name': 'Standard 2025',
-                'date_debut': date(2025, 1, 1),
-            }
-        )
-        moulin_1 = self.env['grille.prix'].create(
-            {
-                'name': 'Moulin 2025',
-                'date_debut': date(2025, 1, 1),
-                'regime_prix': 'moulin',
-            }
-        )
-        # La grille standard ouverte n'est pas fermée par la création de la Moulin.
-        self.assertFalse(standard_ouverte.date_fin)
-
-        self.env['grille.prix'].create(
-            {
-                'name': 'Moulin 2025 bis',
-                'date_debut': date(2025, 6, 1),
-                'regime_prix': 'moulin',
-            }
-        )
-        # Seule la grille Moulin précédente est fermée.
-        self.assertEqual(moulin_1.date_fin, date(2025, 5, 31))
-        self.assertFalse(standard_ouverte.date_fin)
+        self.assertFalse(self.grille.date_fin)
 
     def test_get_grille_active_par_regime(self):
         """La sélection se fait par (régime, date) : standard et Moulin sont
@@ -242,7 +259,6 @@ class TestGrillePrix(TransactionCase):
             {
                 'name': 'Grille Moulin 2024',
                 'date_debut': date(2024, 1, 1),
-                'date_fin': date(2024, 12, 31),
                 'regime_prix': 'moulin',
             }
         )
@@ -271,7 +287,6 @@ class TestGrillePrix(TransactionCase):
             {
                 'name': 'Grille Moulin 2023',
                 'date_debut': date(2023, 1, 1),
-                'date_fin': date(2023, 12, 31),
                 'regime_prix': 'moulin',
             }
         )
@@ -294,3 +309,22 @@ class TestGrillePrix(TransactionCase):
 
         self.assertFalse(nouvelle.active, 'La copie doit être un brouillon inactif')
         self.assertFalse(grille_active.date_fin, "La grille d'origine ne doit pas être fermée")
+
+    def test_dupliquer_grille_propose_le_premier_du_mois_suivant(self):
+        """L'action propose date_debut = 1er du mois suivant (jamais `today`,
+        qui violerait la contrainte 1er-du-mois tout jour sauf le 1er, #309)."""
+        action = self.grille.dupliquer_cette_grille()
+        nouvelle = self.env['grille.prix'].browse(action['res_id'])
+        self.assertEqual(nouvelle.date_debut.day, 1)
+
+    def test_dupliquer_puis_activer_ne_chevauche_ni_ne_laisse_de_grille_ouverte(self):
+        """Dupliquer puis activer une grille ne produit ni chevauchement ni
+        grille laissée ouverte : la copie prend le relais de l'originale à
+        sa date de début (#309)."""
+        action = self.grille.dupliquer_cette_grille()
+        copie = self.env['grille.prix'].browse(action['res_id'])
+
+        copie.active = True  # l'utilisateur active la copie après ajustement
+
+        self.assertEqual(self.grille.date_fin, copie.date_debut, "l'originale se termine où la copie commence")
+        self.assertFalse(copie.date_fin, 'la copie, la plus récente, reste ouverte')

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -20,11 +20,11 @@ class TestIntegration(TransactionCase):
         )
 
         # Grille de test résolue par date (get_grille_active), pas par drapeau.
+        # date_fin est dérivée (#309) : pas de grille suivante, elle reste ouverte.
         self.grille = self.env['grille.prix'].create(
             {
                 'name': 'Grille Intégration',
                 'date_debut': date(2024, 1, 1),
-                'date_fin': date(2024, 12, 31),
                 'active': True,
             }
         )

--- a/tests/test_invoice_template.py
+++ b/tests/test_invoice_template.py
@@ -31,7 +31,6 @@ class TestInvoiceTemplate(TransactionCase):
             {
                 'name': 'Grille Test Template',
                 'date_debut': date(2024, 1, 1),
-                'date_fin': date(2024, 12, 31),
                 'active': True,
             }
         )

--- a/tests/test_mails_raccordement.py
+++ b/tests/test_mails_raccordement.py
@@ -112,13 +112,12 @@ class TestPackBienvenueRaccordement(SouscriptionsTestMixin, TransactionCase):
         # La CP jointe au pack se rend à la date de début de la Souscription
         # (date_debut_souhaitee = aujourd'hui + 30 j) : grille ouverte à
         # partir de 2025 pour couvrir cette date quel que soit le jour du
-        # run — la grille 2024 du mixin ne couvre que les fixtures
-        # historiques (pas de chevauchement).
+        # run — la grille 2024 du mixin devient historique, sa date_fin se
+        # dérive automatiquement au 2025-01-01 (#309).
         grille_courante = cls.env['grille.prix'].create(
             {
                 'name': 'Grille Test courante',
                 'date_debut': date(2025, 1, 1),
-                'date_fin': False,
                 'active': True,
             }
         )

--- a/tests/test_periode_composition.py
+++ b/tests/test_periode_composition.py
@@ -312,10 +312,10 @@ class TestPeriodeComposition(SouscriptionsTestCase):
     # === Régime de prix (standard | Moulin) — #105 ===
 
     def _grille_moulin(self, **kwargs):
+        # date_fin est dérivée (#309) : jamais passée en création.
         vals = {
             'name': 'Grille Moulin Test',
             'date_debut': date(2024, 1, 1),
-            'date_fin': date(2024, 12, 31),
             'regime_prix': 'moulin',
         }
         vals.update(kwargs)

--- a/tests/test_periode_facture.py
+++ b/tests/test_periode_facture.py
@@ -9,7 +9,7 @@ from datetime import date
 
 from odoo.tests.common import tagged
 
-from .common import SouscriptionsTestCase
+from .common import SouscriptionsTestCase, build_grille_lignes
 
 
 @tagged('souscriptions', 'souscriptions_periode_facture', 'post_install', '-at_install')
@@ -292,6 +292,59 @@ class TestPeriodeFactureRegenerationEmission(SouscriptionsTestCase):
         facture.unlink()  # ne lève rien : cascade autorisée
 
         self.assertFalse(periode.facture_id)
+
+
+@tagged('souscriptions', 'souscriptions_periode_facture', 'souscriptions_grille_prix', 'post_install', '-at_install')
+class TestPeriodeFactureSelectionGrilleSurDateDebut(SouscriptionsTestCase):
+    """Sélection de la grille sur `periode.date_debut`, en lockstep sur les
+    trois chemins Période (#309, ADR 0029/0032). La Période est demi-ouverte
+    (`date_fin` = 1er du mois suivant) : sélectionner sur `date_fin` prixait
+    un mois à la grille du mois suivant dès qu'un changement de grille
+    tombait entre les deux — ce défaut n'avait jamais mordu faute d'un mois
+    enjambant un changement de grille dans les fixtures existantes."""
+
+    def test_facture_de_juin_utilise_la_grille_de_juin_pas_celle_de_juillet(self):
+        """Non-régression du défaut #309 : une Période de juin, avec une
+        grille B commençant le 1er juillet (même régime), se facture à la
+        grille de JUIN — pas à celle que sa `date_fin` (2024-07-01) désigne."""
+        grille_juillet = self.env['grille.prix'].create({'name': 'Grille Juillet 2024', 'date_debut': date(2024, 7, 1)})
+        build_grille_lignes(self.env, grille_juillet, prix_base=0.99, prix_hp=0.99, prix_hc=0.99)
+
+        periode = self.create_test_periode(
+            self.souscription_base, date_debut=date(2024, 6, 1), date_fin=date(2024, 7, 1), provision_base_kwh=100.0
+        )
+        facture = periode._creer_facture()
+
+        ligne = facture.invoice_line_ids.filtered(lambda l: l.name == 'Énergie Base')
+        self.assertAlmostEqual(
+            ligne.price_unit, 0.15, places=6, msg='grille de juin (common.py), jamais celle de juillet (0.99)'
+        )
+
+    def test_creation_et_regeneration_a_lemission_resolvent_la_meme_grille(self):
+        """Lockstep (ADR 0032) : `_creer_facture` (création du brouillon) et
+        `_composer_lignes_generees` (régénération à l'émission) résolvent
+        la MÊME grille pour la même Période — une grille future apparue
+        entre les deux ne doit rien changer, sous peine de changer
+        silencieusement le prix d'une facture à son émission."""
+        periode = self.create_test_periode(
+            self.souscription_base, date_debut=date(2024, 6, 1), date_fin=date(2024, 7, 1), provision_base_kwh=100.0
+        )
+        facture = periode._creer_facture()
+        prix_creation = facture.invoice_line_ids.filtered(lambda l: l.name == 'Énergie Base').price_unit
+
+        # Une grille future apparaît après la création du brouillon, avant l'émission.
+        grille_future = self.env['grille.prix'].create({'name': 'Grille Août 2024', 'date_debut': date(2024, 8, 1)})
+        build_grille_lignes(self.env, grille_future, prix_base=0.99, prix_hp=0.99, prix_hc=0.99)
+
+        facture.action_post()
+
+        ligne_apres = facture.invoice_line_ids.filtered(lambda l: l.name == 'Énergie Base')
+        self.assertAlmostEqual(
+            ligne_apres.price_unit, prix_creation, places=6, msg='même grille à la création et à l’émission'
+        )
+        self.assertAlmostEqual(
+            ligne_apres.price_unit, 0.15, places=6, msg='toujours la grille de juin, pas la future d’août'
+        )
 
 
 @tagged('souscriptions', 'souscriptions_periode_facture', 'souscriptions_provenance', 'post_install', '-at_install')

--- a/tests/test_periode_facture.py
+++ b/tests/test_periode_facture.py
@@ -326,6 +326,13 @@ class TestPeriodeFactureSelectionGrilleSurDateDebut(SouscriptionsTestCase):
         la MÊME grille pour la même Période — une grille future apparue
         entre les deux ne doit rien changer, sous peine de changer
         silencieusement le prix d'une facture à son émission."""
+        # La grille de juillet existe DÈS la création : c'est elle que
+        # `periode.date_fin` (2024-07-01) désignerait. Sans elle, les deux
+        # chemins résolvent la grille de juin même non corrigés — le test ne
+        # discriminerait alors rien (#309).
+        grille_juillet = self.env['grille.prix'].create({'name': 'Grille Juillet 2024', 'date_debut': date(2024, 7, 1)})
+        build_grille_lignes(self.env, grille_juillet, prix_base=0.99, prix_hp=0.99, prix_hc=0.99)
+
         periode = self.create_test_periode(
             self.souscription_base, date_debut=date(2024, 6, 1), date_fin=date(2024, 7, 1), provision_base_kwh=100.0
         )

--- a/tests/test_periode_ouverture.py
+++ b/tests/test_periode_ouverture.py
@@ -47,7 +47,7 @@ class TestPeriodeOuverture(SouscriptionsTestCase):
     def test_porte_provision_base_jours_et_prix_via_grille(self):
         """AC2 (Base) : provision facturée et jours sont portés par la Période ;
         le prix appliqué reste résolvable par la même mécanique que toute
-        Période (grille sélectionnée par régime + date de fin, ADR 0002/0006 —
+        Période (grille sélectionnée par régime + date de DÉBUT, ADR 0002/0006/0029 —
         jamais recopié sur la Période)."""
         self.souscription_base.lisse = True
         periode = self._periode_ouverture(
@@ -60,7 +60,7 @@ class TestPeriodeOuverture(SouscriptionsTestCase):
         self.assertEqual(periode.provision_base_kwh, 280.0)
         self.assertEqual(periode.jours, 30)
 
-        grille = self.env['grille.prix'].get_grille_active(periode.date_fin, regime=periode.regime_prix_periode)
+        grille = self.env['grille.prix'].get_grille_active(periode.date_debut, regime=periode.regime_prix_periode)
         composants = grille.composants(
             periode.type_tarif_periode,
             periode.puissance_souscrite_periode,

--- a/tests/test_portal.py
+++ b/tests/test_portal.py
@@ -257,7 +257,6 @@ class PortalTestCase(SouscriptionsTestMixin, HttpCase):
             {
                 'name': 'Grille Test 2023',
                 'date_debut': date(2023, 1, 1),
-                'date_fin': date(2023, 12, 31),
                 'active': True,
             }
         )

--- a/tests/test_regularisation.py
+++ b/tests/test_regularisation.py
@@ -78,12 +78,12 @@ class TestRegularisationCandidats(SouscriptionsTestCase):
             }
         )
 
-    def _grille_moulin(self, name='Grille Moulin', date_debut=date(2024, 1, 1), date_fin=False, prix_base=0.15):
+    def _grille_moulin(self, name='Grille Moulin', date_debut=date(2024, 1, 1), prix_base=0.15):
+        # date_fin est dérivée (#309) : jamais passée en création.
         grille = self.env['grille.prix'].create(
             {
                 'name': name,
                 'date_debut': date_debut,
-                'date_fin': date_fin,
                 'active': True,
                 'regime_prix': 'moulin',
             }
@@ -161,10 +161,11 @@ class TestRegularisationCandidats(SouscriptionsTestCase):
         grille), chacune aux prix de sa sous-période."""
         souscription = self._souscription_lissee(ref='RSC-REGUL-AC2', pdl='PDL_REGUL_AC2')
         grille1 = self._grille_moulin(name='Grille AC2 - 1', date_debut=date(2024, 1, 1), prix_base=0.15)
-        # Nouvelle grille moulin à partir du 2 juillet : ferme automatiquement
-        # grille1 au 1er juillet (date de clôture = veille) — la Période de
-        # juin (date_fin = 2024-07-01) reste donc bien sur grille1.
-        grille2 = self._grille_moulin(name='Grille AC2 - 2', date_debut=date(2024, 7, 2), prix_base=0.20)
+        # Nouvelle grille moulin à partir du 1er juillet (un changement de
+        # grille tombe toujours un 1er, #309) : la Période de juin
+        # (date_debut = 2024-06-01) sélectionne toujours grille1, celle de
+        # juillet (date_debut = 2024-07-01) sélectionne grille2.
+        grille2 = self._grille_moulin(name='Grille AC2 - 2', date_debut=date(2024, 7, 1), prix_base=0.20)
 
         for m in range(1, 7):  # janvier à juin : écart 10 kWh/mois -> grille1
             self._periode_facturee(souscription, m, energie_base_kwh=210.0)

--- a/tests/test_regularisation_tampon.py
+++ b/tests/test_regularisation_tampon.py
@@ -74,7 +74,6 @@ class TestRegularisationTamponEmission(SouscriptionsTestCase):
             {
                 'name': name,
                 'date_debut': date(2024, 1, 1),
-                'date_fin': date(2024, 12, 31),
                 'active': True,
                 'regime_prix': 'moulin',
             }

--- a/tests/test_souscription_etat.py
+++ b/tests/test_souscription_etat.py
@@ -274,7 +274,6 @@ class TestEtatEnAttenteCloture(SouscriptionsTestCase):
             {
                 'name': name,
                 'date_debut': date(2024, 1, 1),
-                'date_fin': date(2024, 12, 31),
                 'active': True,
                 'regime_prix': 'moulin',
             }

--- a/views/core/grille_prix_views.xml
+++ b/views/core/grille_prix_views.xml
@@ -105,8 +105,9 @@
                 Créer votre première grille de prix
             </p>
             <p>
-                Les grilles de prix définissent les tarifs applicables à partir d'une date donnée.
-                La création d'une nouvelle grille ferme automatiquement la précédente.
+                Les grilles de prix définissent les tarifs applicables à partir d'une date donnée
+                (toujours un 1er du mois). La fin de validité affichée se déduit de la grille
+                suivante du même régime — rien à fermer manuellement.
             </p>
         </field>
     </record>


### PR DESCRIPTION
Closes #309

Corrige la sélection de grille fausse sur les trois chemins de facturation Période (ils résolvaient sur `date_fin`, borne demi-ouverte — donc la grille du mois suivant) et supprime les quatre défauts latents de synchronisation causés par un `grille.prix.date_fin` stocké, fermé par effet de bord dans `create()`.

Le correctif dérive `date_fin` (jamais stocké ni saisi), retire l'effet de bord de `create()` et le `_check_no_overlap` devenu irreprésentable, bascule les trois chemins Période (et le défaut de duplication au « 1er du mois ») sur `date_debut`, et ajoute un `@api.constrains` contraignant les changements de grille au 1er du mois. ADR 0029 et ADR 0031 amendés en conséquence.

Suite de tests : 712 tests, 0 failed, 0 error(s) (recette docker, vérifié deux fois).

⚠️ Ordonnancement (cf. « Hors périmètre » de #309) : cette PR n'est réellement correcte en prod qu'une fois la correction `souscriptions_migration` passée et `prodlocal` rechargée — le `@api.constrains` n'étant pas rétroactif, les trois grilles existantes démarrant en cours de mois (2024-12-05, 2025-09-05 ×2) restent fausses.