### PR TITLE
test(common): stub PeriodeMeta v3 unique — periode_meta + objet_releve dans la couture de test nommée (#356)

### DIFF
--- a/tests/common.py
+++ b/tests/common.py
@@ -84,6 +84,77 @@ def client_sorties_factice(items=(), *, leve=None):
     return client
 
 
+def periode_meta(**overrides):
+    """Stub duck-typé de `PeriodeMeta` (contrat v3, ADR 0011/0020) : miroir
+    **complet** (~20 champs) du modèle pydantic réel, mêmes noms — le mapping
+    ne fait aucune traduction — y compris `pdl`, `nb_jours`,
+    `formule_tarifaire_acheminement` que le mapping ne lit pas (même
+    philosophie que `resultat_rsc`/`ligne_sortie`). Défauts réalistes (280 kWh,
+    TURPE 8,5/4,2 €, CTA 1,1 €, accise 21,0) repris du `_periode_meta`
+    canonique de test_pull_meta_periodes.py.
+
+    Centralise ce qui était ré-encodé à la main dans 5 sites (#356).
+    Renversement assumé de la note « dupliqué ici (petit, local) pour ne pas
+    coupler les deux suites de tests » qui accompagnait l'ancien
+    `test_regularisation._meta_stub` : le couplage au contrat pydantic v3
+    existait déjà, juste invisible derrière 5 copies indépendantes — et
+    `common.py` couple déjà ces suites via `client_flux_factice`/
+    `patcher_client_fabrique`. Un passage v3→v4 du contrat ne touche plus
+    qu'un seul endroit.
+
+    Les suites régul/tampon posent leurs zéros (TURPE/CTA/accise/énergie) en
+    overrides **explicites** au site d'appel plutôt que d'hériter d'un
+    wrapper local : ces zéros sont porteurs de sens (écart mesuré − facturé
+    lisible de tête), ils doivent se voir."""
+    base = dict(
+        ref_situation_contractuelle='RSC-00000000000001',
+        pdl='14000000000001',
+        mois_annee='2024-01',
+        debut='2024-01-01',
+        fin='2024-02-01',
+        nb_jours=31,
+        puissance_moyenne_kva=6.0,
+        formule_tarifaire_acheminement='CU4',
+        energie_base_kwh=280.0,
+        energie_hp_kwh=None,
+        energie_hc_kwh=None,
+        turpe_fixe_eur=8.5,
+        turpe_variable_eur=4.2,
+        cta_eur=1.1,
+        taux_accise_eur_mwh=21.0,
+        has_changement=False,
+        qualite='réelle',
+        statut_communication='communicante',
+        releves_utilises=[],
+        source_hash='hash-abc123',
+    )
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
+
+def objet_releve(**overrides):
+    """Stub duck-typé d'`ObjetReleve` (contrat v3) — stub enfant de
+    `periode_meta` (même contrat, champ `releves_utilises`) : mêmes
+    attributs, valeurs par défaut à None pour les champs optionnels du
+    contrat."""
+    base = dict(
+        releve_id='ELC-RELEVE-001',
+        date_releve='2024-01-31',
+        nature_index='reel',
+        origine_releve='flux_R151',
+        evenement=None,
+        index_base_kwh=None,
+        index_hp_kwh=None,
+        index_hc_kwh=None,
+        index_hph_kwh=None,
+        index_hch_kwh=None,
+        index_hpb_kwh=None,
+        index_hcb_kwh=None,
+    )
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
+
 # Tarif d'abonnement affine (ADR 0018) : base 3 kVA + coefficient par kVA.
 # prix_an(P) = base + coef * (P - 3)
 ABO_BASE_3KVA_STD = 150.0

--- a/tests/test_campagne_etapes_actions.py
+++ b/tests/test_campagne_etapes_actions.py
@@ -30,8 +30,7 @@ from .common import periode_meta as _periode_meta_partage
 
 def _periode_meta(**kwargs):
     """Overrides locaux de campagne (RSC/PDL/mois de mars) par-dessus le stub
-    partagé (`periode_meta`, tests/common.py, #356) — cf.
-    test_pull_meta_periodes.py."""
+    partagé (`periode_meta`, tests/common.py, #356)."""
     overrides = dict(
         ref_situation_contractuelle='RSC-CAMPAGNE-BASE',
         pdl='14000000000099',

--- a/tests/test_campagne_etapes_actions.py
+++ b/tests/test_campagne_etapes_actions.py
@@ -12,7 +12,6 @@ Dates dans la couverture de la grille de prix fixture (2024, tests/common.py).
 import os
 import runpy
 from datetime import date
-from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 from odoo.addons.souscriptions_odoo.models.core import souscription_refacturation as refacturation_module
@@ -26,34 +25,23 @@ from .common import (
     patcher_client_fabrique,
     patcher_transport,
 )
+from .common import periode_meta as _periode_meta_partage
 
 
 def _periode_meta(**kwargs):
-    """Stub duck-typé de `PeriodeMeta` (contrat v3) — cf. test_pull_meta_periodes.py."""
-    base = dict(
+    """Overrides locaux de campagne (RSC/PDL/mois de mars) par-dessus le stub
+    partagé (`periode_meta`, tests/common.py, #356) — cf.
+    test_pull_meta_periodes.py."""
+    overrides = dict(
         ref_situation_contractuelle='RSC-CAMPAGNE-BASE',
         pdl='14000000000099',
         mois_annee='2024-03',
         debut='2024-03-01',
         fin='2024-04-01',
-        nb_jours=31,
-        puissance_moyenne_kva=6.0,
-        formule_tarifaire_acheminement='CU4',
-        energie_base_kwh=280.0,
-        energie_hp_kwh=None,
-        energie_hc_kwh=None,
-        turpe_fixe_eur=8.5,
-        turpe_variable_eur=4.2,
-        cta_eur=1.1,
-        taux_accise_eur_mwh=21.0,
-        has_changement=False,
-        qualite='réelle',
-        statut_communication='communicante',
-        releves_utilises=[],
         source_hash='hash-campagne',
     )
-    base.update(kwargs)
-    return SimpleNamespace(**base)
+    overrides.update(kwargs)
+    return _periode_meta_partage(**overrides)
 
 
 @tagged('souscriptions', 'souscriptions_campagne', 'post_install', '-at_install')

--- a/tests/test_cloture_campagne.py
+++ b/tests/test_cloture_campagne.py
@@ -14,7 +14,6 @@ réel de la dernière mensuelle d'un lissé (`_tamponner_provision`).
 """
 
 from datetime import date
-from types import SimpleNamespace
 
 from odoo.tests.common import tagged
 
@@ -25,6 +24,7 @@ from .common import (
     client_sorties_factice,
     ligne_sortie,
     patcher_client_fabrique,
+    periode_meta,
 )
 
 
@@ -160,23 +160,15 @@ class TestPeriodeClotureAuReel(SouscriptionsTestCase):
 
         periode = self.env['souscription.periode']._amorcer_depuis_meta(
             souscription,
-            SimpleNamespace(
+            periode_meta(
                 ref_situation_contractuelle='RSC-CLOTURE-REEL-UNIT',
                 debut='2024-06-01',
                 fin='2024-06-12',
                 mois_annee='2024-06',
-                puissance_moyenne_kva=6.0,
                 energie_base_kwh=90.0,
-                energie_hp_kwh=None,
-                energie_hc_kwh=None,
                 turpe_fixe_eur=3.0,
                 turpe_variable_eur=1.2,
                 cta_eur=0.4,
-                taux_accise_eur_mwh=21.0,
-                has_changement=False,
-                qualite='réelle',
-                statut_communication='communicante',
-                releves_utilises=[],
                 source_hash='H-CLOTURE-REEL-UNIT',
             ),
         )
@@ -264,23 +256,15 @@ class TestRegulariserClotures(SouscriptionsTestCase):
 
         periode_juin = self.env['souscription.periode']._amorcer_depuis_meta(
             souscription,
-            SimpleNamespace(
+            periode_meta(
                 ref_situation_contractuelle='RSC-CLOTURE-REEL',
                 debut='2024-06-01',
                 fin='2024-06-12',
                 mois_annee='2024-06',
-                puissance_moyenne_kva=6.0,
                 energie_base_kwh=90.0,
-                energie_hp_kwh=None,
-                energie_hc_kwh=None,
                 turpe_fixe_eur=3.0,
                 turpe_variable_eur=1.2,
                 cta_eur=0.4,
-                taux_accise_eur_mwh=21.0,
-                has_changement=False,
-                qualite='réelle',
-                statut_communication='communicante',
-                releves_utilises=[],
                 source_hash='H-CLOTURE-REEL-JUIN',
             ),
         )
@@ -345,19 +329,13 @@ class TestRegulariserClotures(SouscriptionsTestCase):
         # electricore raffine ensuite le mesuré (nouvelle empreinte) : la
         # vraie conso des 11 jours, plus faible que le mois plein provisionné.
         periode_juin._rafraichir_depuis_meta(
-            SimpleNamespace(
+            periode_meta(
                 source_hash='H-JUIN-REEL-TRONQUE',
                 energie_base_kwh=80.0,
-                energie_hp_kwh=None,
-                energie_hc_kwh=None,
-                puissance_moyenne_kva=6.0,
                 turpe_fixe_eur=0.0,
                 turpe_variable_eur=0.0,
                 cta_eur=0.0,
                 taux_accise_eur_mwh=0.0,
-                has_changement=False,
-                qualite='réelle',
-                statut_communication='communicante',
             )
         )
         self.assertAlmostEqual(periode_juin.ecart_base_kwh, -120.0, places=2)
@@ -386,25 +364,15 @@ class TestRegulariserClotures(SouscriptionsTestCase):
 
         # Même si electricore renverrait encore une méta-période de juillet
         # pour cette RSC, le périmètre — pas le flux — est la garde.
-        meta_juillet = SimpleNamespace(
+        meta_juillet = periode_meta(
             ref_situation_contractuelle='RSC-CLOTURE-APRES',
             pdl='PDL_CLOTURE_APRES',
             mois_annee='2024-07',
             debut='2024-07-01',
             fin='2024-08-01',
-            nb_jours=31,
-            puissance_moyenne_kva=6.0,
             energie_base_kwh=200.0,
-            energie_hp_kwh=None,
-            energie_hc_kwh=None,
-            turpe_fixe_eur=8.5,
             turpe_variable_eur=3.0,
             cta_eur=1.0,
-            taux_accise_eur_mwh=21.0,
-            has_changement=False,
-            qualite='réelle',
-            statut_communication='communicante',
-            releves_utilises=[],
             source_hash='H-JUILLET-JAMAIS',
         )
         with patcher_client_fabrique(client_flux_factice('meta_periodes', [meta_juillet])):

--- a/tests/test_pull_meta_periodes.py
+++ b/tests/test_pull_meta_periodes.py
@@ -23,7 +23,6 @@ Fixtures RSC/PDL : identifiants factices (jamais des vrais échantillons).
 
 import unittest
 from datetime import date
-from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 from odoo.addons.souscriptions_odoo.models.core import electricore_client_fabrique as fabrique_module
@@ -32,56 +31,8 @@ from odoo.exceptions import UserError
 from odoo.tests.common import tagged
 
 from .common import SouscriptionsTestCase, client_flux_factice, flux_electricore, patcher_client_fabrique
-
-
-def _objet_releve(**kwargs):
-    """Stub duck-typé d'`ObjetReleve` (contrat v3) : mêmes attributs, valeurs
-    par défaut à None pour les champs optionnels du contrat."""
-    base = dict(
-        releve_id='ELC-RELEVE-001',
-        date_releve='2024-01-31',
-        nature_index='reel',
-        origine_releve='flux_R151',
-        evenement=None,
-        index_base_kwh=None,
-        index_hp_kwh=None,
-        index_hc_kwh=None,
-        index_hph_kwh=None,
-        index_hch_kwh=None,
-        index_hpb_kwh=None,
-        index_hcb_kwh=None,
-    )
-    base.update(kwargs)
-    return SimpleNamespace(**base)
-
-
-def _periode_meta(**kwargs):
-    """Stub duck-typé de `PeriodeMeta` (contrat v3) : mêmes attributs que le
-    modèle pydantic réel, mêmes noms — le mapping ne fait aucune traduction."""
-    base = dict(
-        ref_situation_contractuelle='RSC-00000000000001',
-        pdl='14000000000001',
-        mois_annee='2024-01',
-        debut='2024-01-01',
-        fin='2024-02-01',
-        nb_jours=31,
-        puissance_moyenne_kva=6.0,
-        formule_tarifaire_acheminement='CU4',
-        energie_base_kwh=280.0,
-        energie_hp_kwh=None,
-        energie_hc_kwh=None,
-        turpe_fixe_eur=8.5,
-        turpe_variable_eur=4.2,
-        cta_eur=1.1,
-        taux_accise_eur_mwh=21.0,
-        has_changement=False,
-        qualite='réelle',
-        statut_communication='communicante',
-        releves_utilises=[],
-        source_hash='hash-abc123',
-    )
-    base.update(kwargs)
-    return SimpleNamespace(**base)
+from .common import objet_releve as _objet_releve
+from .common import periode_meta as _periode_meta
 
 
 @tagged('souscriptions', 'souscriptions_pull_meta', 'post_install', '-at_install')

--- a/tests/test_regularisation.py
+++ b/tests/test_regularisation.py
@@ -14,7 +14,6 @@ candidats.
 """
 
 from datetime import date
-from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 from odoo.exceptions import UserError, ValidationError
@@ -28,34 +27,8 @@ from .common import (
     client_flux_factice,
     flux_electricore,
     patcher_client_fabrique,
+    periode_meta,
 )
-
-
-def _meta_stub(**kwargs):
-    """Stub duck-typé minimal de `PeriodeMeta` (contrat v3) — mêmes attributs
-    que le stub de test_pull_meta_periodes.py, dupliqué ici (petit, local)
-    pour ne pas coupler les deux suites de tests."""
-    base = dict(
-        ref_situation_contractuelle='RSC-REGUL-AC4',
-        debut='2024-02-01',
-        fin='2024-03-01',
-        mois_annee='2024-02',
-        puissance_moyenne_kva=6.0,
-        energie_base_kwh=230.0,
-        energie_hp_kwh=None,
-        energie_hc_kwh=None,
-        turpe_fixe_eur=0.0,
-        turpe_variable_eur=0.0,
-        cta_eur=0.0,
-        taux_accise_eur_mwh=0.0,
-        has_changement=False,
-        qualite='réelle',
-        statut_communication='communicante',
-        releves_utilises=[],
-        source_hash='H-FEB',
-    )
-    base.update(kwargs)
-    return SimpleNamespace(**base)
 
 
 @tagged('souscriptions', 'souscriptions_regularisation', 'post_install', '-at_install')
@@ -262,7 +235,22 @@ class TestRegularisationCandidats(SouscriptionsTestCase):
         # nouvelle empreinte -> rafraîchie).
         client.meta_periodes.side_effect = [
             flux_electricore([]),
-            flux_electricore([_meta_stub()]),
+            flux_electricore(
+                [
+                    periode_meta(
+                        ref_situation_contractuelle='RSC-REGUL-AC4',
+                        debut='2024-02-01',
+                        fin='2024-03-01',
+                        mois_annee='2024-02',
+                        energie_base_kwh=230.0,
+                        turpe_fixe_eur=0.0,
+                        turpe_variable_eur=0.0,
+                        cta_eur=0.0,
+                        taux_accise_eur_mwh=0.0,
+                        source_hash='H-FEB',
+                    )
+                ]
+            ),
         ]
 
         regularisation = self.env['souscription.regularisation'].create({'souscription_id': souscription.id})

--- a/tests/test_regularisation_tampon.py
+++ b/tests/test_regularisation_tampon.py
@@ -10,39 +10,17 @@ facture qui la porte.
 """
 
 from datetime import date
-from types import SimpleNamespace
 
 from odoo.exceptions import UserError
 from odoo.tests.common import tagged
 
-from .common import SouscriptionsTestCase, build_grille_lignes, client_flux_factice, patcher_client_fabrique
-
-
-def _meta_stub(**kwargs):
-    """Stub duck-typé minimal de `PeriodeMeta` (contrat v3), même idiome que
-    test_regularisation.py — simule un mesuré raffiné (nouvelle empreinte)
-    après le solde d'une première Régularisation (AC « re-régul »)."""
-    base = dict(
-        ref_situation_contractuelle='RSC-TAMPON',
-        debut='2024-01-01',
-        fin='2024-02-01',
-        mois_annee='2024-01',
-        puissance_moyenne_kva=6.0,
-        energie_base_kwh=0.0,
-        energie_hp_kwh=None,
-        energie_hc_kwh=None,
-        turpe_fixe_eur=0.0,
-        turpe_variable_eur=0.0,
-        cta_eur=0.0,
-        taux_accise_eur_mwh=0.0,
-        has_changement=False,
-        qualite='réelle',
-        statut_communication='communicante',
-        releves_utilises=[],
-        source_hash='H-TAMPON',
-    )
-    base.update(kwargs)
-    return SimpleNamespace(**base)
+from .common import (
+    SouscriptionsTestCase,
+    build_grille_lignes,
+    client_flux_factice,
+    patcher_client_fabrique,
+    periode_meta,
+)
 
 
 @tagged('souscriptions', 'souscriptions_regularisation', 'post_install', '-at_install')
@@ -267,7 +245,20 @@ class TestRegularisationTamponEmission(SouscriptionsTestCase):
 
         # Mesuré raffiné (nouvelle empreinte, exemption ciblée du verrou #235) :
         # l'écart renaît.
-        periode._rafraichir_depuis_meta(_meta_stub(source_hash='H-TAMPON-REFINE', energie_base_kwh=235.0))
+        periode._rafraichir_depuis_meta(
+            periode_meta(
+                ref_situation_contractuelle='RSC-TAMPON',
+                debut='2024-01-01',
+                fin='2024-02-01',
+                mois_annee='2024-01',
+                turpe_fixe_eur=0.0,
+                turpe_variable_eur=0.0,
+                cta_eur=0.0,
+                taux_accise_eur_mwh=0.0,
+                source_hash='H-TAMPON-REFINE',
+                energie_base_kwh=235.0,
+            )
+        )
         self.assertAlmostEqual(periode.ecart_base_kwh, 15.0, places=2)
 
         regularisation2 = self.env['souscription.regularisation'].create({'souscription_id': souscription.id})


### PR DESCRIPTION
Closes #356

Centralise le stub duck-typé du contrat electricore PeriodeMeta v3 (ADR 0011/0020)
dans la couture de test nommée `tests/common.py` (ADR 0024 §6) : `periode_meta`
et son stub enfant `objet_releve` remplacent les 5 encodages manuels dispersés
dans test_pull_meta_periodes/test_campagne_etapes_actions/test_regularisation/
test_regularisation_tampon/test_cloture_campagne. Les suites régul/tampon
posent leurs zéros TURPE/CTA/accise/énergie en overrides explicites au site
d'appel — porteurs de sens, ils doivent se voir. Pur refactor de tests : zéro
code de prod touché, zéro assertion changée, test_chronologie.py (contrat v1)
intact.

Suite complète (docker, `--test-tags /souscriptions_odoo`) : 0 failed, 0 error(s) of 774 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)