### PR TITLE
refactor(electricore): traduire_exceptions_electricore() — le vocabulaire d'erreur en un point (#360)

### DIFF
--- a/docs/adr/0024-electricore-dependance-molle-garde-import-fabrique-client-unique.md
+++ b/docs/adr/0024-electricore-dependance-molle-garde-import-fabrique-client-unique.md
@@ -13,6 +13,10 @@ Odoo consomme electricore via le paquet fin `electricore-client` ([ADR-0019](001
 5. **Échec rapide et déterministe.** Chaque action acquiert le client **en tête** (`client()`), avant tout travail dépendant des données : un même clic produit toujours la même classe de résultat. La construction **n'ouvre aucune socket** (le HTTP n'a lieu qu'à l'ouverture du flux / à l'appel batch), donc l'échec précoce est gratuit.
 6. **Couture de test par endpoint.** Chaque appelant patche **sa** méthode de transport nommée (`_appeler` côté RSC — inchangée ; `_ouvrir_flux` côté pull) et retourne une réponse en boîte, sans construire de client. La **fabrique** a son propre petit test (paquet manquant / config manquante / construction), là où ces gardes se testaient auparavant **en double**.
 
+## Amendement (#360, 19/07)
+
+La *traduction* du vocabulaire d'exceptions (`IngestionEnCours`/`PreconditionNonRemplie`/`ContractVersionError` → `UserError`) vit désormais dans un unique `traduire_exceptions_electricore()` (module de la fabrique) ; la structure par appelant — chaque endpoint garde son appel, chacun sa forme (lot ↔ flux) — demeure inchangée. Ce n'est **pas** la « fabrique de transport complète » écartée ci-dessous (aucun appel d'endpoint ne bouge) : un futur audit ne doit pas lire ce context manager comme une violation de cet ADR.
+
 ## Conséquences
 
 - Le module reste **installable partout** ; le déploiement doit `pip install electricore-client` (odoo.sh / Docker) — une **étape de build**, pas une dépendance de manifeste.

--- a/models/core/electricore_client_fabrique.py
+++ b/models/core/electricore_client_fabrique.py
@@ -25,13 +25,21 @@ chronologie) importent `ContractVersionError`/`IngestionEnCours`/
 `PreconditionNonRemplie` depuis **ce** module plutôt que de porter chacun sa
 propre garde d'import + ses propres stubs de repli — un seul point d'origine,
 réel si le paquet est présent, stub sinon.
+
+`traduire_exceptions_electricore()` (#360) : la traduction de ce vocabulaire
+en `UserError` actionnable est elle aussi partagée — cinq sites la
+répétaient à l'identique (un seul `_()`, un seul `from exc`). Chaque
+appelant garde son propre appel d'endpoint et sa propre structure ; seul le
+corps du mapping, strictement identique partout, vit ici (ADR 0024, cf.
+amendement).
 """
 
 from __future__ import annotations
 
 import os
+from contextlib import contextmanager
 
-from odoo import models
+from odoo import _, models
 from odoo.exceptions import UserError
 
 try:
@@ -56,6 +64,21 @@ except ImportError:  # pragma: no cover - exercé par test_electricore_client_fa
 
     class PreconditionNonRemplie(Exception):
         """Repli si `electricore_client` est absent : jamais levée en pratique."""
+
+
+@contextmanager
+def traduire_exceptions_electricore():
+    """Traduit le vocabulaire d'exceptions electricore en UserError
+    actionnables. La structure par appelant reste (ADR 0024) — chaque
+    endpoint garde son appel ; seul le corps identique du mapping vit ici."""
+    try:
+        yield
+    except IngestionEnCours as exc:
+        raise UserError(_("L'ingestion electricore est en cours (verrou base) : réessayez plus tard.")) from exc
+    except PreconditionNonRemplie as exc:
+        raise UserError(_('Précondition non remplie côté electricore : %s', exc)) from exc
+    except ContractVersionError as exc:
+        raise UserError(_('Contrat electricore obsolète : %s', exc)) from exc
 
 
 class SouscriptionElectricoreClient(models.AbstractModel):

--- a/models/core/electricore_client_fabrique.py
+++ b/models/core/electricore_client_fabrique.py
@@ -15,9 +15,10 @@ chargement du module, seul l'appel à `client()` échoue, avec un message
 actionnable.
 
 Chaque appelant garde son propre appel d'endpoint (`resoudre_rsc` en lot ↔
-`meta_periodes` en flux) et son propre mapping d'exceptions : cette fabrique
-s'arrête à « rends-moi un client configuré » (ADR 0024 §4, option écartée
-« fabrique de transport complète »).
+`meta_periodes` en flux) : cette fabrique s'arrête à « rends-moi un client
+configuré » (ADR 0024 §4, option écartée « fabrique de transport complète »).
+Seule la *traduction* du vocabulaire d'exceptions est partagée depuis #360
+(cf. plus bas) — pas l'appel d'endpoint lui-même.
 
 Ré-export des exceptions du contrat (#222, tranche 2 du PRD #219) : les
 quatre appelants (résolution RSC, pull méta-périodes, refacturation F15,

--- a/models/core/electricore_rsc_service.py
+++ b/models/core/electricore_rsc_service.py
@@ -4,8 +4,10 @@
 Le client electricore est acquis auprès de la fabrique unique
 `souscription.electricore.client` (ADR 0024) : ce module ne porte plus ni
 garde d'import, ni drapeau de disponibilité, ni lecture de config — seul son
-propre appel d'endpoint (`resoudre_rsc` en lot) et son mapping d'exception
-(`ContractVersionError`, ré-exportée par la fabrique — #222).
+propre appel d'endpoint (`resoudre_rsc` en lot). La traduction d'exception
+(`ContractVersionError` -> `UserError`) passe par
+`traduire_exceptions_electricore()` (#360), partagée avec les quatre autres
+sites — ce module ne porte plus son propre mapping.
 
 C'est l'unique point du module qui parle réseau pour la résolution RSC ; le
 pull des périodes (#12) s'y branchera plus tard.
@@ -14,9 +16,11 @@ pull des périodes (#12) s'y branchera plus tard.
 from __future__ import annotations
 
 from odoo import models
-from odoo.exceptions import UserError
 
-from .electricore_client_fabrique import ContractVersionError
+# `ContractVersionError` n'est plus attrapée ici (le mapping vit dans
+# `traduire_exceptions_electricore()`, #360) mais reste importée : couture de
+# test — `test_rsc_service.py` construit `service_module.ContractVersionError(...)`.
+from .electricore_client_fabrique import ContractVersionError, traduire_exceptions_electricore  # noqa: F401
 
 
 class SouscriptionRscService(models.AbstractModel):
@@ -44,10 +48,8 @@ class SouscriptionRscService(models.AbstractModel):
         ids = list(ids)
         if not ids:
             return {}
-        try:
+        with traduire_exceptions_electricore():
             resultats = self._appeler(ids)
-        except ContractVersionError as exc:
-            raise UserError(f'Contrat electricore obsolète : {exc}') from exc
         return {r.id_affaire: r for r in resultats}
 
     def _appeler(self, ids):

--- a/models/core/souscription_chronologie.py
+++ b/models/core/souscription_chronologie.py
@@ -12,7 +12,8 @@ pourrait un jour exposer la vue point, hors périmètre ici). Exceptions du
 mapping ré-exportées par la fabrique (ADR 0024, #222), même posture que le
 pull des méta-périodes (`souscription_pull_meta_periodes_service.py`) :
 la fabrique s'arrête à « rends-moi un client configuré », chaque appelant
-garde son appel d'endpoint et son propre mapping.
+garde son appel d'endpoint — la traduction du mapping, elle, est partagée
+(`traduire_exceptions_electricore()`, #360).
 """
 
 from __future__ import annotations
@@ -20,7 +21,15 @@ from __future__ import annotations
 from odoo import api, fields, models
 from odoo.exceptions import UserError
 
-from .electricore_client_fabrique import ContractVersionError, IngestionEnCours, PreconditionNonRemplie
+# ContractVersionError/IngestionEnCours/PreconditionNonRemplie ne sont plus
+# attrapées ici (mapping partagé, `traduire_exceptions_electricore()`, #360)
+# mais restent importées : couture de test (`chronologie_module.<Nom>(...)`).
+from .electricore_client_fabrique import (  # noqa: F401
+    ContractVersionError,
+    IngestionEnCours,
+    PreconditionNonRemplie,
+    traduire_exceptions_electricore,
+)
 
 
 class SouscriptionChronologieLigne(models.Model):
@@ -189,16 +198,9 @@ class Souscription(models.Model):
         Ligne = self.env['souscription.chronologie.ligne']
 
         vals_list = []
-        try:
-            with self._ouvrir_flux(client, self.ref_situation_contractuelle) as stream:
-                for ligne in stream:
-                    vals_list.append(Ligne._vals_depuis_ligne(self, ligne))
-        except IngestionEnCours:
-            raise UserError("L'ingestion electricore est en cours (verrou base) : réessayez plus tard.")
-        except PreconditionNonRemplie as exc:
-            raise UserError(f'Précondition non remplie côté electricore : {exc}')
-        except ContractVersionError as exc:
-            raise UserError(f'Contrat electricore obsolète : {exc}')
+        with traduire_exceptions_electricore(), self._ouvrir_flux(client, self.ref_situation_contractuelle) as stream:
+            for ligne in stream:
+                vals_list.append(Ligne._vals_depuis_ligne(self, ligne))
 
         Ligne.search([('souscription_id', '=', self.id)]).unlink()
         if vals_list:

--- a/models/core/souscription_pull_meta_periodes_service.py
+++ b/models/core/souscription_pull_meta_periodes_service.py
@@ -45,9 +45,16 @@ from datetime import timedelta
 
 from dateutil.relativedelta import relativedelta
 from odoo import fields, models
-from odoo.exceptions import UserError
 
-from .electricore_client_fabrique import ContractVersionError, IngestionEnCours, PreconditionNonRemplie
+# Exceptions du mapping electricore : la traduction en UserError vit dans
+# `traduire_exceptions_electricore()` (#360). Les trois noms d'exception
+# restent importés : couture de test (`service_module.ContractVersionError(...)`).
+from .electricore_client_fabrique import (  # noqa: F401
+    ContractVersionError,
+    IngestionEnCours,
+    PreconditionNonRemplie,
+    traduire_exceptions_electricore,
+)
 
 # Verdicts electricore jugés fiables pour écraser le mesuré stocké (ADR 0030
 # décision 1) — les termes du glossaire electricore, accents compris
@@ -141,42 +148,38 @@ class SouscriptionPullMetaPeriodesService(models.AbstractModel):
         mois_str = fields.Date.to_string(mois_cle_requete)
         rsc_traitees = set()
 
-        try:
-            with self._ouvrir_flux(client, mois_str, list(par_rsc)) as stream:
-                for meta in stream:
-                    souscription = par_rsc.get(meta.ref_situation_contractuelle)
-                    if souscription is None:
-                        continue  # RSC hors du filtre demandé, ignorée silencieusement
-                    rsc_traitees.add(meta.ref_situation_contractuelle)
-                    try:
-                        # Savepoint par élément (skip-and-report, ADR 0011) :
-                        # un échec de mapping/contrainte sur une RSC ne doit
-                        # ni écrire de résultat partiel ni casser le curseur
-                        # pour les RSC suivantes du même lot.
-                        with self.env.cr.savepoint():
-                            self._appliquer_une(
-                                Periode,
-                                souscription,
-                                meta,
-                                creer_manquantes=creer_manquantes,
-                                creees=creees,
-                                rafraichies=rafraichies,
-                                inchangees=inchangees,
-                                conservees=conservees,
-                            )
-                    except Exception as exc:
-                        # Skip-and-report durable (#341, ADR 0036 décision
-                        # 8a) : l'erreur va au chatter de la souscription
-                        # fautive, au point d'échec, pour les deux chemins
-                        # (bouton manuel ET futur automate d'amorçage).
-                        souscription.message_post(body=f'Pull méta-périodes ({mois_str}) : échec — {exc}')
-                        erreurs.append(f'{souscription.name} ({mois_str}) : {exc}')
-        except IngestionEnCours:
-            raise UserError("L'ingestion electricore est en cours (verrou base) : réessayez plus tard.")
-        except PreconditionNonRemplie as exc:
-            raise UserError(f'Précondition non remplie côté electricore : {exc}')
-        except ContractVersionError as exc:
-            raise UserError(f'Contrat electricore obsolète : {exc}')
+        with (
+            traduire_exceptions_electricore(),
+            self._ouvrir_flux(client, mois_str, list(par_rsc)) as stream,
+        ):
+            for meta in stream:
+                souscription = par_rsc.get(meta.ref_situation_contractuelle)
+                if souscription is None:
+                    continue  # RSC hors du filtre demandé, ignorée silencieusement
+                rsc_traitees.add(meta.ref_situation_contractuelle)
+                try:
+                    # Savepoint par élément (skip-and-report, ADR 0011) :
+                    # un échec de mapping/contrainte sur une RSC ne doit
+                    # ni écrire de résultat partiel ni casser le curseur
+                    # pour les RSC suivantes du même lot.
+                    with self.env.cr.savepoint():
+                        self._appliquer_une(
+                            Periode,
+                            souscription,
+                            meta,
+                            creer_manquantes=creer_manquantes,
+                            creees=creees,
+                            rafraichies=rafraichies,
+                            inchangees=inchangees,
+                            conservees=conservees,
+                        )
+                except Exception as exc:
+                    # Skip-and-report durable (#341, ADR 0036 décision
+                    # 8a) : l'erreur va au chatter de la souscription
+                    # fautive, au point d'échec, pour les deux chemins
+                    # (bouton manuel ET futur automate d'amorçage).
+                    souscription.message_post(body=f'Pull méta-périodes ({mois_str}) : échec — {exc}')
+                    erreurs.append(f'{souscription.name} ({mois_str}) : {exc}')
 
         # Mois absent du flux (ADR 0030 décision 1) : une Période déjà
         # amorcée dont la RSC n'est pas revenue dans ce lot est conservée et
@@ -273,14 +276,8 @@ class SouscriptionPullMetaPeriodesService(models.AbstractModel):
         if not par_rsc:
             return ecrites, corrigees, inchangees, erreurs
 
-        try:
+        with traduire_exceptions_electricore():
             lignes = self._appeler_sorties(client, list(par_rsc))
-        except IngestionEnCours:
-            raise UserError("L'ingestion electricore est en cours (verrou base) : réessayez plus tard.")
-        except PreconditionNonRemplie as exc:
-            raise UserError(f'Précondition non remplie côté electricore : {exc}')
-        except ContractVersionError as exc:
-            raise UserError(f'Contrat electricore obsolète : {exc}')
 
         for ligne in lignes:
             souscription = par_rsc.get(ligne.ref_situation_contractuelle)

--- a/models/core/souscription_refacturation.py
+++ b/models/core/souscription_refacturation.py
@@ -1,12 +1,16 @@
 import logging
 
 from odoo import _, api, fields, models
-from odoo.exceptions import UserError
 
-# Exceptions du mapping de ce module, ré-exportées par la fabrique unique
-# (ADR 0024, #222) : la construction du client (garde + drapeau + config) vit
-# dans la fabrique, seule la correspondance d'exceptions reste ici.
-from .electricore_client_fabrique import ContractVersionError, IngestionEnCours, PreconditionNonRemplie
+# Exceptions du mapping electricore : la traduction en UserError vit dans
+# `traduire_exceptions_electricore()` (#360). Les trois noms d'exception
+# restent importés : couture de test (`refacturation_module.ContractVersionError(...)`).
+from .electricore_client_fabrique import (  # noqa: F401
+    ContractVersionError,
+    IngestionEnCours,
+    PreconditionNonRemplie,
+    traduire_exceptions_electricore,
+)
 
 _logger = logging.getLogger(__name__)
 
@@ -123,14 +127,8 @@ class SouscriptionRefacturation(models.Model):
             (toast) et par tout appelant non-UI (automate d'amorçage, tests).
         """
         client = self.env['souscription.electricore.client'].client()
-        try:
+        with traduire_exceptions_electricore():
             lignes = self._tirer_prestations(client)
-        except IngestionEnCours:
-            raise UserError(_("L'ingestion electricore est en cours (verrou base) : réessayez plus tard."))
-        except PreconditionNonRemplie as exc:
-            raise UserError(_('Précondition non remplie côté electricore : %s', exc))
-        except ContractVersionError as exc:
-            raise UserError(_('Contrat electricore obsolète : %s', exc))
         return self._inserer_prestations(lignes)
 
     def synchroniser_depuis_electricore(self):


### PR DESCRIPTION
Closes #360

Extrait la traduction du vocabulaire d'exceptions electricore
(IngestionEnCours/PreconditionNonRemplie/ContractVersionError → UserError)
en un context manager unique, `traduire_exceptions_electricore()`, dans le
module de la fabrique client (ADR 0024). Les 5 sites qui la répétaient
(RSC, méta-périodes, sorties C15, sync F15, chronologie) passent
maintenant par `with traduire_exceptions_electricore():` — un seul `_()`,
un seul `from exc`, textes FR inchangés. ADR 0024 amendé pour prévenir
toute lecture future comme régression vers la « fabrique de transport
complète » écartée.

Suite complète : 0 failed, 0 error(s) of 774 tests (docker, --test-tags /souscriptions_odoo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)