### PR TITLE
docs(facture): carte de la régénération au fil de l'eau — points d'entrée (a)-(d) et clés de contexte in-repo (#364)

### DIFF
--- a/models/core/account_move.py
+++ b/models/core/account_move.py
@@ -166,7 +166,10 @@ class AccountMove(models.Model):
         Facture d'énergie porte `periode_id`/`regularisation_id` (pas
         `copy=False`, CONTEXT.md « Avoir ») mais n'est jamais *la* facture
         de sa source — sans ce filtre il serait recomposé depuis la Période
-        (lignes doublées) et raflerait les Refacturations en file."""
+        (lignes doublées) et raflerait les Refacturations en file.
+
+        Filet final de la régénération au fil de l'eau : carte complète (5
+        points d'entrée, 4 clés de contexte) dans la bannière ci-dessous."""
         a_regenerer = self.filtered(
             lambda m: m.is_facture_energie and m.state == 'draft' and m._facture_de_la_source() == m
         )
@@ -196,9 +199,39 @@ class AccountMove(models.Model):
         null') remet les Refacturations rassemblées en file, et le statut de
         facturation de la Souscription (dérivé, ADR 0025 §2) retombe tout
         seul à « à facturer » — la cascade native suffit, aucun code dédié
-        ici."""
+        ici.
+
+        Producteur de la clé de contexte `souscription_move_unlink` : carte
+        complète dans la bannière « Régénération au fil de l'eau » ci-dessous."""
         self = self.with_context(souscription_move_unlink=True)
         return super().unlink()
+
+    # === Régénération au fil de l'eau (#267, carte #364) ===
+    #
+    # Invariant : le brouillon = sa source à l'instant T + les lignes
+    # manuelles (#266). Tout converge vers `_recomposer_lignes_generees`
+    # ci-dessous, DÉCLENCHÉ par 5 points d'entrée dans 4 fichiers — l'ORM
+    # impose cet éparpillement (verrou ici, dédup là), le mécanisme central
+    # reste unique. Carte, pas refactor : les lettres (a)-(d) citées par les
+    # docstrings des sites sont définies UNIQUEMENT ici.
+    #
+    # Points d'entrée :
+    #   (a) pull méta-périodes -> `souscription.periode._rafraichir_depuis_meta`
+    #   (b) édition facturable  -> `souscription.periode.write()`
+    #   (c) insertion F15       -> `souscription.refacturation._recomposer_brouillons_mensuels`
+    #   (d) recalcul régul      -> `souscription.regularisation.action_recalculer`
+    #   + filet final à l'émission : `_post()` ci-dessus (ordre : cf. sa docstring)
+    #
+    # Clés de contexte (produite par -> consommée par : effet) :
+    #   regularisation_tampon        `regularisation._solder_provisions` -> `periode.write` : lève le verrou #14
+    #   souscription_tampon_emission `periode._tamponner_provision` -> `periode.write` : évite une double recomposition
+    #   souscription_regenere_lignes `_recomposer_lignes_generees` -> `account.move.line.ondelete` : lève la garde #266
+    #   souscription_move_unlink     `unlink()` ci-dessus -> `account.move.line.ondelete` : lève la garde #266
+    #
+    # Risque connu (PR #259, non résolu) : re-poster un move de Régularisation
+    # (post -> button_draft -> re-post) rejoue `_solder_provisions` (+=) —
+    # gardé par `_verifier_regularisation_emise_immuable` ci-dessous, qui
+    # interdit le `button_draft`/`button_cancel` d'une régularisation ÉMISE.
 
     # === Provenance des lignes (#266, tranche 2 du PRD #264, ADR 0014 amendé) ===
     #
@@ -258,7 +291,12 @@ class AccountMove(models.Model):
 
         Contexte `souscription_regenere_lignes` : lève la garde `ondelete`
         (#266) pour la suppression, ici, des lignes flaguées qu'on remplace —
-        seule cette méthode (et `unlink()`, cascade) pose ce contexte."""
+        seule cette méthode (et `unlink()`, cascade) pose ce contexte.
+
+        Mécanisme central de la régénération au fil de l'eau (#267) : les 5
+        points d'entrée et le protocole de contexte sont cartographiés dans
+        la bannière « Régénération au fil de l'eau », plus haut dans ce
+        fichier."""
         self.ensure_one()
         self.invoice_line_ids.filtered('souscription_ligne_generee').with_context(
             souscription_regenere_lignes=True

--- a/models/core/account_move_line.py
+++ b/models/core/account_move_line.py
@@ -48,7 +48,10 @@ class AccountMoveLine(models.Model):
 
         Une facture déjà **postée** n'a pas besoin de cette garde :
         l'immutabilité comptable (Odoo core) bloque déjà toute suppression de
-        ligne."""
+        ligne.
+
+        Consommateur des deux clés de contexte ci-dessus : carte complète
+        (« Régénération au fil de l'eau ») dans `account_move.py`."""
         if self.env.context.get('souscription_move_unlink') or self.env.context.get('souscription_regenere_lignes'):
             return
         for ligne in self:

--- a/models/core/souscription_periode.py
+++ b/models/core/souscription_periode.py
@@ -447,7 +447,11 @@ class SouscriptionPeriode(models.Model):
         `souscription_tampon_emission` (posé uniquement par
         `_tamponner_provision`) : la re-génération de `account.move._post()`
         suit immédiatement le tampon dans le même événement d'émission,
-        inutile de la déclencher deux fois."""
+        inutile de la déclencher deux fois.
+
+        Point d'entrée (b), et consommateur des deux clés de contexte
+        ci-dessus : carte complète dans la bannière « Régénération au fil de
+        l'eau » de `account_move.py`."""
         champs_geles = self._LOCKED_FIELDS.intersection(vals)
         if champs_geles and not self.env.context.get('regularisation_tampon'):
             for periode in self:
@@ -854,7 +858,9 @@ class SouscriptionPeriode(models.Model):
         du mesuré déclenche lui-même la recomposition d'un brouillon lié
         (`_CHAMPS_MESURE_COMPOSES`, suivi de review #271) — les vals
         d'atterrissage portent toujours les énergies/TURPE, un seul mécanisme
-        suffit, plus d'appel explicite ici."""
+        suffit, plus d'appel explicite ici. Carte complète des 5 points
+        d'entrée : bannière « Régénération au fil de l'eau » dans
+        `account_move.py`."""
         self.ensure_one()
         vals = self._vals_atterrissage_v3(meta)
         if not self._est_facturee_emise():
@@ -928,6 +934,10 @@ class SouscriptionPeriode(models.Model):
         la ré-émettre rejoue ce tampon aux valeurs courantes de ``energie_*``
         — la future « régularisation des réels » d'un non-lissé rééditée par
         Enedis emprunte le même mécanisme.
+
+        Producteur de la clé de contexte `souscription_tampon_emission` :
+        carte complète dans la bannière « Régénération au fil de l'eau » de
+        `account_move.py`.
         """
         self.ensure_one()
         if not self._a_tamponner():

--- a/models/core/souscription_refacturation.py
+++ b/models/core/souscription_refacturation.py
@@ -262,7 +262,10 @@ class SouscriptionRefacturation(models.Model):
         que le·la facturiste voie tout de suite la ligne rassemblée sur le
         document qu'il·elle s'apprête à émettre. Aucun effet sur une facture
         déjà émise (filtre `state == 'draft'`) : la re-génération à
-        l'émission (#266) reste le filet de sécurité final."""
+        l'émission (#266) reste le filet de sécurité final.
+
+        Point d'entrée (c) : carte complète des 5 points d'entrée dans la
+        bannière « Régénération au fil de l'eau » de `account_move.py`."""
         if not souscription_ids:
             return
         brouillons = self.env['account.move'].search(

--- a/models/core/souscription_regularisation.py
+++ b/models/core/souscription_regularisation.py
@@ -115,7 +115,10 @@ class SouscriptionRegularisation(models.Model):
         déjà lié (``_recalculer`` l'autorise tant qu'il n'est pas ÉMIS), ses
         lignes générées sont recomposées juste après — le·la facturiste voit
         immédiatement l'effet du recalcul sur le document, sans devoir
-        rouvrir la Facture."""
+        rouvrir la Facture.
+
+        Point d'entrée (d) : carte complète des 5 points d'entrée dans la
+        bannière « Régénération au fil de l'eau » de `account_move.py`."""
         self.ensure_one()
         self._recalculer()
         if self.facture_id.state == 'draft':
@@ -422,7 +425,11 @@ class SouscriptionRegularisation(models.Model):
         `account.move._post()` sur les moves qui viennent d'être postés,
         jamais un second effet non idempotent ajouté) : poser un booléen à
         `True` deux fois est un non-événement, donc un re-post n'aggrave rien
-        de ce côté-là."""
+        de ce côté-là.
+
+        Producteur de la clé de contexte `regularisation_tampon` : carte
+        complète dans la bannière « Régénération au fil de l'eau » de
+        `account_move.py`."""
         self.ensure_one()
         for ligne in self.ligne_ids:
             champ = f'provision_{ligne.cadran}_kwh'


### PR DESCRIPTION
Closes #364

Documente en UN endroit le câblage de la régénération au fil de l'eau du brouillon de Facture (#267) : bannière dans `account_move.py` (même idiome que « Provenance des lignes » #266) donnant l'invariant, les 5 points d'entrée (a)-(d) + le filet final `_post()`, la table des 4 clés de contexte (producteur -> consommateur : effet), et le risque connu de re-post régul.

Chaque site de déclenchement et chaque producteur/consommateur de clé gagne un renvoi d'une ligne vers la carte, sans réécriture des docstrings existantes.

Doc-only : aucun comportement changé, `git diff` ne touche que des commentaires/docstrings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)