### PR TITLE
fix(raccordement) : estimation des provisions via electricore-client — la brèche requests se referme (#229)

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -21,7 +21,7 @@ Journeys de capacités (`REQ-XXX-nn`), chacune avec un statut (✅ Proven · ⚠
 - REQ-SOU-01 ✅ souscription base ou HP/HC avec provisions par cadran — preuve: tests/test_souscription.py::test_souscription_creation
 - REQ-SOU-02 ✅ tarif solidaire et majoration pro — preuve: tests/test_souscription.py::test_tarif_solidaire
 - REQ-SOU-03 ✅ identité Enedis : RSC unique, id_affaire, recherche — preuve: tests/test_souscription_etat.py::test_rsc_dupliquee_refusee · #15
-- REQ-SOU-04 ✅ estimation automatique des provisions (electricore) — preuve: tests/test_estimation_provisions.py · #121
+- REQ-SOU-04 ✅ estimation automatique des provisions (electricore, `client.provision_estimation(pdl)` — dernière brèche `requests` hors fabrique refermée, ADR 0024 restauré) : `IngestionEnCours`/`PreconditionNonRemplie` → notification non bloquante + chatter, `ContractVersionError` → `UserError` (garde de version côté client, plus de vérification manuelle) — preuve: tests/test_estimation_provisions.py · #121, #229
 - REQ-SOU-05 ✅ journal de consentement append-only — preuve: tests/test_documents_contractuels.py::test_journal_est_append_only_en_ecriture
 - REQ-SOU-06 ✅ conditions particulières et attestation PDF — preuve: tests/test_documents_contractuels.py
 - REQ-SOU-07 ✅ droits resserrés user/manager sur souscriptions et grilles — preuve: tests/test_security.py · #17

--- a/models/raccordement/raccordement_demande.py
+++ b/models/raccordement/raccordement_demande.py
@@ -1,10 +1,18 @@
 import logging
 import re
 
-import requests
 from odoo import api, fields, models
 from odoo.addons.base_iban.models.res_partner_bank import validate_iban
 from odoo.exceptions import UserError, ValidationError
+
+# Trio ré-exporté par la fabrique (#222/#360, ADR 0024) : la garde de version
+# vit désormais dans le client (ContractVersionError), IngestionEnCours et
+# PreconditionNonRemplie couvrent le flux R67 absent (typé upstream, #229).
+# Importés ici (pas `traduire_exceptions_electricore()`) : ce bouton a un
+# mapping propre, distinct de celui des quatre appelants frères — les deux
+# premières deviennent une notification non bloquante plutôt qu'une
+# UserError, cf. action_estimer_provisions.
+from ..core.electricore_client_fabrique import ContractVersionError, IngestionEnCours, PreconditionNonRemplie
 
 _logger = logging.getLogger(__name__)
 
@@ -676,38 +684,37 @@ class RaccordementDemande(models.Model):
         self.sepa_mandate_ref = mandat.name
         self.message_post(body=f'Mandat SEPA créé et actif (RUM : {mandat.name}).')
 
-    # --- Estimation des provisions (#121, GET /provision/estimation) ---
+    # --- Estimation des provisions (#121, `provision_estimation`, #229) ---
     #
     # Bouton seulement, pas d'auto-déclenchement au drag kanban : un appel
     # réseau dans write() bloquerait la transaction du drag-and-drop — le
     # bouton suffit (l'AC de l'issue accepte « bouton, et/ou auto »).
 
-    _CONTRACT_VERSION_ESTIMATION_ATTENDU = 1
-
     def action_estimer_provisions(self):
         """Bouton « Estimer les provisions » (visible à l'étape « Calcul de
         mensualités en cours ») : interroge electricore
-        (GET /provision/estimation) et pré-remplit les provisions selon le
-        tarif. L'humain garde la main — les champs restent éditables — et
-        l'absence de données (trouve=False, 503 flux R67) n'empêche jamais la
-        saisie manuelle : c'est le chemin normal."""
+        (`client.provision_estimation(pdl)`) et pré-remplit les provisions
+        selon le tarif. L'humain garde la main — les champs restent éditables
+        — et l'absence de données (trouve=False, flux R67 indisponible)
+        n'empêche jamais la saisie manuelle : c'est le chemin normal.
+
+        Mapping d'exceptions (#229, trio ré-exporté par la fabrique) :
+        `IngestionEnCours`/`PreconditionNonRemplie` (flux R67 absent, typé
+        upstream) -> notification non bloquante + chatter (même
+        comportement que l'ancien 503, plus précis) ; `ContractVersionError`
+        -> `UserError` (la garde de version vit dans le client) ; tout le
+        reste (réseau coupé, 500 inattendu) remonte tel quel — plus
+        d'enveloppe `UserError` générique."""
         self.ensure_one()
         client = self.env['souscription.electricore.client'].client()  # fast-fail paquet+config (ADR 0024)
         try:
             reponse = self._appeler_estimation(client, self.pdl)
-        except requests.exceptions.HTTPError as exc:
-            if exc.response is not None and exc.response.status_code == 503:
-                return self._notifier_estimation_indisponible(exc.response)
-            raise UserError(f"Erreur electricore lors de l'estimation des provisions : {exc}") from exc
-        except requests.exceptions.RequestException as exc:
-            raise UserError(f"Erreur electricore lors de l'estimation des provisions : {exc}") from exc
-
-        contract_version = reponse.get('contract_version')
-        if contract_version is None or contract_version < self._CONTRACT_VERSION_ESTIMATION_ATTENDU:
+        except (IngestionEnCours, PreconditionNonRemplie) as exc:
+            return self._notifier_estimation_indisponible(exc)
+        except ContractVersionError as exc:
             raise UserError(
-                "Version de contrat electricore inattendue pour l'estimation des provisions : "
-                f'{contract_version!r} (attendu >= {self._CONTRACT_VERSION_ESTIMATION_ATTENDU}).'
-            )
+                f"Version de contrat electricore inattendue pour l'estimation des provisions : {exc}"
+            ) from exc
 
         if not reponse.get('trouve'):
             self.message_post(
@@ -718,34 +725,20 @@ class RaccordementDemande(models.Model):
         self._appliquer_estimation(reponse['estimation'])
 
     def _appeler_estimation(self, client, pdl):
-        """Point de transport unique : GET /provision/estimation?pdl=<pdl>
-        (couture patchée en tests, réponse en boîte — rien d'autre n'est
-        mocké).
+        """Point de transport unique : passe-plat vers
+        `client.provision_estimation(pdl)` (`electricore-client` 0.5.0,
+        #229) — couture patchée en tests, réponse en boîte, rien d'autre
+        n'est mocké."""
+        return client.provision_estimation(pdl)
 
-        TODO: electricore-client 0.2.0 n'expose pas encore
-        `/provision/estimation` (seuls meta_periodes, chronologie,
-        turpe_variable, resoudre_rsc existent) : basculer sur la méthode du
-        client quand elle existera."""
-        response = requests.get(
-            f'{client.url}/provision/estimation',
-            params={'pdl': pdl},
-            headers={'X-API-Key': client.api_key},
-            timeout=30,
-        )
-        response.raise_for_status()
-        return response.json()
-
-    def _notifier_estimation_indisponible(self, response):
-        """503 = état opérationnel attendu (flux R67 non matérialisé — M023
-        pas encore ingérée sur le portail SGE — ou ingestion en cours) :
-        jamais une UserError. Tracé au chatter comme information
-        opérationnelle, et notification non bloquante côté utilisateur."""
+    def _notifier_estimation_indisponible(self, exc):
+        """`IngestionEnCours`/`PreconditionNonRemplie` (#229) = état
+        opérationnel attendu (flux R67 non matérialisé — M023 pas encore
+        ingérée sur le portail SGE — ou ingestion en cours) : jamais une
+        UserError. Tracé au chatter comme information opérationnelle, et
+        notification non bloquante côté utilisateur."""
         self.ensure_one()
-        try:
-            detail = response.json().get('detail')
-        except ValueError:
-            detail = None
-        message = detail or (
+        message = str(exc) or (
             'Flux R67 non disponible pour ce PDL (mesures pas encore ingérées, ou ingestion en cours) : '
             'réessayez plus tard, ou saisissez les provisions à la main.'
         )

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,4 +14,9 @@
 # sont tous présents en 0.4.0. Lève le gate de déploiement du #147.
 # 0.5.0 : ajoute sorties() (requis par le pull des sorties C15 #246 / ADR 0031,
 # souscription_pull_meta_periodes_service._appeler_sorties). Surface vérifiée au tag.
+# 0.5.0 ajoute aussi provision_estimation() (requis par le bouton « Estimer
+# les provisions » du raccordement, #229 — referme la dernière brèche
+# `requests` hors fabrique, restaure ADR 0024) :
+# raccordement_demande._appeler_estimation devient un passe-plat d'une ligne
+# vers cette méthode, garde de version comprise côté client.
 electricore-client==0.5.0

--- a/tests/test_estimation_provisions.py
+++ b/tests/test_estimation_provisions.py
@@ -1,19 +1,24 @@
-"""Tests #121 — estimation des provisions à l'étape « Calcul de mensualités »
-(GET /provision/estimation).
+"""Tests #121/#229 — estimation des provisions à l'étape « Calcul de
+mensualités » (`client.provision_estimation(pdl)`).
 
 Couture de test : on patche `_appeler_estimation`, la méthode transport de
 `raccordement.demande`, avec des réponses en boîte. Le client lui-même est
 fourni directement par la fabrique patchée (`souscription.electricore.client`,
 ADR 0024) — sa garde paquet/config est testée une fois dans
 test_electricore_client_fabrique.py, pas ici. Aucun HTTP réel.
+
+Exceptions typées importées de la fabrique (#229, trio ré-exporté) — plus de
+stubs `requests.exceptions` : `IngestionEnCours`/`PreconditionNonRemplie`
+mènent à une notification non bloquante, `ContractVersionError` à une
+`UserError` (la garde de version vit désormais dans le client).
 """
 
 from datetime import date, timedelta
 from unittest.mock import MagicMock, patch
 
-import requests
 from odoo.addons.souscriptions_odoo.models.core import electricore_client_fabrique as fabrique_module
 from odoo.addons.souscriptions_odoo.models.raccordement import raccordement_demande as demande_module
+from odoo.exceptions import UserError
 from odoo.tests.common import tagged
 
 from .common import SouscriptionsTestCase
@@ -41,24 +46,14 @@ def _estimation(**kwargs):
     return base
 
 
-def _reponse(trouve=True, estimation=None, contract_version=1):
-    """Stub de l'enveloppe JSON de `GET /provision/estimation`."""
+def _reponse(trouve=True, estimation=None):
+    """Stub de l'enveloppe rendue par `client.provision_estimation(pdl)`."""
     return {
-        'contract_version': contract_version,
         'pdl': 'PDL_ESTIMATION_TEST',
         'as_of': '2024-01-01',
         'trouve': trouve,
         'estimation': estimation,
     }
-
-
-def _http_error_503(detail=None):
-    """Stub de `requests.exceptions.HTTPError` (503), avec ou sans `detail`
-    JSON — mime `response.raise_for_status()`."""
-    response = MagicMock()
-    response.status_code = 503
-    response.json.return_value = {'detail': detail} if detail else {}
-    return requests.exceptions.HTTPError(response=response)
 
 
 @tagged('souscriptions', 'souscriptions_estimation_provisions', 'post_install', '-at_install')
@@ -67,8 +62,10 @@ class TestEstimationProvisions(SouscriptionsTestCase):
         super().setUp()
         # Le client est fourni directement par la fabrique patchée : la garde
         # paquet/config (ADR 0024) est hors sujet ici (cf.
-        # test_electricore_client_fabrique.py).
-        self.fake_client = MagicMock(url='https://electricore.example.test', api_key='fake-api-key')
+        # test_electricore_client_fabrique.py). `_appeler_estimation` étant
+        # lui-même patché par chaque test (#229), ce client n'est jamais
+        # vraiment sollicité — un MagicMock nu suffit.
+        self.fake_client = MagicMock()
         patcher = patch.object(fabrique_module.SouscriptionElectricoreClient, 'client', return_value=self.fake_client)
         patcher.start()
         self.addCleanup(patcher.stop)
@@ -146,7 +143,7 @@ class TestEstimationProvisions(SouscriptionsTestCase):
         self.assertEqual(len(demande.message_ids) - avant_msgs, 1)
         self.assertIn('profondeur', demande.message_ids[0].body.lower())
 
-    # --- trouve=False / 503 : jamais bloquant ---
+    # --- trouve=False / flux R67 indisponible : jamais bloquant ---
 
     def test_trouve_false_necrit_rien(self):
         demande = self._demande_calcul_mensualites(type_tarif='base')
@@ -159,13 +156,14 @@ class TestEstimationProvisions(SouscriptionsTestCase):
         self.assertEqual(demande.provision_mensuelle_kwh, avant)
         self.assertEqual(len(demande.message_ids) - avant_msgs, 1)
 
-    def test_503_ne_leve_pas_userror(self):
-        """503 = état opérationnel attendu (flux R67 pas encore matérialisé) :
-        chatter + notification non bloquante, jamais une UserError."""
+    def test_ingestion_en_cours_ne_leve_pas_userror(self):
+        """IngestionEnCours (#229) = état opérationnel attendu (verrou base
+        electricore) : chatter + notification non bloquante, jamais une
+        UserError — même comportement que l'ancien 503."""
         demande = self._demande_calcul_mensualites(type_tarif='base')
         avant_msgs = len(demande.message_ids)
 
-        with self._patch_appeler_estimation(side_effect=_http_error_503('flux R67 non matérialisé')):
+        with self._patch_appeler_estimation(side_effect=fabrique_module.IngestionEnCours('ingestion en cours')):
             resultat = demande.action_estimer_provisions()  # ne doit pas lever
 
         self.assertEqual(resultat['type'], 'ir.actions.client')
@@ -173,6 +171,36 @@ class TestEstimationProvisions(SouscriptionsTestCase):
         self.assertEqual(resultat['params']['type'], 'warning')
         self.assertFalse(resultat['params']['sticky'])
         self.assertEqual(len(demande.message_ids) - avant_msgs, 1)
+
+    def test_precondition_non_remplie_ne_leve_pas_userror(self):
+        """PreconditionNonRemplie (#229) = flux R67 non matérialisé (typé
+        upstream) : chatter + notification non bloquante, jamais une
+        UserError — même comportement que l'ancien 503, plus précis."""
+        demande = self._demande_calcul_mensualites(type_tarif='base')
+        avant_msgs = len(demande.message_ids)
+
+        with self._patch_appeler_estimation(
+            side_effect=fabrique_module.PreconditionNonRemplie('flux R67 non matérialisé')
+        ):
+            resultat = demande.action_estimer_provisions()  # ne doit pas lever
+
+        self.assertEqual(resultat['type'], 'ir.actions.client')
+        self.assertEqual(resultat['tag'], 'display_notification')
+        self.assertEqual(resultat['params']['type'], 'warning')
+        self.assertFalse(resultat['params']['sticky'])
+        self.assertEqual(len(demande.message_ids) - avant_msgs, 1)
+
+    def test_contract_version_error_leve_userror(self):
+        """ContractVersionError (#229) : la garde de version vit dans le
+        client, le bouton la traduit en UserError — plus de vérification
+        manuelle de contract_version côté addon."""
+        demande = self._demande_calcul_mensualites(type_tarif='base')
+
+        with (
+            self._patch_appeler_estimation(side_effect=fabrique_module.ContractVersionError('trop ancien')),
+            self.assertRaises(UserError),
+        ):
+            demande.action_estimer_provisions()
 
     # --- Éditabilité + recopie vers la Souscription ---
 


### PR DESCRIPTION
Closes #229

Referme la dernière brèche `requests` hors fabrique (carte 4 de la revue
d'architecture du 2026-07-12) : le bouton « Estimer les provisions » du
raccordement passe désormais par `client.provision_estimation(pdl)`
(electricore-client 0.5.0) au lieu d'un `requests.get` manuel — la méthode
de transport reste une couture d'une ligne, patchée en tests.

Le mapping d'exceptions s'aligne sur le trio ré-exporté par la fabrique :
`IngestionEnCours`/`PreconditionNonRemplie` deviennent une notification non
bloquante + chatter (comportement de l'ancien 503, plus précis), et
`ContractVersionError` devient une `UserError` — la garde de version vit
désormais côté client, le bloc de vérification manuelle a disparu. ADR 0024
est restauré (non amendé) : la fabrique s'arrête à « rends-moi un client
configuré », l'appelant garde son appel d'endpoint et son propre mapping.

Suite docker complète : 0 failed, 0 error(s) of 875 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)