### PR TITLE
fix(dev) : crons actifs en local — max-cron-threads=2, garde-fou mail recentré sur ir.mail_server

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -37,6 +37,10 @@ services:
     volumes:
       - odoo-web-data:/var/lib/odoo
       - ../:/mnt/extra-addons/souscriptions_odoo:rw
+    # max-cron-threads=2 (pas 0) : le module dépend des crons (amorçage campagne,
+    # vidanges — ADR 0035/0036), et 2 threads (défaut Odoo) évitent qu'un amorçage
+    # long ne bloque les autres jobs. Aucun mail ne peut sortir pour autant : zéro
+    # ir.mail_server (garde-fou dev.sh) ni SMTP joignable.
     command: >
       odoo
       --db_host=db
@@ -44,7 +48,7 @@ services:
       --db_password=odoo
       --addons-path=/usr/lib/python3/dist-packages/odoo/addons,/mnt/extra-addons
       --load-language=fr_FR
-      --max-cron-threads=0
+      --max-cron-threads=2
       --dev=reload,xml,qweb
 
 volumes:

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -20,8 +20,11 @@
 # Mode prod : pilote `../souscriptions_migration` (ADR 0003/0023, dépôt jetable **voisin**,
 # jamais fusionné ici) en shell-out — transform -> load --cible vierge (base fraîche : rien
 # à bind, `bind` sert le chemin bascule odoo.sh, hors sujet ici). Garde-fous fail-closed
-# (charte migration) vérifiés avant ET après chargement : crons coupés, aucun mail sortant,
-# aucun règlement SEPA groupé — une base non conforme arrête le script.
+# (charte migration) vérifiés avant ET après chargement : aucun mail sortant, aucun
+# règlement SEPA groupé — une base non conforme arrête le script. Les crons tournent
+# (--max-cron-threads=2 depuis le 19/07/2026) : le module en dépend (amorçage de
+# campagne, vidanges, poll RSC — ADR 0035/0036) ; le fail-closed mail repose sur
+# l'absence d'ir.mail_server (vérifiée ci-dessous) + aucun SMTP joignable du conteneur.
 #
 # Secrets electricore (ELECTRICORE_URL / _API_KEY) : injectés depuis Proton Pass —
 #   pr ./scripts/dev.sh              # pass-cli résout .env.pass -> env shell -> pass-through compose -> conteneur
@@ -127,12 +130,9 @@ fi
 
 # --- Mode prod : bring-up détaché, câblage souscriptions_migration, garde-fous ---
 
-# Garde-fou statique : crons coupés au niveau serveur (docker-compose.yml, partagé par
-# les deux modes) — vérifié ici pour que --data=prod s'arrête si jamais retiré.
-if ! grep -q -- '--max-cron-threads=0' "$REPO_ROOT/docker/docker-compose.yml"; then
-    echo "Garde-fou violé : --max-cron-threads=0 absent de docker-compose.yml (crons potentiellement actifs)." >&2
-    exit 1
-fi
+# Les crons tournent volontairement (le module en dépend : amorçage, vidanges, poll RSC).
+# Le fail-closed « aucun mail sortant » est porté par assert_garde_fous (ir.mail_server
+# vide) — un mail mis en file sans serveur SMTP finit en exception, il ne sort pas.
 
 assert_garde_fous() {
     # Garde-fous fail-closed niveau base (charte migration : aucun mail sortant, aucun SEPA
@@ -161,7 +161,7 @@ assert_garde_fous() {
         echo "Garde-fou violé ($1) : des règlements SEPA groupés existent sur '$DB'." >&2
         exit 1
     fi
-    echo "==> Garde-fous OK ($1) : crons coupés, mail sortant vide, aucun SEPA."
+    echo "==> Garde-fous OK ($1) : mail sortant vide, aucun SEPA (crons actifs, sans transport mail)."
 }
 
 "${COMPOSE[@]}" up -d --build odoo


### PR DESCRIPTION
## Problème

La création d'une campagne ne tirait pas les 3 pulls (amorçage #343, ADR 0036) : le `--max-cron-threads=0` du compose neutralisait **tout** `ir.cron` en local. Le `_trigger()` posé à la création restait en attente pour toujours (`ir.cron.trigger` jamais consommé, `lastcall` vide) — idem pour les vidanges (ADR 0035) et le poll RSC.

## Fix

- `docker/docker-compose.yml` : `--max-cron-threads=2` (défaut Odoo — un amorçage long ne bloque pas les autres jobs), avec commentaire expliquant pourquoi ne pas remettre 0.
- `scripts/dev.sh` : le garde-fou statique « crons coupés » (charte migration) est remplacé par son intention réelle — le fail-closed « aucun mail sortant » est porté par `assert_garde_fous` (zéro `ir.mail_server`, vérifié avant ET après chargement) + aucun SMTP joignable du conteneur.

## Vérifié

- Premier passage du worker cron sur `souscriptions_prodlocal` : job « amorçage automatique de campagne » exécuté, trigger en attente consommé.
- Aucun canal mail : 0 `mail.mail` toutes files confondues, 0 `ir.mail_server`, port 25 fermé dans le conteneur, 0 `account.move` en attente d'envoi auto.
- `bash -n dev.sh` + `docker compose config` OK (le commentaire est hors du bloc `command: >`, sinon il serait injecté dans la ligne de commande).

🤖 Generated with [Claude Code](https://claude.com/claude-code)