### PR TITLE
fix(campagne) : la vidange rappelle la passe terminale sur un échec persistant (#383)

### DIFF
--- a/models/core/souscription_campagne.py
+++ b/models/core/souscription_campagne.py
@@ -1689,10 +1689,17 @@ class SouscriptionCampagneEtape(models.Model):
                 with self.env.cr.savepoint():
                     self._traiter_une_unite(unite)
                 aucun_progres = False
+                cron._commit_progress(1)
             except UserError as exc:
                 unite.message_post(body=self._message_echec(exc))
-            finally:
-                cron._commit_progress(1)
+                # Commite l'échec SANS décrémenter `remaining` (#383) : un
+                # `finally: cron._commit_progress(1)` inconditionnel comptait
+                # aussi l'échec comme « traité » — `remaining` natif tombait
+                # à 0 dès qu'un lot mixte était tenté une fois, `ir.cron.
+                # _run_job` concluait FULLY_DONE et ne rappelait plus la
+                # vidange, empêchant la passe terminale (règle « pas de
+                # progrès » ci-dessous) de tourner dans le MÊME job.
+                cron._commit_progress()
 
         if aucun_progres:
             self.demande = False

--- a/tests/test_campagne_etapes_actions.py
+++ b/tests/test_campagne_etapes_actions.py
@@ -458,6 +458,47 @@ class TestCampagneEtapeCreerFactures(SouscriptionsTestCase):
         self.assertEqual(len(souscription_ko.facture_ids), 1, "l'échec est retenté et réussit une fois corrigé")
         self.assertEqual(len(self.souscription_base.facture_ids), 1, 'déjà créée, pas de doublon')
 
+    def test_lot_mixte_conclut_dans_la_meme_execution_du_job(self):
+        """#383 : la vidange s'arrêtait avant la passe terminale quand un
+        échec était compté « traité ». Dans le repli unitaire, un `finally:
+        cron._commit_progress(1)` inconditionnel décrémentait le `remaining`
+        natif pour TOUTE unité — succès ou échec — donc `remaining` tombait
+        à 0 dès qu'un lot mixte était tenté une fois : `ir.cron._run_job`
+        concluait `FULLY_DONE` et ne rappelait plus la vidange. La passe
+        terminale (règle « pas de progrès », ADR 0035 décision 3) ne
+        tournait qu'au déclenchement externe SUIVANT du cron (le quotidien,
+        le lendemain) : `demande` restait levée et le récap (#366) n'était
+        jamais posté au journal.
+
+        D'où l'exception assumée à la règle de tête de classe (« aucun test
+        ne s'accroche au nombre de passes ») : ce test s'accroche à UNE
+        exécution du job — un seul `method_direct_trigger()`, PAS la boucle
+        de convergence `_vider()`, qui re-déclenche jusqu'à `demande`
+        retombée et papote exactement par-dessus ce bug. C'est la boucle
+        INTERNE d'`ir.cron._run_job` qui doit suffire : lot mixte (1 succès,
+        1 échec persistant — la grille Moulin manque toujours) → passe
+        mixte, puis passe terminale rappelée nativement (`remaining` resté
+        ≥ 1) → intention retombée et récap posté, sans nouveau
+        déclenchement externe."""
+        souscription_ko = self._preparer_lot_avec_un_echec()
+        self.campagne.action_creer_factures()
+        etape = self._etape()
+
+        with self.enter_registry_test_mode():
+            self.cron.method_direct_trigger()  # UNE seule exécution du job
+
+        etape.invalidate_recordset()
+        self.assertFalse(
+            etape.demande,
+            "la passe terminale a tourné dans la MÊME exécution du job — sans elle, l'intention resterait "
+            'levée jusqu’au passage quotidien suivant du cron',
+        )
+        messages = self.campagne.message_ids.mapped('body')
+        self.assertTrue(any('Créées : 1' in m for m in messages), 'récap posté au journal, dans le même job')
+        self.assertTrue(any('Échecs : 1' in m for m in messages))
+        self.assertEqual(len(self.souscription_base.facture_ids), 1, 'la souscription saine est facturée')
+        self.assertEqual(len(souscription_ko.facture_ids), 0, "l'échec persiste, aucune facture pour cette unité")
+
 
 @tagged('souscriptions', 'souscriptions_campagne', 'post_install', '-at_install')
 class TestCampagneEtapeEmettreFactures(SouscriptionsTestCase):


### PR DESCRIPTION
Closes #383

La vidange en tâche de fond (créer/émettre factures) s'arrêtait avant sa
passe terminale quand un lot mixte (succès + échec persistant, ex. grille
incapable de prixer) était tenté : le repli unitaire commitait le
`remaining` natif pour TOUTE unité, échec compris, via un `finally`
inconditionnel. `remaining` tombait alors à 0 dès la première tentative du
lot mixte, `ir.cron._run_job` concluait `FULLY_DONE` et ne rappelait plus
la vidange — la passe terminale (règle « pas de progrès », ADR 0035
décision 3) qui poste le récapitulatif au journal (#366) et fait retomber
`demande` n'avait plus l'occasion de tourner avant le passage quotidien
suivant du cron.

Seuls les succès décrémentent désormais `remaining` ; un échec commite
sans le décrémenter — `ir.cron._run_job` continue donc de rappeler la
vidange dans la même exécution jusqu'à ce que la règle « pas de progrès »
s'applique normalement.

Test ajouté : `test_lot_mixte_conclut_dans_la_meme_execution_du_job` —
UNE seule exécution du job (un `method_direct_trigger()`, pas la boucle de
convergence `_vider()` qui masquait le bug) doit suffire à retomber
l'intention et poster « Créées : 1 / Échecs : 1 » au journal. Vérifié
rouge sur le code pré-fix (échec sur l'assertion `demande`), vert avec le
fix ; suite complète : 0 failed, 0 error(s) of 876 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)