### PR TITLE
fix(cheque-energie) : le gate action_valider renvoie True — un retour None fault en XML-RPC Odoo 19

### DIFF
--- a/models/core/souscription_cheque_energie.py
+++ b/models/core/souscription_cheque_energie.py
@@ -161,6 +161,9 @@ class SouscriptionChequeEnergie(models.Model):
             )
             payment.action_post()
             cheque.write({'payment_id': payment.id, 'state': 'valide'})
+        # None n'est pas marshallable en XML-RPC (Odoo 19, allow_none=False) —
+        # la migration appelle ce gate via execute_kw.
+        return True
 
     @api.model
     def _setup_compta(self):


### PR DESCRIPTION
## Problème

Le load de migration (souscriptions_migration) appelle le gate `action_valider()` du chèque énergie via `execute_kw`. En Odoo 19, le contrôleur XML-RPC (`OdooMarshaller(allow_none=False)`) refuse de sérialiser un retour `None` : le client reçoit un Fault « cannot marshal None unless allow_none is enabled » **alors que la validation a été exécutée et commitée** — l'exception n'est levée qu'à la sérialisation de la réponse, après le commit.

## Correctif

`action_valider()` renvoie `True` (convention Odoo pour les méthodes d'action appelables en RPC). Une ligne + commentaire expliquant la contrainte.

Côté migration, la parade transport (mapping du Fault → `None`) couvre les méthodes core non patchables (`account.move.line.reconcile`) — PR jumelle dans souscriptions_migration.

## Validation

Load complet des 85 chèques énergie sur `souscriptions_prodlocal` le 19/07 au soir : 85/85 validés avec paiement, 60/60 OD de reprise lettrées, aucun Fault.

🤖 Generated with [Claude Code](https://claude.com/claude-code)