### PR TITLE
fix(ci) : épingle odoo:19.0 au digest du 02/07 — le nightly du 30/07 casse l'init (#393)

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,7 @@
-FROM odoo:19.0
+# Épinglé par digest (#393) : le tag 19.0 est un nightly mouvant, et celui du
+# 30/07/2026 casse l'init de la base (ValidationError du module account core).
+# Digest = image du 02/07/2026, dernière vérifiée bonne. Dé-épinglage : #394.
+FROM odoo:19.0@sha256:f54272f31d5f77e4146b887efb3761c98480317daf687e4b4b5e76ed8bcc08c5
 
 USER root
 


### PR DESCRIPTION
Closes #393

Le tag `odoo:19.0` est un nightly mouvant re-pull à chaque run de CI ; celui du 30/07 casse l'initialisation de la base avant le premier test (`ValidationError` de la contrainte bank-account du module `account` core, au flush du chargement des modules). Reproduit et contre-prouvé localement : image du 30/07 (`e415f992…`) → plante ; image du 02/07 (`f54272f3…`) → installation propre. Détail complet dans #393.

Épingle la base au digest du 02/07, dernier vérifié bon. La CI redevient déterministe ; le dé-épinglage (ou la montée de digest quand le nightly est réparé) est tracé dans #394.

🤖 Generated with [Claude Code](https://claude.com/claude-code)