### PR TITLE
fix(educpopage) : « la coopérative » devient « le commun »

### DIFF
--- a/docs/educpopage/consentement.md
+++ b/docs/educpopage/consentement.md
@@ -71,17 +71,17 @@ ne se modifie pas, il s'enrichit. Pour enregistrer un changement d'avis, on
 
 ### La chaîne de responsabilité : qui répond de quoi
 
-Pourquoi tant de rigueur ? Parce que c'est la coopérative qui **déclare au
+Pourquoi tant de rigueur ? Parce que c'est le commun qui **déclare au
 gestionnaire du réseau (Enedis)** détenir le consentement de la personne
 avant de collecter ses données fines. Le jour où la CNIL — l'autorité de
-contrôle des données personnelles — demande la preuve, c'est la coopérative
+contrôle des données personnelles — demande la preuve, c'est le commun
 qui doit la produire. Le Journal des actes est cette preuve.
 
 ![La chaîne de responsabilité](diagrammes/consentement-chaine-responsabilite.png)
 
-En clair : le·la souscripteur·rice donne (ou retire) son accord ; la
-coopérative l'enregistre dans le journal et le déclare à Enedis ; Enedis
-transmet les données ; la CNIL peut demander des comptes à la coopérative,
+En clair : le·la souscripteur·rice donne (ou retire) son accord ; le
+commun l'enregistre dans le journal et le déclare à Enedis ; Enedis
+transmet les données ; la CNIL peut demander des comptes au commun,
 et à personne d'autre. Chaque maillon a son rôle, et la preuve vit chez nous.
 
 !!! question "🤖 À valider avec vous"

--- a/docs/educpopage/contrat.md
+++ b/docs/educpopage/contrat.md
@@ -2,7 +2,7 @@
 
 ## En deux mots
 
-Chaque personne fournie en électricité par la coopérative a une fiche de contrat : la Souscription.
+Chaque personne fournie en électricité par le commun a une fiche de contrat : la Souscription.
 Elle dit qui est fourni, où, à quel tarif, depuis quand — et tout le reste du logiciel s'appuie
 dessus pour facturer. Son état (en instance, en service, en attente de clôture, résiliée) se lit
 mais ne se choisit jamais : il se déduit de faits vérifiables. Cette page explique comment lire une

--- a/docs/educpopage/raccordement.md
+++ b/docs/educpopage/raccordement.md
@@ -2,7 +2,7 @@
 
 ## En deux mots
 
-Quand une personne demande à être fournie en électricité par la coopérative, sa demande
+Quand une personne demande à être fournie en électricité par le commun, sa demande
 entre dans un tableau de suivi, colonne par colonne, de l'accueil jusqu'à la mise en
 service. L'équipe vérifie le dossier et accepte la demande ; à partir de là, le contrat
 existe et les cartes avancent toutes seules au rythme des confirmations du gestionnaire

--- a/docs/educpopage/regulariser.md
+++ b/docs/educpopage/regulariser.md
@@ -54,7 +54,7 @@ brouillon, relisible comme toute facture (voir [facture](facture.md)), que l'ém
 
 ### La sortie d'un·e usager·ère
 
-Quand quelqu'un·e quitte la coopérative, la chaîne se déroule d'un bout à l'autre de la
+Quand quelqu'un·e quitte le commun, la chaîne se déroule d'un bout à l'autre de la
 Campagne de facturation, sans saisie manuelle :
 
 1. **« Pull sorties C15 »** (fiche Campagne, phase Tirer) : les sorties signalées par le


### PR DESCRIPTION
Demandé par Virgile : la doc educpopage ne parle plus de coopérative mais de commun — l'identité du projet, même vocabulaire que la doc electricore (« un commun pour reprendre la main… »).

7 occurrences dans 4 pages (consentement ×4, raccordement, contrat, regulariser), accords refaits (« le commun », « au commun », « par le commun »), aucun diagramme concerné, build strict vert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)